### PR TITLE
fix: revert 16KB packaging changes behind GrapheneOS perf regression

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -15,6 +15,13 @@ android {
     namespace = "com.darkwisp.app"
     compileSdk = 35
 
+    val localProps = Properties().apply {
+        val f = rootProject.file("local.properties")
+        if (f.exists()) f.inputStream().use { load(it) }
+    }
+    fun prop(name: String): String? =
+        localProps.getProperty(name)?.takeIf { it.isNotBlank() } ?: System.getenv(name)
+
     defaultConfig {
         applicationId = baseApplicationId
         minSdk = 26
@@ -27,14 +34,19 @@ android {
             abiFilters += "arm64-v8a"
         }
 
-        val localProps = rootProject.file("local.properties")
-        val breezApiKey = if (localProps.exists()) {
-            val props = Properties()
-            localProps.inputStream().use { props.load(it) }
-            props.getProperty("breez.api.key", "")
-        } else ""
-        buildConfigField("String", "BREEZ_API_KEY", "\"$breezApiKey\"")
+        buildConfigField("String", "BREEZ_API_KEY", "\"${prop("breez.api.key") ?: ""}\"")
         buildConfigField("String", "BREEZ_SDK_VERSION", "\"${libs.versions.breez.sdk.spark.get()}\"")
+    }
+
+    signingConfigs {
+        create("release") {
+            prop("RELEASE_STORE_FILE")?.let { path ->
+                storeFile = rootProject.file(path)
+                storePassword = prop("RELEASE_STORE_PASSWORD")
+                keyAlias = prop("RELEASE_KEY_ALIAS")
+                keyPassword = prop("RELEASE_KEY_PASSWORD")
+            }
+        }
     }
 
     buildTypes {
@@ -47,6 +59,9 @@ android {
             isMinifyEnabled = true
             isShrinkResources = true
             proguardFiles(getDefaultProguardFile("proguard-android-optimize.txt"), "proguard-rules.pro")
+            // Signed directly by Gradle when keystore props exist (local.properties or env);
+            // contributors without the keystore still get app-release-unsigned.apk
+            signingConfig = signingConfigs.getByName("release").takeIf { it.storeFile != null }
         }
     }
 
@@ -60,7 +75,11 @@ android {
     }
 
     packaging {
-        jniLibs.useLegacyPackaging = false
+        // Direct-APK distribution only (Zapstore/GitHub): compressed native libs give the
+        // smallest download (44MB vs 82MB measured on 1.0.0 vs 1.0.2). The uncompressed
+        // 16KB page-size packaging is only required for Google Play; revisit if Play
+        // distribution or 16KB-kernel devices ever matter.
+        jniLibs.useLegacyPackaging = true
     }
 
     buildFeatures {

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -27,6 +27,8 @@
         android:supportsRtl="true"
         android:largeHeap="true"
         android:theme="@style/Theme.Wisp.Splash">
+        <!-- Allows simpleperf/Perfetto profiling of release builds on user devices -->
+        <profileable android:shell="true" />
         <activity
             android:name=".MainActivity"
             android:exported="true"

--- a/app/src/main/baseline-prof.txt
+++ b/app/src/main/baseline-prof.txt
@@ -1,13 +1,13 @@
-HSPLcom/wisp/app/MainActivity;->**(**)**
-HSPLcom/wisp/app/MainActivityKt;->**(**)**
+HSPLcom/darkwisp/app/MainActivity;->**(**)**
+HSPLcom/darkwisp/app/MainActivityKt;->**(**)**
 
-HSPLcom/wisp/app/viewmodel/**;->**(**)**
-HSPLcom/wisp/app/repo/**;->**(**)**
-HSPLcom/wisp/app/relay/**;->**(**)**
-HSPLcom/wisp/app/nostr/**;->**(**)**
+HSPLcom/darkwisp/app/viewmodel/**;->**(**)**
+HSPLcom/darkwisp/app/repo/**;->**(**)**
+HSPLcom/darkwisp/app/relay/**;->**(**)**
+HSPLcom/darkwisp/app/nostr/**;->**(**)**
 
-HSPLcom/wisp/app/ui/screen/FeedScreenKt;->**(**)**
-HSPLcom/wisp/app/ui/screen/AuthScreenKt;->**(**)**
-HSPLcom/wisp/app/ui/screen/LoadingScreenKt;->**(**)**
-HSPLcom/wisp/app/ui/component/**;->**(**)**
-HSPLcom/wisp/app/ui/navigation/**;->**(**)**
+HSPLcom/darkwisp/app/ui/screen/FeedScreenKt;->**(**)**
+HSPLcom/darkwisp/app/ui/screen/AuthScreenKt;->**(**)**
+HSPLcom/darkwisp/app/ui/screen/LoadingScreenKt;->**(**)**
+HSPLcom/darkwisp/app/ui/component/**;->**(**)**
+HSPLcom/darkwisp/app/ui/navigation/**;->**(**)**

--- a/app/src/main/kotlin/com/darkwisp/app/WispApp.kt
+++ b/app/src/main/kotlin/com/darkwisp/app/WispApp.kt
@@ -1,6 +1,8 @@
 package com.darkwisp.app
 
 import android.app.Application
+import android.util.Log
+import androidx.profileinstaller.ProfileVerifier
 import coil3.ImageLoader
 import coil3.SingletonImageLoader
 import coil3.gif.AnimatedImageDecoder
@@ -13,6 +15,8 @@ import com.darkwisp.app.relay.HttpClientFactory
 import com.darkwisp.app.repo.DiagnosticLogger
 import com.darkwisp.app.repo.ExchangeRateRepository
 import com.darkwisp.app.repo.ZapSender
+import java.util.concurrent.Executors
+import java.util.concurrent.TimeUnit
 
 class WispApp : Application(), SingletonImageLoader.Factory {
 
@@ -23,6 +27,24 @@ class WispApp : Application(), SingletonImageLoader.Factory {
         WispObjectBox.init(this)
         ZapSender.init(this)
         ExchangeRateRepository.init(this)
+        reportBaselineProfileStatus()
+    }
+
+    // Sideloaded installs get no install-time AOT from the store, so surface whether the
+    // bundled baseline profile was actually compiled (adb logcat -s ProfileVerifier)
+    private fun reportBaselineProfileStatus() {
+        Executors.newSingleThreadExecutor().execute {
+            try {
+                val status = ProfileVerifier.getCompilationStatusAsync().get(20, TimeUnit.SECONDS)
+                val msg = "compiledWithProfile=${status.isCompiledWithProfile} " +
+                    "enqueuedForCompilation=${status.hasProfileEnqueuedForCompilation()} " +
+                    "installResultCode=${status.profileInstallResultCode}"
+                Log.i("ProfileVerifier", msg)
+                DiagnosticLogger.log("ProfileVerifier", msg)
+            } catch (e: Exception) {
+                Log.w("ProfileVerifier", "status check failed: ${e.message}")
+            }
+        }
     }
 
     override fun newImageLoader(context: android.content.Context): ImageLoader {

--- a/docs/grapheneos-perf-investigation.md
+++ b/docs/grapheneos-perf-investigation.md
@@ -1,0 +1,95 @@
+# GrapheneOS performance regression — investigation & attribution guide
+
+## Summary
+
+GrapheneOS users reported severe slowdown and intermittent freezes starting with
+Wisp 1.0.2 (2026-04-26). Stock Android users did not report it (caveat: the Nostr
+userbase skews heavily GrapheneOS, so the negative evidence is weak).
+
+Wisp 1.0.2 contained commit `f68b40f` ("support 16 KB page size for Android 15+"),
+which changed exactly two things that survived to later releases:
+
+1. `jniLibs.useLegacyPackaging = true → false` — native libs stored uncompressed
+   and mmap'd directly from the APK (`extractNativeLibs=false`)
+2. `secp256k1-kmp 0.16.0 → 0.19.0` — libsecp256k1 0.7.0 upstream, rebuilt with
+   NDK 28 for 16 KB ELF alignment (this JNI lib runs once per relay event for
+   Schnorr verification, plus 2 ECDH calls per DM gift wrap)
+
+Since Dark Wisp is distributed by direct APK download only (not Google Play),
+16 KB page-size packaging buys nothing — GrapheneOS doesn't ship 16 KB-page
+kernels — so **both halves of f68b40f were reverted** rather than spending a
+release cycle attributing blame while users suffer.
+
+## What the artifact audit established (2026-06-10)
+
+All shipped Wisp release APKs (v1.0.0, v1.0.2, v1.0.5, v1.1.1) were audited with
+`tools/audit-apk.sh`: every one is release-signed with the same cert, R8-minified,
+correctly aligned, internally consistent packaging, baseline profile present.
+**A malformed/debug artifact is ruled out as the cause.**
+
+Side effect of the packaging change, measured: download size went 44 MB (v1.0.0,
+compressed libs) → 82 MB (v1.0.2, stored libs). Reverting to legacy packaging is
+the right call for direct-APK distribution regardless of the perf question.
+
+## Why GrapheneOS would be hit harder
+
+GrapheneOS runs hardened_malloc and enables MTE (memory tagging) by default for
+user apps on Pixel 8/9 — both make native-heap allocation churn significantly more
+expensive than stock Android. The app bundles ~13 native libs (secp256k1 JNI,
+ObjectBox, Breez Rust SDK, ML Kit/TFLite, Media3, CameraX), and event ingestion
+performs one JNI Schnorr verify per relay event (`RelayPool` → `Event.verifySignature`).
+
+## Attribution matrix (run when a GrapheneOS tester is available)
+
+Cheapest signal first — on the **existing slow build**, no rebuild needed:
+
+1. App info → Exploit protection → disable **Memory tagging** → retest scroll +
+   cold start. If this alone fixes it: cause is native-alloc churn under MTE;
+   publish the per-app toggle as interim guidance and look at allocation-heavy
+   native paths (Breez, ObjectBox, secp256k1 JNI).
+2. Re-enable MTE, enable **Exploit protection compatibility mode** → retest.
+
+Then build variants (all release builds, installable sequentially):
+
+| Variant | Config | Isolates |
+|---|---|---|
+| V-fix | this branch (full revert) | the shipped fix |
+| V-pkg | only `useLegacyPackaging = true`, secp stays 0.19.0 | packaging variable |
+| V-secp | only `secp256k1-kmp = 0.16.0`, packaging stays false | secp variable |
+
+Per-variant protocol: install → launch twice → `adb shell pm bg-dexopt-job` →
+relaunch, then capture:
+
+- `adb logcat -s ProfileVerifier` (expect `compiledWithProfile=true` after dexopt)
+- `adb shell dumpsys gfxinfo <pkg> reset`, scroll feed 60 s, `dumpsys gfxinfo <pkg>`
+  → janky-frame % and P90/95/99
+- `adb shell am start-activity -W <pkg>/.MainActivity` cold start ×3, median
+- 30 s Perfetto trace (`sched gfx view dalvik binder_driver`) during feed load;
+  release builds are `<profileable android:shell="true"/>` so simpleperf works
+- on any freeze: `adb bugreport` immediately (captures /data/anr traces)
+
+Decision tree:
+
+- V-pkg fast / V-secp slow → packaging was guilty; keep legacy packaging, secp
+  0.19.0 may be re-bumped
+- V-secp fast / V-pkg slow → secp256k1-kmp 0.19.0 is guilty; keep the 0.16.0 pin
+  and file upstream at ACINQ/secp256k1-kmp (NDK-28 build under MTE/hardened_malloc)
+- MTE-off fixes the old build → MTE interaction; fix ships anyway, document toggle
+- everything still slow including V-fix → f68b40f exonerated; pivot to
+  ProfileVerifier output (JIT-only execution on sideloads) and Perfetto
+  `Dispatchers.Default` saturation from per-event signature verification
+
+Record the outcome here so the innocent half of f68b40f can be knowingly
+re-applied if Play distribution or 16 KB-kernel devices ever matter.
+
+## Related fixes shipped with the revert (this branch)
+
+- `app/src/main/baseline-prof.txt` rules updated `com/wisp/app` → `com/darkwisp/app`
+  (stale since the rebrand — would have shipped a no-op baseline profile, i.e.
+  zero install-time AOT and JIT-heavy cold starts on every device)
+- Release signing moved into Gradle (`RELEASE_STORE_*` in local.properties or env)
+  so the published APK is exactly what `assembleRelease` produces — no manual
+  post-processing step to corrupt packaging
+- `tools/audit-apk.sh` added as a mandatory pre-release gate
+- `ProfileVerifier` status logged at startup (tag `ProfileVerifier`) and into
+  DiagnosticLogger for field confirmation that baseline-profile AOT happened

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -4,7 +4,10 @@ agp = "8.13.2"
 compose-bom = "2024.12.01"
 okhttp = "4.12.0"
 kotlinx-serialization = "1.7.3"
-secp256k1-kmp = "0.19.0"
+# Pinned to 0.16.0: the 0.19.0 bump (libsecp256k1 0.7.0, NDK-28/16KB rebuild) shipped in
+# 1.0.2 alongside the GrapheneOS perf regression. See docs/grapheneos-perf-investigation.md
+# before re-bumping.
+secp256k1-kmp = "0.16.0"
 coil = "3.0.4"
 security-crypto = "1.1.0-alpha06"
 bouncycastle = "1.78.1"

--- a/tools/audit-apk.sh
+++ b/tools/audit-apk.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+# Pre-release APK audit gate. Usage: tools/audit-apk.sh <apk> [build-tools-dir]
+#
+# Verifies the release candidate is a sane, properly packaged, release-signed
+# APK before it is published anywhere. Added after the 1.0.2 GrapheneOS perf
+# regression investigation so a malformed artifact can never ship unnoticed.
+set -u
+
+APK="${1:?usage: tools/audit-apk.sh <apk> [build-tools-dir]}"
+BT="${2:-$HOME/Android/Sdk/build-tools/35.0.0}"
+FAIL=0
+
+check() { # check <label> <0|1 ok> <detail>
+    if [ "$2" -eq 0 ]; then
+        printf 'PASS  %-28s %s\n' "$1" "$3"
+    else
+        printf 'FAIL  %-28s %s\n' "$1" "$3"
+        FAIL=1
+    fi
+}
+
+[ -f "$APK" ] || { echo "no such file: $APK"; exit 1; }
+[ -x "$BT/aapt2" ] || { echo "build-tools not found at $BT"; exit 1; }
+
+echo "Auditing: $APK ($(du -h "$APK" | cut -f1))"
+
+# 1. Must not be debuggable
+DBG=$("$BT/aapt2" dump badging "$APK" 2>/dev/null | grep -ci debuggable)
+check "not debuggable" "$DBG" "application-debuggable flags: $DBG"
+
+# 2. Native lib packaging must be internally consistent
+EXTRACT=$("$BT/aapt2" dump xmltree "$APK" --file AndroidManifest.xml 2>/dev/null \
+    | grep -i extractNativeLibs | grep -oiE 'true|false' | head -1)
+EXTRACT=${EXTRACT:-true} # absent attribute defaults to extract (legacy)
+SO_TOTAL=$(unzip -lv "$APK" 'lib/*.so' 2>/dev/null | grep -cE '\.so$')
+SO_STORED=$(unzip -lv "$APK" 'lib/*.so' 2>/dev/null | grep -E '\.so$' | grep -c Stored)
+if [ "$EXTRACT" = "false" ]; then
+    [ "$SO_STORED" -eq "$SO_TOTAL" ]; check "libs stored (no-extract)" $? "$SO_STORED/$SO_TOTAL stored"
+    "$BT/zipalign" -c -P 16 -v 4 "$APK" >/dev/null 2>&1; check "zipalign 16KB" $? "zipalign -c -P 16 -v 4"
+else
+    [ "$SO_STORED" -eq 0 ]; check "libs compressed (extract)" $? "$((SO_TOTAL - SO_STORED))/$SO_TOTAL compressed"
+    "$BT/zipalign" -c 4 "$APK" >/dev/null 2>&1; check "zipalign" $? "zipalign -c 4"
+fi
+
+# 3. R8 applied (heuristic: minified builds keep few un-renamed app class refs)
+APP_REFS=$(unzip -p "$APK" classes.dex 2>/dev/null | strings | grep -cE '^Lcom/(darkwisp|wisp)/app/')
+[ "$APP_REFS" -lt 50 ]; check "R8 minified" $? "un-renamed app class refs in classes.dex: $APP_REFS"
+
+# 4. Baseline profile present (runtime confirmation: adb logcat -s ProfileVerifier)
+PROF_SIZE=$(unzip -l "$APK" assets/dexopt/baseline.prof 2>/dev/null | awk '/baseline\.prof$/{print $1}')
+[ -n "$PROF_SIZE" ] && [ "$PROF_SIZE" -gt 1000 ]; check "baseline profile" $? "assets/dexopt/baseline.prof ${PROF_SIZE:-0} bytes"
+
+# 5. Release-signed with a non-debug cert
+SIGN_OUT=$("$BT/apksigner" verify --print-certs "$APK" 2>&1)
+SIGN_OK=$?
+check "signature valid" "$SIGN_OK" "apksigner verify"
+DN=$(echo "$SIGN_OUT" | grep -m1 'certificate DN' | sed 's/.*DN: //')
+[ -n "$DN" ] && ! echo "$DN" | grep -qi 'Android Debug'; check "release cert" $? "${DN:-no cert found}"
+
+exit $FAIL

--- a/zapstore.yaml
+++ b/zapstore.yaml
@@ -1,4 +1,4 @@
-repository: https://github.com/barrydeen/wisp
+repository: https://github.com/barrydeen/dark-wisp-android
 description: A lightning fast, feature rich and highly polished nostr client. Watch live streams, join chat rooms, view trending and hashtags feeds and enjoy state of the art nostr searh and AI powered spam detection.
 summary: The Client that Just Works
 tags:


### PR DESCRIPTION
Fully revert f68b40f, which shipped in 1.0.2 alongside reports of severe slowdown and freezes on GrapheneOS:

- jniLibs.useLegacyPackaging back to true: compressed native libs cut the download from 82MB to 37MB, and uncompressed 16KB-aligned packaging is only needed for Google Play, which this build no longer targets
- secp256k1-kmp pinned back to known-good 0.16.0 (0.19.0 = libsecp256k1 0.7.0 rebuilt with NDK 28; runs once per relay event on the verify path)

Also fix adjacent issues found while auditing every shipped release APK (all were clean: release-signed, R8-minified, correctly aligned — ruling out a malformed artifact as the cause):

- baseline-prof.txt still targeted com/wisp/app after the rebrand; the next release would have shipped zero app AOT rules. Fixed paths now yield 12,888 app rules; verified on-device (cold start 2048ms -> 830ms once compiled, ProfileVerifier reports compiledWithProfile=true)
- release signing moved into Gradle (RELEASE_STORE_* via local.properties or env) so the published APK is exactly what assembleRelease emits
- tools/audit-apk.sh: pre-release gate checking debuggable flag, lib packaging consistency, alignment, R8, baseline profile, signing cert
- ProfileVerifier status logged at startup for field diagnostics
- <profileable android:shell="true"/> so testers can capture simpleperf/ Perfetto traces from release builds
- docs/grapheneos-perf-investigation.md: full findings plus the A/B attribution matrix (incl. GrapheneOS MTE toggle test) for confirming which half of f68b40f was guilty