### PR TITLE
feat(tor): embedded Tor with fail-closed routing for all connections

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -79,6 +79,8 @@ android {
         // smallest download (44MB vs 82MB measured on 1.0.0 vs 1.0.2). The uncompressed
         // 16KB page-size packaging is only required for Google Play; revisit if Play
         // distribution or 16KB-kernel devices ever matter.
+        // Also load-bearing for kmp-tor: its exec loader needs libtor.so extracted to
+        // nativeLibraryDir (W^X: app storage is non-executable on targetSdk 29+).
         jniLibs.useLegacyPackaging = true
     }
 
@@ -127,6 +129,9 @@ dependencies {
     implementation(libs.objectbox.android)
     implementation(libs.objectbox.kotlin)
     implementation(libs.breez.sdk.spark)
+    implementation(libs.kmp.tor.runtime)
+    implementation(libs.kmp.tor.runtime.service.ui)
+    implementation(libs.kmp.tor.resource.exec)
     implementation(libs.mlkit.barcode)
     implementation(libs.camerax.core)
     implementation(libs.camerax.camera2)

--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -62,3 +62,8 @@
 # JNA (used by Breez SDK UniFFI)
 -keep class com.sun.jna.** { *; }
 -dontwarn com.sun.jna.**
+
+# kmp-tor (embedded Tor) — kmp-process probes JVM-only management APIs behind
+# runtime guards; the classes don't exist on Android by design.
+-dontwarn java.lang.management.ManagementFactory
+-dontwarn java.lang.management.RuntimeMXBean

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools">
 
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.VIBRATE" />
@@ -7,6 +8,8 @@
     <uses-permission android:name="android.permission.CAMERA" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE_MEDIA_PLAYBACK" />
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE_SPECIAL_USE" />
+    <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
 
     <uses-feature android:name="android.hardware.camera" android:required="false" />
 
@@ -52,6 +55,16 @@
             <intent-filter>
                 <action android:name="androidx.media3.session.MediaSessionService" />
             </intent-filter>
+        </service>
+        <service
+            android:name="io.matthewnelson.kmp.tor.runtime.service.TorService"
+            android:enabled="true"
+            android:exported="false"
+            android:foregroundServiceType="specialUse"
+            tools:node="merge">
+            <property
+                android:name="android.app.PROPERTY_SPECIAL_USE_FGS_SUBTYPE"
+                android:value="Embedded Tor proxy that routes all app network traffic for user privacy" />
         </service>
         <provider
             android:name="androidx.core.content.FileProvider"

--- a/app/src/main/kotlin/com/darkwisp/app/Navigation.kt
+++ b/app/src/main/kotlin/com/darkwisp/app/Navigation.kt
@@ -661,7 +661,8 @@ fun WispNavHost(
                 },
                 onLogIn = {
                     navController.navigate(Routes.AUTH)
-                }
+                },
+                onToggleTor = { feedViewModel.setTorEnabled(it) }
             )
         }
 
@@ -709,7 +710,8 @@ fun WispNavHost(
                             popUpTo(Routes.AUTH) { inclusive = true }
                         }
                     }
-                }
+                },
+                onToggleTor = { feedViewModel.setTorEnabled(it) }
             )
         }
 

--- a/app/src/main/kotlin/com/darkwisp/app/WispApp.kt
+++ b/app/src/main/kotlin/com/darkwisp/app/WispApp.kt
@@ -12,11 +12,16 @@ import coil3.network.okhttp.OkHttpNetworkFetcherFactory
 import coil3.request.crossfade
 import com.darkwisp.app.db.WispObjectBox
 import com.darkwisp.app.relay.HttpClientFactory
+import com.darkwisp.app.relay.TorManager
 import com.darkwisp.app.repo.DiagnosticLogger
 import com.darkwisp.app.repo.ExchangeRateRepository
+import com.darkwisp.app.repo.TorPreferences
 import com.darkwisp.app.repo.ZapSender
 import java.util.concurrent.Executors
 import java.util.concurrent.TimeUnit
+import kotlinx.coroutines.MainScope
+import kotlinx.coroutines.launch
+import okhttp3.Call
 
 class WispApp : Application(), SingletonImageLoader.Factory {
 
@@ -24,6 +29,18 @@ class WispApp : Application(), SingletonImageLoader.Factory {
         super.onCreate()
         CrashHandler.install(this)
         DiagnosticLogger.init(this)
+        TorPreferences.init(this)
+        TorManager.init()
+        if (TorPreferences.isEnabled()) {
+            // Fail-closed BEFORE any repo init can touch the network: every client
+            // built from here on routes to a dead SOCKS port until Tor bootstraps.
+            HttpClientFactory.setTorSocks(HttpClientFactory.TorSocks.Pending)
+            MainScope().launch {
+                TorManager.start()?.let {
+                    HttpClientFactory.setTorSocks(HttpClientFactory.TorSocks.Ready(it))
+                }
+            }
+        }
         WispObjectBox.init(this)
         ZapSender.init(this)
         ExchangeRateRepository.init(this)
@@ -52,7 +69,12 @@ class WispApp : Application(), SingletonImageLoader.Factory {
             .components {
                 add(AnimatedImageDecoder.Factory())
                 add(VideoFrameDecoder.Factory())
-                add(OkHttpNetworkFetcherFactory(callFactory = { HttpClientFactory.getImageClient() }))
+                // Coil caches the callFactory lambda's result forever; the delegating
+                // Call.Factory re-resolves the current client per request so a Tor
+                // toggle applies to image loading without an app restart.
+                add(OkHttpNetworkFetcherFactory(callFactory = {
+                    Call.Factory { request -> HttpClientFactory.getImageClient().newCall(request) }
+                }))
             }
             .memoryCache {
                 MemoryCache.Builder()

--- a/app/src/main/kotlin/com/darkwisp/app/relay/HttpClientFactory.kt
+++ b/app/src/main/kotlin/com/darkwisp/app/relay/HttpClientFactory.kt
@@ -6,17 +6,92 @@ import androidx.media3.exoplayer.ExoPlayer
 import androidx.media3.exoplayer.source.DefaultMediaSourceFactory
 import okhttp3.Dispatcher
 import okhttp3.OkHttpClient
+import java.net.InetSocketAddress
+import java.net.Proxy
+import java.util.Collections
+import java.util.WeakHashMap
 import java.util.concurrent.TimeUnit
+import kotlin.concurrent.thread
 
 object HttpClientFactory {
+
+    /**
+     * Tor proxy state for every client built here. Fail-closed: [Pending] routes
+     * to a loopback port that always refuses connections (unprivileged processes
+     * can't bind ports < 1024 on Android), so nothing reaches clearnet between
+     * "user enabled Tor" and "Tor finished bootstrapping".
+     */
+    sealed interface TorSocks {
+        data object Off : TorSocks
+        data object Pending : TorSocks
+        data class Ready(val port: Int) : TorSocks
+    }
+
+    @Volatile private var torSocks: TorSocks = TorSocks.Off
+
     @Volatile private var imageClient: OkHttpClient? = null
     @Volatile private var generalClient: OkHttpClient? = null
     @Volatile private var shortTimeoutClient: OkHttpClient? = null
     @Volatile private var mediaClient: OkHttpClient? = null
     @Volatile private var nip05Client: OkHttpClient? = null
     @Volatile private var downloadClient: OkHttpClient? = null
+    @Volatile private var dmMediaClient: OkHttpClient? = null
+    @Volatile private var relayClient: OkHttpClient? = null
+    @Volatile private var loopbackClient: OkHttpClient? = null
 
-    fun createRelayClient(): OkHttpClient {
+    /**
+     * Every client built since the last [setTorSocks], including per-call ones
+     * (Blossom uploads, relay probes), so a toggle can cancel their in-flight
+     * requests and evict their keep-alive pools. Weak keys: abandoned clients
+     * just fall out.
+     */
+    private val liveClients: MutableSet<OkHttpClient> =
+        Collections.newSetFromMap(WeakHashMap())
+
+    private fun OkHttpClient.Builder.applyProxy(): OkHttpClient.Builder = apply {
+        when (val t = torSocks) {
+            TorSocks.Off -> {}
+            TorSocks.Pending -> proxy(Proxy(Proxy.Type.SOCKS, InetSocketAddress("127.0.0.1", 9)))
+            is TorSocks.Ready -> proxy(Proxy(Proxy.Type.SOCKS, InetSocketAddress("127.0.0.1", t.port)))
+        }
+    }
+
+    private fun track(client: OkHttpClient): OkHttpClient {
+        synchronized(liveClients) { liveClients.add(client) }
+        return client
+    }
+
+    /**
+     * Applies the new proxy state to all future clients and kills every existing
+     * one — cancels in-flight requests and evicts pooled keep-alive connections,
+     * so no pre-toggle socket survives the switch.
+     */
+    fun setTorSocks(mode: TorSocks) {
+        val old: List<OkHttpClient>
+        synchronized(this) {
+            if (torSocks == mode) return
+            torSocks = mode
+            old = synchronized(liveClients) {
+                val snapshot = liveClients.toList()
+                liveClients.clear()
+                snapshot
+            }
+            imageClient = null
+            generalClient = null
+            shortTimeoutClient = null
+            mediaClient = null
+            nip05Client = null
+            downloadClient = null
+            dmMediaClient = null
+            relayClient = null
+            // loopbackClient intentionally survives — never proxied, can't leak
+        }
+        thread(name = "tor-client-shutdown") {
+            old.forEach { runCatching { safeShutdownClient(it) } }
+        }
+    }
+
+    private fun relayClientBuilder(): OkHttpClient.Builder {
         // OkHttp's default Dispatcher.maxRequests is 64, which caps concurrent
         // WebSocket upgrade requests. With outbox routing creating 50+ ephemeral
         // connections, new user-initiated connections get queued and time out.
@@ -41,7 +116,27 @@ object HttpClientFactory {
                     .build()
                 chain.proceed(request)
             }
-            .build()
+    }
+
+    fun createRelayClient(): OkHttpClient = track(relayClientBuilder().applyProxy().build())
+
+    /** Shared relay WebSocket client; relays resolve it through their client provider on every (re)connect. */
+    fun getRelayClient(): OkHttpClient {
+        relayClient?.let { return it }
+        return synchronized(this) {
+            relayClient ?: createRelayClient().also { relayClient = it }
+        }
+    }
+
+    /**
+     * For loopback/LAN endpoints only (local relay). Never proxied: Tor refuses
+     * connections to loopback targets, and 127.0.0.1 can't leak anyway.
+     */
+    fun getLoopbackClient(): OkHttpClient {
+        loopbackClient?.let { return it }
+        return synchronized(this) {
+            loopbackClient ?: relayClientBuilder().build().also { loopbackClient = it }
+        }
     }
 
     fun getImageClient(): OkHttpClient {
@@ -108,6 +203,18 @@ object HttpClientFactory {
         }
     }
 
+    // Encrypted DM media: small files but slow hosts; generous read timeout.
+    fun getDmMediaClient(): OkHttpClient {
+        dmMediaClient?.let { return it }
+        return synchronized(this) {
+            dmMediaClient ?: createHttpClient(
+                connectTimeoutSeconds = 15,
+                readTimeoutSeconds = 60,
+                writeTimeoutSeconds = 15
+            ).also { dmMediaClient = it }
+        }
+    }
+
     fun createExoPlayer(context: Context): ExoPlayer {
         val client = getMediaClient()
         val dataSourceFactory = OkHttpDataSource.Factory(client)
@@ -139,11 +246,12 @@ object HttpClientFactory {
             .connectTimeout(connectTimeoutSeconds, TimeUnit.SECONDS)
             .readTimeout(readTimeoutSeconds, TimeUnit.SECONDS)
             .followRedirects(followRedirects)
+            .applyProxy()
 
         if (writeTimeoutSeconds > 0) {
             builder.writeTimeout(writeTimeoutSeconds, TimeUnit.SECONDS)
         }
 
-        return builder.build()
+        return track(builder.build())
     }
 }

--- a/app/src/main/kotlin/com/darkwisp/app/relay/Relay.kt
+++ b/app/src/main/kotlin/com/darkwisp/app/relay/Relay.kt
@@ -24,7 +24,9 @@ data class RelayFailure(val relayUrl: String, val httpCode: Int?, val message: S
 
 class Relay(
     val config: RelayConfig,
-    private val client: OkHttpClient,
+    /** Resolved on every (re)connect so a Tor toggle's new client is picked up
+     *  without recreating the Relay. */
+    private val clientProvider: () -> OkHttpClient,
     private val scope: CoroutineScope? = null
 ) {
     @Volatile private var webSocket: WebSocket? = null
@@ -132,7 +134,7 @@ class Relay(
             }
             val socketId = System.nanoTime()
             Log.d("RLC", "[Relay] connect() creating ws#$socketId for ${config.url}")
-            webSocket = client.newWebSocket(request, object : WebSocketListener() {
+            webSocket = clientProvider().newWebSocket(request, object : WebSocketListener() {
                 override fun onOpen(webSocket: WebSocket, response: Response) {
                     Log.d("RLC", "[Relay] ws#$socketId onOpen ${config.url} | isConnected was=$isConnected")
                     isConnected = true

--- a/app/src/main/kotlin/com/darkwisp/app/relay/RelayPool.kt
+++ b/app/src/main/kotlin/com/darkwisp/app/relay/RelayPool.kt
@@ -35,7 +35,9 @@ class RelayPool(private val prefs: SharedPreferences? = null) {
     @Volatile var reconnectGeneration: Long = 0
         private set
 
-    private var client: OkHttpClient = Relay.createClient()
+    /** Resolved by each Relay on every (re)connect, so a Tor toggle's rebuilt
+     *  client is picked up without recreating Relay instances. */
+    private val clientProvider: () -> OkHttpClient = { HttpClientFactory.getRelayClient() }
     private val relays = CopyOnWriteArrayList<Relay>()
     private val dmRelays = CopyOnWriteArrayList<Relay>()
     /** Persistent connections for NIP-29 group chat relays — auto-reconnect enabled. */
@@ -263,7 +265,7 @@ class RelayPool(private val prefs: SharedPreferences? = null) {
         val existingUrls = relays.map { it.config.url }.toSet()
         for (config in filtered) {
             if (config.url !in existingUrls) {
-                val relay = Relay(config, client, scope)
+                val relay = Relay(config, clientProvider, scope)
                 wireByteTracking(relay)
                 relays.add(relay)
                 relayIndex[config.url] = relay
@@ -294,7 +296,7 @@ class RelayPool(private val prefs: SharedPreferences? = null) {
                     activeSubscriptions.getOrPut(url) { java.util.concurrent.ConcurrentHashMap() }
                         .putAll(templateSubs)
                 }
-                val relay = Relay(RelayConfig(url, read = true, write = true), client, scope)
+                val relay = Relay(RelayConfig(url, read = true, write = true), clientProvider, scope)
                 wireByteTracking(relay)
                 dmRelays.add(relay)
                 relayIndex[url] = relay
@@ -318,7 +320,7 @@ class RelayPool(private val prefs: SharedPreferences? = null) {
         // will skip the group relay fast-path and send REQs on the disconnected ephemeral.
         ephemeralRelays.remove(url)?.disconnect()
         ephemeralLastUsed.remove(url)
-        val relay = Relay(RelayConfig(url, read = true, write = true), client, scope)
+        val relay = Relay(RelayConfig(url, read = true, write = true), clientProvider, scope)
         // autoReconnect defaults to true — subscriptions will be re-sent on reconnect
         wireByteTracking(relay)
         groupRelays[url] = relay
@@ -850,7 +852,7 @@ class RelayPool(private val prefs: SharedPreferences? = null) {
         if (ephemeralRelays.containsKey(url) || relayIndex.containsKey(url)) return
         if (ephemeralRelays.size >= MAX_EPHEMERAL) return
         ephemeralRelays.computeIfAbsent(url) {
-            val relay = Relay(RelayConfig(url, read = true, write = false), client, scope)
+            val relay = Relay(RelayConfig(url, read = true, write = false), clientProvider, scope)
             relay.autoReconnect = false
             wireByteTracking(relay)
             relayIndex[url] = relay
@@ -920,7 +922,7 @@ class RelayPool(private val prefs: SharedPreferences? = null) {
         var isNew = false
         val ephemeral = ephemeralRelays.computeIfAbsent(url) {
             isNew = true
-            val relay = Relay(RelayConfig(url, read = true, write = write), client, scope)
+            val relay = Relay(RelayConfig(url, read = true, write = write), clientProvider, scope)
             relay.autoReconnect = autoReconnect
             wireByteTracking(relay)
             relayIndex[url] = relay
@@ -1023,7 +1025,49 @@ class RelayPool(private val prefs: SharedPreferences? = null) {
             message.contains("unknown message", ignoreCase = true)
     }
 
+    /** Loopback/LAN hosts get the never-proxied client — Tor refuses private
+     *  network targets, and they can't leak the user's IP anyway. */
+    private fun clientProviderFor(url: String): () -> OkHttpClient {
+        val host = url.substringAfter("://").substringBefore("/").substringBefore(":")
+        val isPrivate = host == "localhost" || host == "127.0.0.1" || host == "[::1]" ||
+            host.startsWith("10.") || host.startsWith("192.168.") ||
+            Regex("^172\\.(1[6-9]|2\\d|3[01])\\.").containsMatchIn(host)
+        return if (isPrivate) ({ HttpClientFactory.getLoopbackClient() }) else clientProvider
+    }
+
+    /** True while a Tor toggle is replacing the relay client — blocks reconnect
+     *  storms against a SOCKS port that isn't up yet (which would trip the
+     *  per-relay 5-minute connection-attempt cooldown). */
+    @Volatile var torSwitchInProgress = false
+        private set
+
+    /** Immediately tears down every WebSocket and suppresses all reconnect paths.
+     *  Call before starting/stopping the Tor daemon. */
+    fun suspendForTorSwitch() {
+        torSwitchInProgress = true
+        val all = relays + dmRelays + groupRelays.values + ephemeralRelays.values + listOfNotNull(localRelay)
+        for (relay in all) {
+            relay.reconnectEnabled = false
+            relay.forceDisconnect()
+        }
+        updateConnectedCount()
+        Log.d("RLC", "[Pool] suspendForTorSwitch — dropped ${all.size} relay sockets")
+    }
+
+    /** Re-enables connections after a Tor switch; relays resolve the new client
+     *  through their provider on connect. */
+    fun resumeAfterTorSwitch() {
+        torSwitchInProgress = false
+        localRelay?.let { if (it.config.url == localRelayConfig?.url) { it.reconnectEnabled = true; it.connect() } }
+        reconnectAll()
+        Log.d("RLC", "[Pool] resumeAfterTorSwitch — reconnect issued")
+    }
+
     fun reconnectAll(): Int {
+        if (torSwitchInProgress) {
+            Log.d("RLC", "[Pool] reconnectAll() skipped — Tor switch in progress")
+            return 0
+        }
         Log.d("RLC", "[Pool] reconnectAll() START — persistent=${relays.size} dm=${dmRelays.size} ephemeral=${ephemeralRelays.size} activeSubs=${activeSubscriptions.size}")
         reconnectGeneration++
         isReconnecting = true
@@ -1088,6 +1132,10 @@ class RelayPool(private val prefs: SharedPreferences? = null) {
      * subscriptions have been silently dropped.
      */
     fun forceReconnectAll() {
+        if (torSwitchInProgress) {
+            Log.d("RLC", "[Pool] forceReconnectAll() skipped — Tor switch in progress")
+            return
+        }
         Log.d("RLC", "[Pool] forceReconnectAll() START — persistent=${relays.size} dm=${dmRelays.size} ephemeral=${ephemeralRelays.size}")
         reconnectGeneration++
         isReconnecting = true
@@ -1202,7 +1250,7 @@ class RelayPool(private val prefs: SharedPreferences? = null) {
         if (!RelayConfig.isValidUrl(url) && !RelayConfig.isLocalRelayUrl(url)) return
         if (ephemeralRelays.containsKey(url)) return
         if (ephemeralRelays.size >= MAX_EPHEMERAL) return
-        val relay = Relay(RelayConfig(url, read = true, write = false), client, scope)
+        val relay = Relay(RelayConfig(url, read = true, write = false), clientProvider, scope)
         relay.autoReconnect = false
         wireByteTracking(relay)
         relayIndex[url] = relay
@@ -1309,7 +1357,7 @@ class RelayPool(private val prefs: SharedPreferences? = null) {
 
         // Create new local relay connection
         val relayConfig = RelayConfig(config.url, read = true, write = true)
-        val relay = Relay(relayConfig, client)
+        val relay = Relay(relayConfig, clientProviderFor(config.url))
         localRelay = relay
         relayIndex[config.url] = relay
         collectMessages(relay)

--- a/app/src/main/kotlin/com/darkwisp/app/relay/RelayProber.kt
+++ b/app/src/main/kotlin/com/darkwisp/app/relay/RelayProber.kt
@@ -105,7 +105,7 @@ object RelayProber {
 
         for (bootstrapUrl in BOOTSTRAP) {
             try {
-                val relay = Relay(RelayConfig(bootstrapUrl, read = true, write = false), client)
+                val relay = Relay(RelayConfig(bootstrapUrl, read = true, write = false), { client })
                 relay.autoReconnect = false
                 relay.connect()
 
@@ -230,7 +230,7 @@ object RelayProber {
 
         // Ephemeral write test: connect, send kind 20242, await OK
         return try {
-            val relay = Relay(RelayConfig(url, read = true, write = true), wsClient)
+            val relay = Relay(RelayConfig(url, read = true, write = true), { wsClient })
             relay.autoReconnect = false
             relay.connect()
 

--- a/app/src/main/kotlin/com/darkwisp/app/relay/TorManager.kt
+++ b/app/src/main/kotlin/com/darkwisp/app/relay/TorManager.kt
@@ -1,0 +1,182 @@
+package com.darkwisp.app.relay
+
+import android.util.Log
+import com.darkwisp.app.BuildConfig
+import com.darkwisp.app.R
+import com.darkwisp.app.repo.TorPreferences
+import io.matthewnelson.kmp.tor.resource.exec.tor.ResourceLoaderTorExec
+import io.matthewnelson.kmp.tor.runtime.Action.Companion.startDaemonAsync
+import io.matthewnelson.kmp.tor.runtime.Action.Companion.stopDaemonAsync
+import io.matthewnelson.kmp.tor.runtime.RuntimeEvent
+import io.matthewnelson.kmp.tor.runtime.TorRuntime
+import io.matthewnelson.kmp.tor.runtime.TorState
+import io.matthewnelson.kmp.tor.runtime.core.OnEvent
+import io.matthewnelson.kmp.tor.runtime.core.TorEvent
+import io.matthewnelson.kmp.tor.runtime.core.config.TorOption
+import io.matthewnelson.kmp.tor.runtime.service.TorServiceConfig
+import io.matthewnelson.kmp.tor.runtime.service.TorServiceUI
+import io.matthewnelson.kmp.tor.runtime.service.ui.KmpTorServiceUI
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.withTimeoutOrNull
+
+/**
+ * Process-wide owner of the embedded Tor daemon (kmp-tor). Tor runs inside a
+ * foreground TorService, so it survives Activity recreation and backgrounding.
+ *
+ * [state] is the single source of truth observed by the drawer toggle, the
+ * pre-login corner button, and the toggle orchestration in StartupCoordinator.
+ */
+object TorManager {
+
+    sealed interface State {
+        data object Off : State
+        data class Starting(val bootstrapPercent: Int) : State
+        data class On(val socksPort: Int) : State
+        data object Stopping : State
+        data class Error(val message: String) : State
+    }
+
+    private val _state = MutableStateFlow<State>(State.Off)
+    val state: StateFlow<State> = _state.asStateFlow()
+
+    @Volatile private var daemon: TorState.Daemon = TorState.Daemon.Off
+    @Volatile private var socksPort: Int? = null
+    @Volatile private var runtime: TorRuntime? = null
+
+    fun init() {
+        if (runtime != null) return
+
+        val uiFactory = KmpTorServiceUI.Factory(
+            iconReady = R.drawable.ic_onion,
+            iconNotReady = R.drawable.ic_onion,
+            info = TorServiceUI.NotificationInfo(
+                notificationId = 4242.toShort(),
+                channelId = "wisp_tor",
+                channelName = R.string.tor_channel_name,
+                channelDescription = R.string.tor_channel_description,
+                channelShowBadge = false,
+            ),
+            block = {
+                // No notification actions: the in-app toggle is the single control
+                // point, so HttpClientFactory's proxy state can never drift from
+                // the daemon state.
+                defaultConfig {
+                    enableActionRestart = false
+                    enableActionStop = false
+                }
+            },
+        )
+
+        val serviceConfig = TorServiceConfig.Foreground.Builder(uiFactory) {
+            // Keep tor alive across task removal — re-bootstrapping on every
+            // app swipe takes tens of seconds.
+            stopServiceOnTaskRemoved = false
+        }
+
+        val environment = serviceConfig.newEnvironment(ResourceLoaderTorExec::getOrCreate)
+        environment.debug = BuildConfig.DEBUG
+
+        runtime = TorRuntime.Builder(environment) {
+            required(TorEvent.ERR)
+            required(TorEvent.WARN)
+
+            config {
+                // Let tor pick a free port; RuntimeEvent.LISTENERS reports it.
+                TorOption.__SocksPort.configure { auto() }
+            }
+
+            observerStatic(RuntimeEvent.STATE, OnEvent.Executor.Immediate) { torState ->
+                daemon = torState.daemon
+                recompute()
+            }
+            observerStatic(RuntimeEvent.LISTENERS, OnEvent.Executor.Immediate) { listeners ->
+                socksPort = listeners.socks.firstOrNull()?.port?.value
+                recompute()
+            }
+            observerStatic(RuntimeEvent.ERROR, OnEvent.Executor.Immediate) { t ->
+                Log.w("TorManager", "Tor runtime error", t)
+            }
+        }
+    }
+
+    private fun recompute() {
+        val d = daemon
+        val port = socksPort
+        // Don't clobber a surfaced Error with Off — the daemon settles to Off
+        // after a failed start, but the user should keep seeing the error.
+        if (_state.value is State.Error && d.isOff) return
+        _state.value = when {
+            d.isOff -> State.Off
+            d.isStopping -> State.Stopping
+            d.isBootstrapped && port != null -> State.On(port)
+            else -> State.Starting(d.bootstrap.toInt())
+        }
+    }
+
+    /**
+     * Starts the daemon and waits for full bootstrap + SOCKS listener.
+     * Returns the SOCKS port, or null on timeout/error (caller stays fail-closed).
+     */
+    suspend fun start(timeoutMs: Long = 120_000): Int? {
+        val rt = runtime ?: return null
+        _state.value = State.Starting(0)
+        return try {
+            val port = withTimeoutOrNull(timeoutMs) {
+                // kmp-tor's service bind has a fixed 1s internal timeout, which a
+                // busy main thread misses during cold app start — retry; by the
+                // second or third attempt init has settled and the bind succeeds.
+                var attempt = 0
+                while (true) {
+                    try {
+                        rt.startDaemonAsync()
+                        break
+                    } catch (e: CancellationException) {
+                        throw e
+                    } catch (e: Exception) {
+                        if (++attempt >= 5) throw e
+                        Log.w("TorManager", "Tor start attempt $attempt failed, retrying", e)
+                        delay(1_000)
+                    }
+                }
+                (state.first { it is State.On } as State.On).socksPort
+            }
+            if (port == null) _state.value = State.Error("Tor bootstrap timed out")
+            port
+        } catch (e: Exception) {
+            Log.w("TorManager", "Tor start failed", e)
+            _state.value = State.Error(e.message ?: "Tor failed to start")
+            null
+        }
+    }
+
+    suspend fun stop() {
+        socksPort = null
+        val rt = runtime ?: return
+        _state.value = State.Stopping
+        try {
+            rt.stopDaemonAsync()
+        } catch (e: Exception) {
+            Log.w("TorManager", "Tor stop failed", e)
+        }
+        _state.value = State.Off
+    }
+
+    /**
+     * Gate for cold-start relay init: suspends until Tor is usable when the
+     * pref is on, no-ops otherwise. Also unblocks if the user turns the pref
+     * off mid-wait. Returns false on timeout (caller stays fail-closed).
+     */
+    suspend fun awaitOnIfEnabled(timeoutMs: Long = 120_000): Boolean {
+        if (!TorPreferences.isEnabled()) return true
+        return withTimeoutOrNull(timeoutMs) {
+            combine(state, TorPreferences.enabled) { s, enabled -> s is State.On || !enabled }
+                .first { it }
+        } != null
+    }
+}

--- a/app/src/main/kotlin/com/darkwisp/app/repo/ExchangeRateRepository.kt
+++ b/app/src/main/kotlin/com/darkwisp/app/repo/ExchangeRateRepository.kt
@@ -3,12 +3,16 @@ package com.darkwisp.app.repo
 import android.content.Context
 import android.util.Log
 import com.darkwisp.app.relay.HttpClientFactory
+import com.darkwisp.app.relay.TorManager
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.drop
+import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.launch
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.doubleOrNull
@@ -76,6 +80,15 @@ object ExchangeRateRepository {
         appContext = context.applicationContext
         loadCached()
         refresh()
+        // The init-time fetch fails closed while Tor is bootstrapping; refetch
+        // once the route settles (Tor up, or toggled off back to clearnet).
+        scope.launch {
+            TorManager.state
+                .filter { it is TorManager.State.On || it is TorManager.State.Off }
+                .distinctUntilChanged()
+                .drop(1)
+                .collect { refresh() }
+        }
     }
 
     fun refresh() {

--- a/app/src/main/kotlin/com/darkwisp/app/repo/NwcRepository.kt
+++ b/app/src/main/kotlin/com/darkwisp/app/repo/NwcRepository.kt
@@ -9,6 +9,7 @@ import com.darkwisp.app.nostr.Filter
 import com.darkwisp.app.nostr.Nip47
 import com.darkwisp.app.nostr.RelayMessage
 import com.darkwisp.app.nostr.toHex
+import com.darkwisp.app.relay.HttpClientFactory
 import com.darkwisp.app.relay.Relay
 import com.darkwisp.app.relay.RelayConfig
 import com.darkwisp.app.relay.RelayPool
@@ -106,8 +107,9 @@ class NwcRepository(private val context: Context, private val relayPool: RelayPo
         val newScope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
         scope = newScope
 
-        val client = Relay.createClient()
-        val r = Relay(RelayConfig(conn.relayUrl), client, scope = newScope)
+        // Shared provider, not a captured client: the NWC relay is long-lived and
+        // must resolve the current (possibly Tor-proxied) client on every reconnect.
+        val r = Relay(RelayConfig(conn.relayUrl), { HttpClientFactory.getRelayClient() }, scope = newScope)
         relay = r
 
         emitStatus("Connecting to relay ${conn.relayUrl}...")

--- a/app/src/main/kotlin/com/darkwisp/app/repo/TorPreferences.kt
+++ b/app/src/main/kotlin/com/darkwisp/app/repo/TorPreferences.kt
@@ -1,0 +1,33 @@
+package com.darkwisp.app.repo
+
+import android.content.Context
+import android.content.SharedPreferences
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+
+/**
+ * Device-level Tor preference. Deliberately NOT per-account: the toggle must work
+ * before login and survive logout/account switches.
+ */
+object TorPreferences {
+    private const val PREFS_NAME = "wisp_tor"
+    private const val KEY_ENABLED = "tor_enabled"
+
+    private lateinit var prefs: SharedPreferences
+
+    private val _enabled = MutableStateFlow(false)
+    val enabled: StateFlow<Boolean> = _enabled
+
+    fun init(context: Context) {
+        if (::prefs.isInitialized) return
+        prefs = context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+        _enabled.value = prefs.getBoolean(KEY_ENABLED, false)
+    }
+
+    fun isEnabled(): Boolean = _enabled.value
+
+    fun setEnabled(enabled: Boolean) {
+        _enabled.value = enabled
+        prefs.edit().putBoolean(KEY_ENABLED, enabled).apply()
+    }
+}

--- a/app/src/main/kotlin/com/darkwisp/app/repo/ZapSender.kt
+++ b/app/src/main/kotlin/com/darkwisp/app/repo/ZapSender.kt
@@ -15,7 +15,9 @@ class ZapSender(
     private val getWalletProvider: () -> WalletProvider,
     private val relayPool: RelayPool,
     private val relayListRepo: RelayListRepository,
-    private val httpClient: OkHttpClient,
+    /** Provider, not a captured client: ZapSender outlives Tor toggles and must
+     *  resolve the current client per LNURL request. */
+    private val httpClient: () -> OkHttpClient,
     private val interfacePrefs: InterfacePreferences
 ) {
     var signer: NostrSigner? = null
@@ -83,7 +85,7 @@ class ZapSender(
         eventCreatedAt: Long? = null
     ): Result<Unit> {
         // 1. LNURL discovery
-        val payInfo = Nip57.resolveLud16(recipientLud16, httpClient)
+        val payInfo = Nip57.resolveLud16(recipientLud16, httpClient())
             ?: return Result.failure(Exception("Could not resolve lightning address"))
 
         if (!payInfo.allowsNostr) {
@@ -190,7 +192,7 @@ class ZapSender(
         }
 
         // 3. Fetch invoice from LNURL callback
-        val bolt11 = Nip57.fetchInvoice(payInfo.callback, amountMsats, zapRequest, httpClient)
+        val bolt11 = Nip57.fetchInvoice(payInfo.callback, amountMsats, zapRequest, httpClient())
             ?: return Result.failure(Exception("Could not get invoice from lightning provider"))
 
         // 4. Record zap recipient for transaction history display

--- a/app/src/main/kotlin/com/darkwisp/app/ui/component/DmBubble.kt
+++ b/app/src/main/kotlin/com/darkwisp/app/ui/component/DmBubble.kt
@@ -766,13 +766,10 @@ private fun formatTime(epoch: Long): String {
 /** In-memory LRU cache for decrypted media bitmaps. ~32 MB max. */
 private val decryptedBitmapCache = LruCache<String, Bitmap>(32)
 
-private val mediaHttpClient by lazy {
-    com.darkwisp.app.relay.HttpClientFactory.createHttpClient(
-        connectTimeoutSeconds = 15,
-        readTimeoutSeconds = 60,
-        writeTimeoutSeconds = 15
-    )
-}
+// Per-access getter (not lazy): the factory invalidates its cached clients on a
+// Tor toggle, and a lazy here would pin the pre-toggle client forever.
+private val mediaHttpClient
+    get() = com.darkwisp.app.relay.HttpClientFactory.getDmMediaClient()
 
 @Composable
 private fun EncryptedMediaContent(

--- a/app/src/main/kotlin/com/darkwisp/app/ui/component/TorCornerButton.kt
+++ b/app/src/main/kotlin/com/darkwisp/app/ui/component/TorCornerButton.kt
@@ -1,0 +1,78 @@
+package com.darkwisp.app.ui.component
+
+import android.Manifest
+import android.content.pm.PackageManager
+import android.os.Build
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.size
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import androidx.core.content.ContextCompat
+import com.darkwisp.app.R
+import com.darkwisp.app.relay.TorManager
+
+/**
+ * Onion toggle for the pre-login screens (Splash/Auth), where no drawer exists.
+ * Self-contained: observes [TorManager.state] and handles the notification
+ * permission prompt; the caller only routes the enable/disable intent.
+ */
+@Composable
+fun TorCornerButton(
+    onToggle: (Boolean) -> Unit,
+    modifier: Modifier = Modifier
+) {
+    val torState by TorManager.state.collectAsState()
+    val context = LocalContext.current
+    // The Tor foreground service runs without this permission; requesting it
+    // just makes the status notification visible on API 33+.
+    val notifPermLauncher = rememberLauncherForActivityResult(
+        ActivityResultContracts.RequestPermission()
+    ) {}
+
+    Box(modifier = modifier, contentAlignment = Alignment.Center) {
+        if (torState is TorManager.State.Starting || torState is TorManager.State.Stopping) {
+            CircularProgressIndicator(
+                modifier = Modifier.size(36.dp),
+                strokeWidth = 2.dp,
+                color = Color(0xFFFFB74D)
+            )
+        }
+        IconButton(onClick = {
+            val enable = torState is TorManager.State.Off || torState is TorManager.State.Error
+            if (enable && Build.VERSION.SDK_INT >= 33 &&
+                ContextCompat.checkSelfPermission(
+                    context, Manifest.permission.POST_NOTIFICATIONS
+                ) != PackageManager.PERMISSION_GRANTED
+            ) {
+                notifPermLauncher.launch(Manifest.permission.POST_NOTIFICATIONS)
+            }
+            onToggle(enable)
+        }) {
+            Icon(
+                painter = painterResource(R.drawable.ic_onion),
+                contentDescription = stringResource(R.string.cd_tor_toggle),
+                modifier = Modifier.size(24.dp),
+                tint = when (torState) {
+                    is TorManager.State.On -> Color(0xFF9C59D1)
+                    is TorManager.State.Starting, TorManager.State.Stopping -> Color(0xFFFFB74D)
+                    is TorManager.State.Error -> MaterialTheme.colorScheme.error
+                    else -> MaterialTheme.colorScheme.onSurfaceVariant
+                }
+            )
+        }
+    }
+}

--- a/app/src/main/kotlin/com/darkwisp/app/ui/component/WispDrawerContent.kt
+++ b/app/src/main/kotlin/com/darkwisp/app/ui/component/WispDrawerContent.kt
@@ -71,8 +71,15 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
 import com.darkwisp.app.nostr.ProfileData
+import com.darkwisp.app.relay.TorManager
 import com.darkwisp.app.repo.AccountInfo
+
+private val TorPurple = Color(0xFF9C59D1)
+private val TorAmber = Color(0xFFFFB74D)
+private val TorGreen = Color(0xFF4CAF50)
 
 
 @Composable
@@ -102,6 +109,8 @@ fun WispDrawerContent(
     onRelaySettings: () -> Unit,
     onInterfaceSettings: () -> Unit = {},
     onLogout: () -> Unit,
+    torState: TorManager.State = TorManager.State.Off,
+    onToggleTor: () -> Unit = {},
     hasEmbeddedWallet: Boolean = false,
     userStatus: String? = null,
     onUpdateStatus: ((String) -> Unit)? = null,
@@ -428,6 +437,44 @@ fun WispDrawerContent(
             label = { Text(stringResource(R.string.drawer_drafts)) },
             selected = false,
             onClick = onDrafts,
+            modifier = Modifier.height(48.dp).padding(horizontal = 12.dp)
+        )
+        NavigationDrawerItem(
+            icon = {
+                Icon(
+                    painter = painterResource(R.drawable.ic_onion),
+                    contentDescription = stringResource(R.string.cd_tor_toggle),
+                    modifier = Modifier.size(24.dp),
+                    tint = when (torState) {
+                        is TorManager.State.On -> TorPurple
+                        is TorManager.State.Starting, TorManager.State.Stopping -> TorAmber
+                        is TorManager.State.Error -> MaterialTheme.colorScheme.error
+                        else -> androidx.compose.material3.LocalContentColor.current
+                    }
+                )
+            },
+            label = { Text(stringResource(R.string.drawer_tor)) },
+            badge = {
+                when (val s = torState) {
+                    is TorManager.State.Starting -> Text(
+                        stringResource(R.string.tor_status_connecting, s.bootstrapPercent),
+                        style = MaterialTheme.typography.labelMedium,
+                        color = TorAmber
+                    )
+                    is TorManager.State.On -> Box(
+                        Modifier.size(8.dp).clip(androidx.compose.foundation.shape.CircleShape).background(TorGreen)
+                    )
+                    is TorManager.State.Error -> Text(
+                        stringResource(R.string.tor_status_error),
+                        style = MaterialTheme.typography.labelMedium,
+                        color = MaterialTheme.colorScheme.error
+                    )
+                    else -> {}
+                }
+            },
+            selected = torState is TorManager.State.On,
+            // Drawer intentionally stays open so the user can watch bootstrap progress.
+            onClick = onToggleTor,
             modifier = Modifier.height(48.dp).padding(horizontal = 12.dp)
         )
         var settingsExpanded by remember { mutableStateOf(false) }

--- a/app/src/main/kotlin/com/darkwisp/app/ui/screen/AuthScreen.kt
+++ b/app/src/main/kotlin/com/darkwisp/app/ui/screen/AuthScreen.kt
@@ -14,6 +14,7 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.statusBarsPadding
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material.icons.Icons
@@ -63,13 +64,15 @@ import androidx.compose.ui.res.stringResource
 import com.darkwisp.app.R
 import com.darkwisp.app.nostr.RemoteSignerBridge
 import com.darkwisp.app.nostr.toHex
+import com.darkwisp.app.ui.component.TorCornerButton
 import com.darkwisp.app.viewmodel.AuthViewModel
 
 @Composable
 fun AuthScreen(
     viewModel: AuthViewModel,
     showSignUp: Boolean = true,
-    onAuthenticated: (isNewAccount: Boolean) -> Unit
+    onAuthenticated: (isNewAccount: Boolean) -> Unit,
+    onToggleTor: (Boolean) -> Unit = {}
 ) {
     val context = LocalContext.current
     val nsecInput by viewModel.nsecInput.collectAsState()
@@ -104,130 +107,139 @@ fun AuthScreen(
         signerLoginComplete = true
     }
 
-    Column(
-        modifier = Modifier
-            .fillMaxSize()
-            .padding(32.dp),
-        horizontalAlignment = Alignment.CenterHorizontally,
-        verticalArrangement = Arrangement.Center
-    ) {
-        Icon(
-            painter = painterResource(R.drawable.ic_wisp_logo),
-            contentDescription = stringResource(R.string.onboarding_wisp_logo),
-            tint = androidx.compose.ui.graphics.Color.Unspecified,
+    Box(modifier = Modifier.fillMaxSize()) {
+        Column(
             modifier = Modifier
-                .size(108.dp)
-                .drawBehind {
-                    drawCircle(
-                        brush = androidx.compose.ui.graphics.Brush.radialGradient(
-                            colors = listOf(
-                                androidx.compose.ui.graphics.Color.Black,
-                                androidx.compose.ui.graphics.Color.Black.copy(alpha = 0.6f),
-                                androidx.compose.ui.graphics.Color.Transparent
+                .fillMaxSize()
+                .padding(32.dp),
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.Center
+        ) {
+            Icon(
+                painter = painterResource(R.drawable.ic_wisp_logo),
+                contentDescription = stringResource(R.string.onboarding_wisp_logo),
+                tint = androidx.compose.ui.graphics.Color.Unspecified,
+                modifier = Modifier
+                    .size(108.dp)
+                    .drawBehind {
+                        drawCircle(
+                            brush = androidx.compose.ui.graphics.Brush.radialGradient(
+                                colors = listOf(
+                                    androidx.compose.ui.graphics.Color.Black,
+                                    androidx.compose.ui.graphics.Color.Black.copy(alpha = 0.6f),
+                                    androidx.compose.ui.graphics.Color.Transparent
+                                ),
+                                radius = size.minDimension * 0.65f
                             ),
                             radius = size.minDimension * 0.65f
-                        ),
-                        radius = size.minDimension * 0.65f
-                    )
-                }
-        )
-        Text(
-            text = stringResource(R.string.auth_wisp),
-            style = MaterialTheme.typography.titleLarge.copy(
-                fontFamily = FontFamily.SansSerif,
-                fontSize = 36.sp,
-                fontWeight = FontWeight.W500
-            ),
-            color = MaterialTheme.colorScheme.primary
-        )
-        Spacer(Modifier.height(4.dp))
-        Text(
-            text = stringResource(R.string.auth_tagline),
-            style = MaterialTheme.typography.bodyMedium,
-            color = MaterialTheme.colorScheme.onSurfaceVariant
-        )
-
-        Spacer(Modifier.height(16.dp))
-
-        if (showSignUp) {
-            Button(
-                onClick = {
-                    if (viewModel.signUp()) onAuthenticated(true)
-                },
-                modifier = Modifier.fillMaxWidth()
-            ) {
-                Text(stringResource(R.string.auth_sign_up))
-            }
-
-            Spacer(Modifier.height(24.dp))
-            HorizontalDivider(color = MaterialTheme.colorScheme.outline)
-            Spacer(Modifier.height(24.dp))
-
+                        )
+                    }
+            )
             Text(
-                text = stringResource(R.string.auth_or_log_in_with_key),
+                text = stringResource(R.string.auth_wisp),
+                style = MaterialTheme.typography.titleLarge.copy(
+                    fontFamily = FontFamily.SansSerif,
+                    fontSize = 36.sp,
+                    fontWeight = FontWeight.W500
+                ),
+                color = MaterialTheme.colorScheme.primary
+            )
+            Spacer(Modifier.height(4.dp))
+            Text(
+                text = stringResource(R.string.auth_tagline),
                 style = MaterialTheme.typography.bodyMedium,
                 color = MaterialTheme.colorScheme.onSurfaceVariant
             )
-            Spacer(Modifier.height(12.dp))
-        } else {
-            Spacer(Modifier.height(12.dp))
-        }
-
-
-        OutlinedTextField(
-            value = nsecInput,
-            onValueChange = { viewModel.updateNsecInput(it) },
-            label = { Text(stringResource(R.string.auth_nsec_or_npub)) },
-            singleLine = true,
-            visualTransformation = if (nsecVisible) VisualTransformation.None else PasswordVisualTransformation(),
-            keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Password),
-            trailingIcon = {
-                IconButton(onClick = { nsecVisible = !nsecVisible }) {
-                    Icon(
-                        imageVector = if (nsecVisible) Icons.Outlined.VisibilityOff else Icons.Outlined.Visibility,
-                        contentDescription = if (nsecVisible) stringResource(R.string.auth_hide_key) else stringResource(R.string.auth_show_key)
-                    )
+    
+            Spacer(Modifier.height(16.dp))
+    
+            if (showSignUp) {
+                Button(
+                    onClick = {
+                        if (viewModel.signUp()) onAuthenticated(true)
+                    },
+                    modifier = Modifier.fillMaxWidth()
+                ) {
+                    Text(stringResource(R.string.auth_sign_up))
                 }
-            },
-            modifier = Modifier.fillMaxWidth()
-        )
-
-        Spacer(Modifier.height(12.dp))
-
-        OutlinedButton(
-            onClick = {
-                if (viewModel.logIn()) onAuthenticated(false)
-            },
-            modifier = Modifier.fillMaxWidth()
-        ) {
-            Text(stringResource(R.string.auth_log_in))
-        }
-
-        if (signerAvailable) {
-            Spacer(Modifier.height(24.dp))
-            HorizontalDivider(color = MaterialTheme.colorScheme.outline)
-            Spacer(Modifier.height(24.dp))
-
+    
+                Spacer(Modifier.height(24.dp))
+                HorizontalDivider(color = MaterialTheme.colorScheme.outline)
+                Spacer(Modifier.height(24.dp))
+    
+                Text(
+                    text = stringResource(R.string.auth_or_log_in_with_key),
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+                Spacer(Modifier.height(12.dp))
+            } else {
+                Spacer(Modifier.height(12.dp))
+            }
+    
+    
+            OutlinedTextField(
+                value = nsecInput,
+                onValueChange = { viewModel.updateNsecInput(it) },
+                label = { Text(stringResource(R.string.auth_nsec_or_npub)) },
+                singleLine = true,
+                visualTransformation = if (nsecVisible) VisualTransformation.None else PasswordVisualTransformation(),
+                keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Password),
+                trailingIcon = {
+                    IconButton(onClick = { nsecVisible = !nsecVisible }) {
+                        Icon(
+                            imageVector = if (nsecVisible) Icons.Outlined.VisibilityOff else Icons.Outlined.Visibility,
+                            contentDescription = if (nsecVisible) stringResource(R.string.auth_hide_key) else stringResource(R.string.auth_show_key)
+                        )
+                    }
+                },
+                modifier = Modifier.fillMaxWidth()
+            )
+    
+            Spacer(Modifier.height(12.dp))
+    
             OutlinedButton(
                 onClick = {
-                    val permissions = """[{"type":"sign_event","kind":0},{"type":"sign_event","kind":1},{"type":"sign_event","kind":3},{"type":"sign_event","kind":5},{"type":"sign_event","kind":6},{"type":"sign_event","kind":7},{"type":"sign_event","kind":13},{"type":"sign_event","kind":9734},{"type":"sign_event","kind":10000},{"type":"sign_event","kind":10001},{"type":"sign_event","kind":10002},{"type":"sign_event","kind":10030},{"type":"sign_event","kind":10063},{"type":"sign_event","kind":22242},{"type":"sign_event","kind":24242},{"type":"sign_event","kind":30000},{"type":"sign_event","kind":30003},{"type":"sign_event","kind":30030},{"type":"nip44_encrypt"},{"type":"nip44_decrypt"}]"""
-                    val intent = RemoteSignerBridge.buildGetPublicKeyIntent(permissions)
-                    signerLauncher.launch(intent)
+                    if (viewModel.logIn()) onAuthenticated(false)
                 },
                 modifier = Modifier.fillMaxWidth()
             ) {
-                Text(stringResource(R.string.auth_login_with_signer))
+                Text(stringResource(R.string.auth_log_in))
+            }
+    
+            if (signerAvailable) {
+                Spacer(Modifier.height(24.dp))
+                HorizontalDivider(color = MaterialTheme.colorScheme.outline)
+                Spacer(Modifier.height(24.dp))
+    
+                OutlinedButton(
+                    onClick = {
+                        val permissions = """[{"type":"sign_event","kind":0},{"type":"sign_event","kind":1},{"type":"sign_event","kind":3},{"type":"sign_event","kind":5},{"type":"sign_event","kind":6},{"type":"sign_event","kind":7},{"type":"sign_event","kind":13},{"type":"sign_event","kind":9734},{"type":"sign_event","kind":10000},{"type":"sign_event","kind":10001},{"type":"sign_event","kind":10002},{"type":"sign_event","kind":10030},{"type":"sign_event","kind":10063},{"type":"sign_event","kind":22242},{"type":"sign_event","kind":24242},{"type":"sign_event","kind":30000},{"type":"sign_event","kind":30003},{"type":"sign_event","kind":30030},{"type":"nip44_encrypt"},{"type":"nip44_decrypt"}]"""
+                        val intent = RemoteSignerBridge.buildGetPublicKeyIntent(permissions)
+                        signerLauncher.launch(intent)
+                    },
+                    modifier = Modifier.fillMaxWidth()
+                ) {
+                    Text(stringResource(R.string.auth_login_with_signer))
+                }
+            }
+    
+            error?.let {
+                Spacer(Modifier.height(16.dp))
+                Text(
+                    text = it,
+                    color = MaterialTheme.colorScheme.error,
+                    style = MaterialTheme.typography.bodySmall
+                )
             }
         }
-
-        error?.let {
-            Spacer(Modifier.height(16.dp))
-            Text(
-                text = it,
-                color = MaterialTheme.colorScheme.error,
-                style = MaterialTheme.typography.bodySmall
-            )
-        }
+        TorCornerButton(
+            onToggle = onToggleTor,
+            modifier = Modifier
+                .align(Alignment.TopEnd)
+                .statusBarsPadding()
+                .padding(8.dp)
+        )
     }
 }
 

--- a/app/src/main/kotlin/com/darkwisp/app/ui/screen/FeedScreen.kt
+++ b/app/src/main/kotlin/com/darkwisp/app/ui/screen/FeedScreen.kt
@@ -1,5 +1,7 @@
 package com.darkwisp.app.ui.screen
 
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
@@ -81,6 +83,7 @@ import com.darkwisp.app.nostr.Nip10
 import com.darkwisp.app.nostr.Nip69
 import com.darkwisp.app.nostr.NostrEvent
 import com.darkwisp.app.R
+import com.darkwisp.app.relay.TorManager
 import com.darkwisp.app.ui.component.NoteActions
 import com.darkwisp.app.ui.component.EmojiLibrarySheet
 import com.darkwisp.app.ui.component.pendingEmojiReactCallback
@@ -648,6 +651,13 @@ fun FeedScreen(
     ModalNavigationDrawer(
         drawerState = drawerState,
         drawerContent = {
+            val torState by TorManager.state.collectAsState()
+            val torContext = LocalContext.current
+            // The Tor foreground service runs without this permission; requesting it
+            // just makes the status notification visible on API 33+.
+            val notifPermLauncher = rememberLauncherForActivityResult(
+                ActivityResultContracts.RequestPermission()
+            ) {}
             WispDrawerContent(
                 profile = userProfile,
                 pubkey = userPubkey,
@@ -732,6 +742,18 @@ fun FeedScreen(
                 onLogout = {
                     scope.launch { drawerState.close() }
                     onLogout()
+                },
+                torState = torState,
+                onToggleTor = {
+                    val enable = torState is TorManager.State.Off || torState is TorManager.State.Error
+                    if (enable && android.os.Build.VERSION.SDK_INT >= 33 &&
+                        androidx.core.content.ContextCompat.checkSelfPermission(
+                            torContext, android.Manifest.permission.POST_NOTIFICATIONS
+                        ) != android.content.pm.PackageManager.PERMISSION_GRANTED
+                    ) {
+                        notifPermLauncher.launch(android.Manifest.permission.POST_NOTIFICATIONS)
+                    }
+                    viewModel.setTorEnabled(enable)
                 },
                 hasEmbeddedWallet = hasEmbeddedWallet,
                 userStatus = statusVersion.let { userPubkey?.let { viewModel.eventRepo.getUserStatus(it) } },

--- a/app/src/main/kotlin/com/darkwisp/app/ui/screen/SplashScreen.kt
+++ b/app/src/main/kotlin/com/darkwisp/app/ui/screen/SplashScreen.kt
@@ -45,7 +45,9 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.compose.ui.res.stringResource
 import coil3.compose.AsyncImage
+import androidx.compose.foundation.layout.statusBarsPadding
 import com.darkwisp.app.R
+import com.darkwisp.app.ui.component.TorCornerButton
 import com.darkwisp.app.viewmodel.LiveMetrics
 import com.darkwisp.app.viewmodel.SplashViewModel
 
@@ -56,7 +58,8 @@ private val AVATAR_GAP = 4.dp
 fun SplashScreen(
     viewModel: SplashViewModel,
     onSignUp: () -> Unit,
-    onLogIn: () -> Unit
+    onLogIn: () -> Unit,
+    onToggleTor: (Boolean) -> Unit = {}
 ) {
     val profilePictures by viewModel.profilePictures.collectAsState()
     val liveMetrics by viewModel.liveMetrics.collectAsState()
@@ -199,6 +202,14 @@ fun SplashScreen(
                 Text(stringResource(R.string.splash_log_in))
             }
         }
+
+        TorCornerButton(
+            onToggle = onToggleTor,
+            modifier = Modifier
+                .align(Alignment.TopEnd)
+                .statusBarsPadding()
+                .padding(8.dp)
+        )
     }
 }
 

--- a/app/src/main/kotlin/com/darkwisp/app/viewmodel/FeedViewModel.kt
+++ b/app/src/main/kotlin/com/darkwisp/app/viewmodel/FeedViewModel.kt
@@ -280,7 +280,7 @@ class FeedViewModel(app: Application) : AndroidViewModel(app) {
             else -> nwcRepo
         }
 
-    val zapSender = ZapSender(keyRepo, { activeWalletProvider }, relayPool, relayListRepo, HttpClientFactory.createRelayClient(), interfacePrefs)
+    val zapSender = ZapSender(keyRepo, { activeWalletProvider }, relayPool, relayListRepo, { HttpClientFactory.getGeneralClient() }, interfacePrefs)
     val powManager = PowManager(powPrefs, relayPool, outboxRouter, eventRepo, viewModelScope)
 
     // -- Manager classes --
@@ -429,6 +429,7 @@ class FeedViewModel(app: Application) : AndroidViewModel(app) {
 
     // -- Startup delegates --
     fun initRelays() = startup.initRelays()
+    fun setTorEnabled(enabled: Boolean) = startup.setTorEnabled(enabled)
     fun resetForAccountSwitch() {
         startup.resetForAccountSwitch()
         groupRepo.clear()
@@ -492,7 +493,7 @@ class FeedViewModel(app: Application) : AndroidViewModel(app) {
 
     private suspend fun tryConnect(url: String): Boolean {
         val client = HttpClientFactory.createRelayClient()
-        val relay = Relay(RelayConfig(url, read = true, write = false), client)
+        val relay = Relay(RelayConfig(url, read = true, write = false), { client })
         relay.autoReconnect = false
         return try {
             relay.connect()

--- a/app/src/main/kotlin/com/darkwisp/app/viewmodel/SplashViewModel.kt
+++ b/app/src/main/kotlin/com/darkwisp/app/viewmodel/SplashViewModel.kt
@@ -3,12 +3,17 @@ package com.darkwisp.app.viewmodel
 import android.app.Application
 import androidx.lifecycle.AndroidViewModel
 import androidx.lifecycle.viewModelScope
+import com.darkwisp.app.relay.HttpClientFactory
+import com.darkwisp.app.relay.TorManager
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.drop
+import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.launch
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonArray
@@ -21,7 +26,6 @@ import okhttp3.Request
 import okhttp3.Response
 import okhttp3.WebSocket
 import okhttp3.WebSocketListener
-import java.util.concurrent.TimeUnit
 
 data class LiveMetrics(val online: Int, val notes: Int)
 
@@ -44,10 +48,27 @@ class SplashViewModel(app: Application) : AndroidViewModel(app) {
     }
 
     init {
-        val client = OkHttpClient.Builder()
-            .connectTimeout(10, TimeUnit.SECONDS)
-            .readTimeout(0, TimeUnit.MILLISECONDS)
-            .build()
+        startNetworkJobs()
+
+        // The splash screen is where a pre-login Tor toggle happens: rerun the
+        // collage fetch and metrics socket when Tor finishes bootstrapping (On)
+        // or is turned off, so they recover on the new route. The factory has
+        // already killed the previous client's connections at that point.
+        viewModelScope.launch {
+            TorManager.state
+                .filter { it is TorManager.State.On || it is TorManager.State.Off }
+                .distinctUntilChanged()
+                .drop(1)
+                .collect {
+                    fetchJob?.cancel()
+                    metricsJob?.cancel()
+                    startNetworkJobs()
+                }
+        }
+    }
+
+    private fun startNetworkJobs() {
+        val client = HttpClientFactory.createRelayClient()
         okHttpClient = client
 
         fetchJob = viewModelScope.launch(Dispatchers.IO) {

--- a/app/src/main/kotlin/com/darkwisp/app/viewmodel/StartupCoordinator.kt
+++ b/app/src/main/kotlin/com/darkwisp/app/viewmodel/StartupCoordinator.kt
@@ -7,6 +7,7 @@ import com.darkwisp.app.nostr.Filter
 import com.darkwisp.app.nostr.Nip30
 import com.darkwisp.app.nostr.Nip51
 import com.darkwisp.app.db.EventPersistence
+import com.darkwisp.app.relay.HttpClientFactory
 import com.darkwisp.app.relay.OutboxRouter
 import com.darkwisp.app.relay.RelayConfig
 import com.darkwisp.app.relay.RelayHealthTracker
@@ -14,6 +15,7 @@ import com.darkwisp.app.relay.RelayLifecycleManager
 import com.darkwisp.app.relay.RelayPool
 import com.darkwisp.app.relay.RelayScoreBoard
 import com.darkwisp.app.relay.SubscriptionManager
+import com.darkwisp.app.relay.TorManager
 import com.darkwisp.app.repo.BlossomRepository
 import com.darkwisp.app.repo.BookmarkRepository
 import com.darkwisp.app.repo.BookmarkSetRepository
@@ -42,6 +44,7 @@ import com.darkwisp.app.repo.RelayListRepository
 import com.darkwisp.app.repo.InterestRepository
 import com.darkwisp.app.repo.LiveStreamRepository
 import com.darkwisp.app.repo.RelaySetRepository
+import com.darkwisp.app.repo.TorPreferences
 import com.darkwisp.app.repo.ZapPreferences
 import com.darkwisp.app.nostr.NostrSigner
 import kotlinx.coroutines.CoroutineScope
@@ -51,6 +54,8 @@ import kotlinx.coroutines.flow.drop
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.withContext
 import kotlinx.coroutines.withTimeoutOrNull
 import java.io.File
@@ -204,6 +209,55 @@ class StartupCoordinator(
         if (relaysInitialized) { Log.d("StartupCoord", "initRelays: already initialized, returning"); return }
         relaysInitialized = true
 
+        if (TorPreferences.isEnabled()) {
+            // Process restarted with Tor on: relays must not attempt connections until
+            // the daemon is bootstrapped — the fail-closed proxy would refuse every
+            // attempt and burn through the per-relay backoff budget.
+            scope.launch {
+                TorManager.awaitOnIfEnabled()
+                initRelaysInternal()
+            }
+        } else {
+            initRelaysInternal()
+        }
+    }
+
+    /**
+     * Toggles Tor and re-routes every connection, both directions, serialized so
+     * rapid toggling can't interleave. Safe pre-login: the pool is empty, so the
+     * suspend/resume steps are no-ops and only the proxy state + daemon change.
+     */
+    fun setTorEnabled(enabled: Boolean) {
+        scope.launch {
+            torSwitchMutex.withLock {
+                if (enabled) {
+                    TorPreferences.setEnabled(true)
+                    // Fail-closed from this instant: future clients hit a dead SOCKS
+                    // port until bootstrap completes; existing clients are cancelled
+                    // and their keep-alive pools evicted.
+                    HttpClientFactory.setTorSocks(HttpClientFactory.TorSocks.Pending)
+                    relayPool.suspendForTorSwitch()
+                    val port = TorManager.start()
+                    if (port != null) {
+                        HttpClientFactory.setTorSocks(HttpClientFactory.TorSocks.Ready(port))
+                        relayPool.resumeAfterTorSwitch()
+                    }
+                    // port == null → stay fail-closed; TorManager.state shows Error
+                    // and the user can retry or toggle off.
+                } else {
+                    TorPreferences.setEnabled(false)
+                    HttpClientFactory.setTorSocks(HttpClientFactory.TorSocks.Off)
+                    relayPool.suspendForTorSwitch()
+                    relayPool.resumeAfterTorSwitch()
+                    TorManager.stop()
+                }
+            }
+        }
+    }
+
+    private val torSwitchMutex = Mutex()
+
+    private fun initRelaysInternal() {
         // Prune old events from ObjectBox in background
         eventPersistence?.let { persistence ->
             scope.launch(processingContext) { persistence.prune() }

--- a/app/src/main/res/drawable/ic_onion.xml
+++ b/app/src/main/res/drawable/ic_onion.xml
@@ -1,0 +1,15 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <!-- Sprout -->
+    <path
+        android:fillColor="#FF000000"
+        android:pathData="M11.3,6.9C10.7,5.1 11.2,3.4 13.1,2C13,3.7 12.9,5.2 12.7,6.7C12.5,6.7 12.2,6.8 11.9,6.8C11.7,6.8 11.5,6.9 11.3,6.9Z" />
+    <!-- Bulb with concentric layers (even-odd rings) -->
+    <path
+        android:fillColor="#FF000000"
+        android:fillType="evenOdd"
+        android:pathData="M12,7.2C7.4,7.2 4.5,10.9 4.5,14.6C4.5,18.6 7.9,21.8 12,21.8C16.1,21.8 19.5,18.6 19.5,14.6C19.5,10.9 16.6,7.2 12,7.2ZM12,9.2C9,9.2 7,11.9 7,14.6C7,17.4 9.3,19.6 12,19.6C14.7,19.6 17,17.4 17,14.6C17,11.9 15,9.2 12,9.2ZM12,11.2C10.4,11.2 9.4,12.9 9.4,14.6C9.4,16.3 10.6,17.5 12,17.5C13.4,17.5 14.6,16.3 14.6,14.6C14.6,12.9 13.6,11.2 12,11.2Z" />
+</vector>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -18,6 +18,13 @@
     <string name="drawer_media_servers">Media Servers</string>
     <string name="drawer_keys">Keys</string>
     <string name="drawer_safety">Safety</string>
+    <string name="drawer_tor">Tor</string>
+    <string name="tor_status_connecting">Connecting %1$d%%</string>
+    <string name="tor_status_on">Active</string>
+    <string name="tor_status_error">Error — tap to retry</string>
+    <string name="cd_tor_toggle">Toggle Tor</string>
+    <string name="tor_channel_name">Tor</string>
+    <string name="tor_channel_description">Status of the embedded Tor connection</string>
     <string name="drawer_proof_of_work">Proof of Work</string>
     <string name="drawer_social_graph">Social Graph</string>
     <string name="drawer_custom_emojis">Custom Emojis</string>

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -23,6 +23,10 @@ mlkit-barcode = "17.3.0"
 camerax = "1.4.1"
 objectbox = "5.2.0"
 breez-sdk-spark = "0.11.0"
+# 2.4.x is the newest kmp-tor line compiled with Kotlin 2.1 — 2.5.0+ requires
+# Kotlin 2.2 metadata, unreadable by this project's Kotlin 2.0.21.
+kmp-tor-runtime = "2.4.0"
+kmp-tor-resource = "408.16.4"
 activity-compose = "1.9.3"
 navigation-compose = "2.8.5"
 lifecycle = "2.8.7"
@@ -69,6 +73,9 @@ kotlinx-coroutines-play-services = { group = "org.jetbrains.kotlinx", name = "ko
 objectbox-android = { group = "io.objectbox", name = "objectbox-android", version.ref = "objectbox" }
 objectbox-kotlin = { group = "io.objectbox", name = "objectbox-kotlin", version.ref = "objectbox" }
 breez-sdk-spark = { group = "breez_sdk_spark", name = "bindings-android", version.ref = "breez-sdk-spark" }
+kmp-tor-runtime = { group = "io.matthewnelson.kmp-tor", name = "runtime", version.ref = "kmp-tor-runtime" }
+kmp-tor-runtime-service-ui = { group = "io.matthewnelson.kmp-tor", name = "runtime-service-ui", version.ref = "kmp-tor-runtime" }
+kmp-tor-resource-exec = { group = "io.matthewnelson.kmp-tor", name = "resource-exec-tor", version.ref = "kmp-tor-resource" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }


### PR DESCRIPTION
## Summary

Embeds a Tor daemon ([kmp-tor](https://github.com/05nelsonm/kmp-tor), the same stack Amethyst uses) with an onion toggle in the sidebar drawer and on the pre-login Splash/Auth screens. When Tor is on, **every** connection routes through its SOCKS proxy: relay WebSockets, Coil images (avatars/banners), ExoPlayer media, NIP-05/NIP-11, LNURL/zap HTTP, Blossom uploads, link previews, exchange rates, encrypted DM media, and the live-metrics sockets.

## Design

**Fail-closed.** From the instant the toggle flips, new clients route to a dead loopback port until bootstrap completes — nothing ever falls back to clearnet, including during bootstrap. Old clients get in-flight requests cancelled and keep-alive pools evicted, so no pre-toggle socket survives the switch. DNS resolves inside Tor (OkHttp hands unresolved hostnames to SOCKS proxies).

**Single choke point.** All clients are built by `HttpClientFactory`, which now applies the proxy and tracks live clients for invalidation. Places that captured a client forever (and would silently keep clearnet connections after a mid-session toggle) were fixed:
- `Relay`/`RelayPool` resolve their client through a provider on every (re)connect
- Coil gets a delegating `Call.Factory` (Coil 3 caches its `callFactory` lambda permanently)
- `ZapSender`, `DmBubble`, `NwcRepository`, `ExchangeRateRepository`, and `SplashViewModel` (which built a raw un-proxied client)

**Toggle orchestration.** Mid-session: persist pref → fail-closed proxy → tear down all relay sockets with reconnects suppressed (so the 20-attempts/60s → 5-min relay cooldown can't trip during bootstrap) → bootstrap → reconnect everything through Tor. Cold start with Tor on: relay init is gated on bootstrap. The local relay intentionally bypasses the proxy — Tor refuses loopback/LAN targets, and those can't leak the user's IP.

**UI.** Onion icon states: default (off), amber + live bootstrap % (connecting), Tor purple + green dot (active), error tint + "tap to retry". The drawer stays open while toggling so the user can watch bootstrap progress. Tor runs in a foreground service with a status notification (`POST_NOTIFICATIONS` requested on first enable; the service runs regardless).

## Notes

- **kmp-tor pinned to 2.4.x** (runtime 2.4.0 / resource-exec-tor 408.16.4): 2.5.0+ is compiled with Kotlin 2.2, whose metadata our Kotlin 2.0.21 can't read. Bumping project Kotlin later unlocks newer kmp-tor.
- APK grows ~8 MB (arm64 `libtor.so`). `jniLibs.useLegacyPackaging = true` is now load-bearing twice over: APK size *and* W^X-legal exec of the tor binary from `nativeLibraryDir`.
- `TorManager.start()` retries around kmp-tor's fixed 1 s service-bind timeout, which a busy main thread misses during cold start (reproduced on-device; succeeds on attempt 2).
- Two R8 `-dontwarn` rules for JVM-only `java.lang.management` classes kmp-tor probes behind runtime guards.
- **Known gaps:** the Breez/Spark SDK (its own Rust networking) and ML Kit model downloads bypass OkHttp entirely and are not routed through Tor.

## Verification

Tested on a physical device (Pixel, cold start with Tor enabled):
- Socket-inode audit: the app process held 43 sockets, **all** to `127.0.0.1:<socks-port>`; only the tor child process held external connections (2 guard relays). Zero clearnet sockets from the app.
- Relay WebSockets connected and feed loaded after bootstrap; relay-init gating and start-retry observed working in logcat.
- `assembleDebug` and minified `assembleRelease` both pass.

To test manually: tap the onion in the drawer (or on the Splash/Auth screens pre-login), wait for the green dot (first bootstrap takes ~1–3 min), then verify with `adb shell ss -tnp` that app sockets only target the loopback SOCKS port.