### PR TITLE
feat: Anon Mode

### DIFF
--- a/app/src/main/kotlin/com/darkwisp/app/Navigation.kt
+++ b/app/src/main/kotlin/com/darkwisp/app/Navigation.kt
@@ -242,13 +242,24 @@ fun WispNavHost(
 
     relayViewModel.relayPool = feedViewModel.relayPool
 
+    // On process death during anon mode, the ephemeral keypair is gone.
+    // Clear the stale anon session flag so the app starts normally.
+    LaunchedEffect(Unit) {
+        if (feedViewModel.keyRepo.getAnonSessionPubkey() != null) {
+            feedViewModel.keyRepo.clearAnonSession()
+        }
+    }
+
     // Unified signer — handles both LOCAL (nsec) and REMOTE (NIP-55) modes
-    // Reactive: recomposes on login, logout, and account switch
+    // Reactive: recomposes on login, logout, account switch, and anon mode toggle
     val context = LocalContext.current
     val signingMode by authViewModel.signingModeFlow.collectAsState()
     val npub by authViewModel.npub.collectAsState()
-    val activeSigner = remember(signingMode, npub) {
-        when (signingMode) {
+    val anonMode by feedViewModel.anonMode.collectAsState()
+    val activeSigner = remember(signingMode, npub, anonMode) {
+        if (anonMode != null) {
+            LocalSigner(anonMode!!.keypair.privkey, anonMode!!.keypair.pubkey)
+        } else when (signingMode) {
             SigningMode.REMOTE -> {
                 val pubkey = authViewModel.keyRepo.getPubkeyHex() ?: ""
                 val pkg = authViewModel.keyRepo.getSignerPackage() ?: ""
@@ -298,6 +309,7 @@ fun WispNavHost(
     var groupListInitKey by rememberSaveable { mutableStateOf(0) }
 
     val onSwitchAccount: (String) -> Unit = { pubkeyHex ->
+        if (anonMode != null) feedViewModel.exitAnonMode()
         feedViewModel.clearSigner()
         feedViewModel.resetForAccountSwitch()
         walletViewModel.suspendForAccountSwitch()  // disconnect only, preserve credentials
@@ -316,10 +328,28 @@ fun WispNavHost(
     }
 
     val onAddAccount: () -> Unit = {
+        if (anonMode != null) feedViewModel.exitAnonMode()
         authViewModel.isAddingAccount = true
         feedViewModel.resetForAccountSwitch()
         walletViewModel.suspendForAccountSwitch()  // disconnect only, preserve credentials
         navController.navigate(Routes.SPLASH) {
+            popUpTo(0) { inclusive = true }
+        }
+    }
+
+    val onEnterAnonMode: () -> Unit = {
+        feedViewModel.enterAnonMode()
+        feedViewModel.resetForAnonSwitch()
+        navController.navigate(Routes.LOADING) {
+            popUpTo(0) { inclusive = true }
+        }
+    }
+
+    val onExitAnonMode: () -> Unit = {
+        feedViewModel.exitAnonMode()
+        feedViewModel.resetForAccountSwitch()
+        feedViewModel.reloadForNewAccount()
+        navController.navigate(Routes.LOADING) {
             popUpTo(0) { inclusive = true }
         }
     }
@@ -629,6 +659,7 @@ fun WispNavHost(
                         isZapAnimating = isZapAnimating,
                         isReplyAnimating = isReplyAnimating,
                         notifSoundEnabled = notifSoundEnabled,
+                        hiddenTabs = if (anonMode != null) setOf(BottomTab.WALLET) else emptySet(),
                         onTabSelected = { tab ->
                             if (currentRoute == tab.route) {
                                 scrollToTopTrigger++
@@ -816,6 +847,8 @@ fun WispNavHost(
                 onScanResult = { route ->
                     navController.navigate(route)
                 },
+                onEnterAnonMode = onEnterAnonMode,
+                onExitAnonMode = onExitAnonMode,
                 accounts = accounts,
                 onSwitchAccount = onSwitchAccount,
                 onAddAccount = onAddAccount,

--- a/app/src/main/kotlin/com/darkwisp/app/repo/KeyRepository.kt
+++ b/app/src/main/kotlin/com/darkwisp/app/repo/KeyRepository.kt
@@ -273,6 +273,29 @@ class KeyRepository(private val context: Context) {
 
     fun hasKeypair(): Boolean = encPrefs.getString("privkey", null) != null
 
+    // --- Anon session tracking (plain prefs — not encrypted, no keys stored) ---
+
+    private val anonPrefs: SharedPreferences =
+        context.getSharedPreferences("wisp_anon", Context.MODE_PRIVATE)
+
+    fun setAnonSessionActive(pubkeyHex: String?, name: String?) {
+        anonPrefs.edit()
+            .putString("anon_pubkey", pubkeyHex)
+            .putString("anon_name", name)
+            .apply()
+    }
+
+    fun getAnonSessionPubkey(): String? = anonPrefs.getString("anon_pubkey", null)
+
+    fun getAnonSessionName(): String? = anonPrefs.getString("anon_name", null)
+
+    fun clearAnonSession() {
+        anonPrefs.edit()
+            .remove("anon_pubkey")
+            .remove("anon_name")
+            .apply()
+    }
+
     fun getNpub(): String? {
         val pubHex = encPrefs.getString("pubkey", null) ?: return null
         return Nip19.npubEncode(pubHex.hexToByteArray())

--- a/app/src/main/kotlin/com/darkwisp/app/ui/component/BottomBar.kt
+++ b/app/src/main/kotlin/com/darkwisp/app/ui/component/BottomBar.kt
@@ -59,6 +59,7 @@ fun WispBottomBar(
     isZapAnimating: Boolean = false,
     isReplyAnimating: Boolean = false,
     notifSoundEnabled: Boolean = true,
+    hiddenTabs: Set<BottomTab> = emptySet(),
     onTabSelected: (BottomTab) -> Unit
 ) {
     Column {
@@ -71,6 +72,7 @@ fun WispBottomBar(
             windowInsets = NavigationBarDefaults.windowInsets
         ) {
         BottomTab.entries.forEach { tab ->
+            if (tab in hiddenTabs) return@forEach
             val selected = currentRoute == tab.route
             val hasUnread = when (tab) {
                 BottomTab.HOME -> hasUnreadHome

--- a/app/src/main/kotlin/com/darkwisp/app/ui/component/WispDrawerContent.kt
+++ b/app/src/main/kotlin/com/darkwisp/app/ui/component/WispDrawerContent.kt
@@ -80,7 +80,7 @@ import com.darkwisp.app.repo.AccountInfo
 private val TorPurple = Color(0xFF9C59D1)
 private val TorAmber = Color(0xFFFFB74D)
 private val TorGreen = Color(0xFF4CAF50)
-
+private val AnonGreen = Color(0xFF00C853)
 
 @Composable
 fun WispDrawerContent(
@@ -91,6 +91,10 @@ fun WispDrawerContent(
     accounts: List<AccountInfo> = emptyList(),
     onSwitchAccount: (String) -> Unit = {},
     onAddAccount: () -> Unit = {},
+    anonModeActive: Boolean = false,
+    anonName: String? = null,
+    onEnterAnonMode: () -> Unit = {},
+    onExitAnonMode: () -> Unit = {},
     onProfile: () -> Unit,
     onFeed: () -> Unit,
     onSearch: () -> Unit,
@@ -357,8 +361,114 @@ fun WispDrawerContent(
                             color = MaterialTheme.colorScheme.onSurfaceVariant
                         )
                     }
+
+                    // Anon mode row
+                    HorizontalDivider(modifier = Modifier.padding(vertical = 4.dp))
+                    if (anonModeActive) {
+                        Row(
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .padding(vertical = 8.dp),
+                            verticalAlignment = Alignment.CenterVertically
+                        ) {
+                            Box(
+                                modifier = Modifier.size(36.dp),
+                                contentAlignment = Alignment.Center
+                            ) {
+                                androidx.compose.material3.Text("🕶️", fontSize = MaterialTheme.typography.titleMedium.fontSize)
+                            }
+                            Spacer(modifier = Modifier.width(12.dp))
+                            Column(modifier = Modifier.weight(1f)) {
+                                Text(
+                                    text = "Anon Mode",
+                                    style = MaterialTheme.typography.bodyMedium,
+                                    color = AnonGreen
+                                )
+                                if (anonName != null) {
+                                    Text(
+                                        text = anonName,
+                                        style = MaterialTheme.typography.bodySmall,
+                                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                                    )
+                                }
+                            }
+                            Icon(
+                                Icons.Filled.Check,
+                                contentDescription = stringResource(R.string.cd_active),
+                                modifier = Modifier.size(18.dp),
+                                tint = AnonGreen
+                            )
+                        }
+                    } else {
+                        Row(
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .clickable {
+                                    accountPickerExpanded = false
+                                    onEnterAnonMode()
+                                }
+                                .padding(vertical = 8.dp),
+                            verticalAlignment = Alignment.CenterVertically
+                        ) {
+                            Box(
+                                modifier = Modifier.size(36.dp),
+                                contentAlignment = Alignment.Center
+                            ) {
+                                androidx.compose.material3.Text("🕶️", fontSize = MaterialTheme.typography.titleMedium.fontSize)
+                            }
+                            Spacer(modifier = Modifier.width(12.dp))
+                            Text(
+                                text = "Anon Mode",
+                                style = MaterialTheme.typography.bodyMedium,
+                                color = MaterialTheme.colorScheme.onSurfaceVariant
+                            )
+                            Spacer(modifier = Modifier.weight(1f))
+                            Icon(
+                                Icons.Outlined.KeyboardArrowRight,
+                                contentDescription = stringResource(R.string.cd_switch_account),
+                                modifier = Modifier.size(20.dp),
+                                tint = MaterialTheme.colorScheme.onSurfaceVariant
+                            )
+                        }
+                    }
                 }
             }
+        }
+
+        // Anon mode persistent banner
+        if (anonModeActive) {
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .background(AnonGreen.copy(alpha = 0.15f))
+                    .clickable { onExitAnonMode() }
+                    .padding(horizontal = 16.dp, vertical = 10.dp),
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                androidx.compose.material3.Text("🕶️", fontSize = MaterialTheme.typography.bodyLarge.fontSize)
+                Spacer(modifier = Modifier.width(8.dp))
+                Column(modifier = Modifier.weight(1f)) {
+                    Text(
+                        text = "Anon Mode",
+                        style = MaterialTheme.typography.labelMedium,
+                        color = AnonGreen
+                    )
+                    if (anonName != null) {
+                        Text(
+                            text = "Posting as $anonName — tap to exit",
+                            style = MaterialTheme.typography.bodySmall,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant
+                        )
+                    }
+                }
+                Icon(
+                    Icons.AutoMirrored.Filled.ExitToApp,
+                    contentDescription = "Exit anon mode",
+                    modifier = Modifier.size(16.dp),
+                    tint = AnonGreen
+                )
+            }
+            HorizontalDivider()
         }
 
         if (showProfileQr && pubkey != null) {

--- a/app/src/main/kotlin/com/darkwisp/app/ui/screen/FeedScreen.kt
+++ b/app/src/main/kotlin/com/darkwisp/app/ui/screen/FeedScreen.kt
@@ -8,6 +8,7 @@ import androidx.compose.animation.fadeOut
 import androidx.compose.animation.slideInVertically
 import androidx.compose.animation.slideOutVertically
 import androidx.compose.foundation.ExperimentalFoundationApi
+import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.ExperimentalLayoutApi
 import androidx.compose.foundation.layout.FlowRow
 import androidx.compose.foundation.clickable
@@ -191,6 +192,8 @@ fun FeedScreen(
     fetchGroupPreview: (suspend (String, String) -> com.darkwisp.app.repo.GroupPreview?)? = null,
     scrollToTopTrigger: Int = 0,
     onScanResult: (String) -> Unit = {},
+    onEnterAnonMode: () -> Unit = {},
+    onExitAnonMode: () -> Unit = {},
 ) {
     val feed by viewModel.feed.collectAsState()
     val feedType by viewModel.feedType.collectAsState()
@@ -210,6 +213,7 @@ fun FeedScreen(
     val translationVersion by viewModel.translationRepo.version.collectAsState()
     val connectedCount by viewModel.relayPool.connectedCount.collectAsState()
     val liveNowStreams by viewModel.liveNowStreams.collectAsState()
+    val anonMode by viewModel.anonMode.collectAsState()
     val listState = rememberLazyListState()
 
     // Viewport-aware engagement: notify ViewModel of visible item range
@@ -653,6 +657,55 @@ fun FeedScreen(
         )
     }
 
+    var showAnonTorDialog by remember { mutableStateOf(false) }
+
+    if (showAnonTorDialog) {
+        val torState by TorManager.state.collectAsState()
+        AlertDialog(
+            onDismissRequest = { showAnonTorDialog = false },
+            title = { Text("Enable Tor?") },
+            text = {
+                Text("Anon Mode works best with Tor. Route your anonymous traffic through the Tor network?")
+            },
+            confirmButton = {
+                TextButton(onClick = {
+                    showAnonTorDialog = false
+                    if (torState is TorManager.State.Off || torState is TorManager.State.Error) {
+                        viewModel.setTorEnabled(true)
+                    }
+                    scope.launch { drawerState.close() }
+                    onEnterAnonMode()
+                }) {
+                    Text("Enable Tor")
+                }
+            },
+            dismissButton = {
+                TextButton(onClick = {
+                    showAnonTorDialog = false
+                    scope.launch { drawerState.close() }
+                    onEnterAnonMode()
+                }) {
+                    Text("No Thanks")
+                }
+            }
+        )
+    }
+
+    val handleEnterAnonMode: () -> Unit = {
+        val currentTorState = TorManager.state.value
+        if (currentTorState is TorManager.State.Off || currentTorState is TorManager.State.Error) {
+            showAnonTorDialog = true
+        } else {
+            scope.launch { drawerState.close() }
+            onEnterAnonMode()
+        }
+    }
+
+    val handleExitAnonMode: () -> Unit = {
+        scope.launch { drawerState.close() }
+        onExitAnonMode()
+    }
+
     ModalNavigationDrawer(
         drawerState = drawerState,
         drawerContent = {
@@ -669,6 +722,10 @@ fun FeedScreen(
                 isDarkTheme = isDarkTheme,
                 onToggleTheme = onToggleTheme,
                 accounts = accounts,
+                anonModeActive = anonMode != null,
+                anonName = anonMode?.name,
+                onEnterAnonMode = handleEnterAnonMode,
+                onExitAnonMode = handleExitAnonMode,
                 onSwitchAccount = { pubkeyHex ->
                     scope.launch { drawerState.close() }
                     onSwitchAccount(pubkeyHex)
@@ -1174,6 +1231,40 @@ fun FeedScreen(
                             state = listState,
                             modifier = Modifier.fillMaxSize()
                         ) {
+                            if (anonMode != null) {
+                                item(key = "anon-banner", contentType = "anon-banner") {
+                                    val anonGreen = androidx.compose.ui.graphics.Color(0xFF00C853)
+                                    Row(
+                                        modifier = Modifier
+                                            .fillMaxWidth()
+                                            .background(anonGreen.copy(alpha = 0.12f))
+                                            .clickable { onExitAnonMode() }
+                                            .padding(horizontal = 16.dp, vertical = 10.dp),
+                                        verticalAlignment = Alignment.CenterVertically
+                                    ) {
+                                        Text("🕶️", fontSize = MaterialTheme.typography.bodyLarge.fontSize)
+                                        Spacer(modifier = Modifier.width(8.dp))
+                                        Column(modifier = Modifier.weight(1f)) {
+                                            Text(
+                                                text = "Anon Mode",
+                                                style = MaterialTheme.typography.labelMedium,
+                                                color = anonGreen
+                                            )
+                                            val anonName = anonMode?.name ?: ""
+                                            Text(
+                                                text = "Posting as $anonName — tap to exit",
+                                                style = MaterialTheme.typography.bodySmall,
+                                                color = MaterialTheme.colorScheme.onSurfaceVariant
+                                            )
+                                        }
+                                        TextButton(onClick = {
+                                            onExitAnonMode()
+                                        }) {
+                                            Text("Exit", color = anonGreen)
+                                        }
+                                    }
+                                }
+                            }
                             if (liveNowStreams.isNotEmpty() && onLiveStreamClick != null && !viewModel.interfacePrefs.isLiveStreamsHidden()) {
                                 item(key = "live-now", contentType = "live-now") {
                                     com.darkwisp.app.ui.component.LiveNowRow(

--- a/app/src/main/kotlin/com/darkwisp/app/util/AnonNameGenerator.kt
+++ b/app/src/main/kotlin/com/darkwisp/app/util/AnonNameGenerator.kt
@@ -1,0 +1,43 @@
+package com.darkwisp.app.util
+
+object AnonNameGenerator {
+    private val adjectives = listOf(
+        "Ghost", "Silent", "Shadow", "Neon", "Void", "Cryptic", "Dark", "Frost",
+        "Hollow", "Feral", "Fractal", "Static", "Phantom", "Dusk", "Drift", "Echo",
+        "Lost", "Blind", "Wisp", "Swift", "Grim", "Pale", "Cold", "Deep", "Raw",
+        "Bare", "Null", "Zero", "Pure", "Sharp", "Vague", "Vast", "Still", "Lite",
+        "Grey", "Faint", "Keen", "Dull", "Rogue", "Lone", "Mad", "Wild", "Free",
+        "Sly", "Thin", "Bare", "Cool", "Warm", "Dark", "Fake", "True", "Blunt",
+        "Slick", "Gloss", "Smooth", "Rough", "Blank", "Empty", "Solid", "Fluid",
+        "Quick", "Slow", "Light", "Heavy", "Taut", "Loose", "Brittle", "Tender",
+        "Bitter", "Sour", "Sweet", "Salty", "Mild", "Spice", "Damp", "Dry",
+        "Dense", "Sparse", "Terse", "Loud", "Mute", "Blind", "Deaf", "Dumb",
+        "Still", "Calm", "Rapid", "Steady", "Fleet", "Slant", "Crook", "Stark",
+        "Plain", "Grand", "Petty", "Noble", "Base", "Prime", "Odd", "Even",
+        "Dire", "Grim", "Sage", "Wise", "Mad", "Balmy", "Sere", "Rife"
+    )
+
+    private val nouns = listOf(
+        "Signal", "Packet", "Wisp", "Mask", "Drifter", "Cipher", "Shade",
+        "Nomad", "Ghost", "Prism", "Blade", "Pulse", "Flux", "Node", "Path",
+        "Gate", "Wire", "Core", "Edge", "Hash", "Code", "Key", "Seed", "Byte",
+        "Bit", "Cell", "Frame", "Wave", "Peak", "Grid", "Root", "Ring", "Loop",
+        "Link", "Mark", "Sign", "Trace", "Trail", "Vein", "Web", "Torch",
+        "Lens", "Spark", "Flame", "Beacon", "Lantern", "Candle", "Star",
+        "Moon", "Tide", "Current", "Stream", "River", "Ocean", "Depth",
+        "Aether", "Vapor", "Smoke", "Ash", "Ember", "Cinder", "Glow",
+        "Radiance", "Shadow", "Umbra", "Penumbra", "Shard", "Fragment",
+        "Splinter", "Needle", "Pin", "Hook", "Claw", "Fang", "Horn",
+        "Spine", "Ridge", "Crest", "Tower", "Spire", "Pillar", "Stone",
+        "Crystal", "Gem", "Ore", "Metal", "Steel", "Iron", "Copper",
+        "Tin", "Zinc", "Lead", "Gold", "Silver", "Bronze", "Brass",
+        "Alloy", "Chain", "Mesh", "Net", "Web", "Weave", "Thread"
+    )
+
+    fun generate(): String {
+        val adj = adjectives.random()
+        val noun = nouns.random()
+        val num = (100..999).random()
+        return "${adj}${noun}$num"
+    }
+}

--- a/app/src/main/kotlin/com/darkwisp/app/viewmodel/FeedViewModel.kt
+++ b/app/src/main/kotlin/com/darkwisp/app/viewmodel/FeedViewModel.kt
@@ -4,8 +4,11 @@ import android.app.Application
 import android.util.Log
 import androidx.lifecycle.AndroidViewModel
 import androidx.lifecycle.viewModelScope
+import com.darkwisp.app.nostr.Keys
+import com.darkwisp.app.nostr.LocalSigner
 import com.darkwisp.app.nostr.NostrEvent
 import com.darkwisp.app.nostr.NostrSigner
+import com.darkwisp.app.util.AnonNameGenerator
 import com.darkwisp.app.relay.HttpClientFactory
 import com.darkwisp.app.relay.Relay
 import com.darkwisp.app.relay.RelayLifecycleManager
@@ -62,7 +65,9 @@ import com.darkwisp.app.nostr.NipA3
 import com.darkwisp.app.nostr.RelaySet
 import android.content.Context
 import com.darkwisp.app.nostr.Filter
+import com.darkwisp.app.nostr.toHex
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.intOrNull
@@ -132,6 +137,11 @@ sealed class InitLoadingState {
     data object Done : InitLoadingState()
 }
 
+data class AnonSession(
+    val keypair: Keys.Keypair,
+    val name: String
+)
+
 class FeedViewModel(app: Application) : AndroidViewModel(app) {
     // -- Infrastructure --
     val keyRepo = KeyRepository(app)
@@ -145,6 +155,11 @@ class FeedViewModel(app: Application) : AndroidViewModel(app) {
     var signer: NostrSigner? = null
         private set
 
+    private var savedSigner: NostrSigner? = null
+
+    private val _anonMode = MutableStateFlow<AnonSession?>(null)
+    val anonMode: StateFlow<AnonSession?> = _anonMode.asStateFlow()
+
     fun setSigner(s: NostrSigner) {
         signer = s
         zapSender.signer = s
@@ -153,6 +168,28 @@ class FeedViewModel(app: Application) : AndroidViewModel(app) {
 
     fun clearSigner() {
         signer = null
+    }
+
+    fun enterAnonMode() {
+        if (_anonMode.value != null) return
+        val anonKeypair = Keys.generate()
+        val anonName = AnonNameGenerator.generate()
+        if (savedSigner == null) {
+            savedSigner = signer
+        }
+        val anonSigner = LocalSigner(anonKeypair.privkey, anonKeypair.pubkey)
+        setSigner(anonSigner)
+        _anonMode.value = AnonSession(anonKeypair, anonName)
+        keyRepo.setAnonSessionActive(anonKeypair.pubkey.toHex(), anonName)
+    }
+
+    fun exitAnonMode() {
+        val session = _anonMode.value ?: return
+        session.keypair.wipe()
+        _anonMode.value = null
+        keyRepo.clearAnonSession()
+        savedSigner?.let { setSigner(it) }
+        savedSigner = null
     }
 
     private fun registerAuthSigner() {
@@ -435,6 +472,11 @@ class FeedViewModel(app: Application) : AndroidViewModel(app) {
     fun setTorEnabled(enabled: Boolean) = startup.setTorEnabled(enabled)
     fun resetForAccountSwitch() {
         startup.resetForAccountSwitch()
+        groupRepo.clear()
+        liveStreamRepo.clear()
+    }
+    fun resetForAnonSwitch() {
+        startup.resetForAnonSwitch()
         groupRepo.clear()
         liveStreamRepo.clear()
     }

--- a/app/src/main/kotlin/com/darkwisp/app/viewmodel/StartupCoordinator.kt
+++ b/app/src/main/kotlin/com/darkwisp/app/viewmodel/StartupCoordinator.kt
@@ -172,6 +172,133 @@ class StartupCoordinator(
         relaysInitialized = false
     }
 
+    fun resetForAnonSwitch() {
+        eventProcessingJob?.cancel()
+        metadataSweepJob?.cancel()
+        ephemeralCleanupJob?.cancel()
+        relayListRefreshJob?.cancel()
+        followWatcherJob?.cancel()
+        authCompletedJob?.cancel()
+        notifRefreshJob?.cancel()
+        startupJob?.cancel()
+        healthSnapshotJob?.cancel()
+        notifSeedJob?.cancel()
+        feedSub.reset()
+
+        lifecycleManager.stop()
+        relayPool.disconnectAll()
+        nwcRepo.disconnect()
+
+        metadataFetcher.clear()
+        eventRepo.clearAll()
+        customEmojiRepo.clear()
+        dmRepo.clear()
+        notifRepo.clear()
+        contactRepo.clear()
+        muteRepo.clear()
+        bookmarkRepo.clear()
+        bookmarkSetRepo.clear()
+        relaySetRepo.clear()
+        pinRepo.clear()
+        listRepo.clear()
+        blossomRepo.clear()
+        interestRepo.clear()
+        extendedNetworkRepo.clear()
+        relayScoreBoard.clear()
+        relayHintStore.clear()
+        healthTracker.clear()
+        relayListRepo.clear()
+        nip05Repo.clear()
+        relayPool.clearSeenEvents()
+        eventRouter.clearSelfDataTimestamps()
+
+        relaysInitialized = false
+    }
+
+    fun initForAnonMode() {
+        // Lightweight init that subscribes a global feed without self-data or DMs/notifications.
+        // Uses only default relays — no account-specific relay config.
+        if (relaysInitialized) return
+
+        // Set up relay pool with default relays only (no account-specific relay config)
+        relayPool.healthTracker = healthTracker
+        relayPool.appIsActive = true
+        relayPool.updateBlockedUrls(keyRepo.getBlockedRelays())
+        relayPool.setPinnedRelays(emptySet())
+        relayPool.updateRelays(RelayConfig.DEFAULTS)
+        relayPool.updateDmRelays(emptyList())
+
+        // Main event processing loop
+        eventProcessingJob = scope.launch(processingContext) {
+            relayPool.relayEvents.collect { (event, relayUrl, subscriptionId) ->
+                try {
+                    eventRouter.processRelayEvent(event, relayUrl, subscriptionId)
+                } catch (e: Exception) {
+                    Log.e("StartupCoord", "processRelayEvent crashed", e)
+                }
+            }
+        }
+
+        // Profile sweep
+        metadataSweepJob = scope.launch(processingContext) {
+            delay(3_000)
+            metadataFetcher.sweepMissingProfiles()
+            delay(5_000)
+            metadataFetcher.sweepMissingProfiles()
+            delay(7_000)
+            metadataFetcher.sweepMissingProfiles()
+            while (true) {
+                delay(120_000)
+                metadataFetcher.sweepMissingProfiles()
+            }
+        }
+
+        // Periodic ephemeral relay cleanup
+        ephemeralCleanupJob = scope.launch {
+            while (true) {
+                delay(60_000)
+                relayPool.cleanupEphemeralRelays()
+                eventRepo.trimSeenEvents()
+                relayHintStore.flush()
+            }
+        }
+
+        // Periodic health snapshot
+        healthSnapshotJob = scope.launch(processingContext) {
+            while (true) {
+                delay(60_000)
+                if (!DiagnosticLogger.isEnabled) continue
+                val pk = getUserPubkey()
+                DiagnosticLogger.log("HEALTH", "pubkey=${pk?.take(8)} " +
+                    "eventProcessingJob.active=${eventProcessingJob?.isActive} " +
+                    "connectedRelays=${relayPool.connectedCount.value}")
+            }
+        }
+
+        feedSub.subscribeFeed()
+
+        // Publish anon profile so the generated name appears on the network
+        val anonName = keyRepo.getAnonSessionName()
+        if (anonName != null) {
+            val s = getSigner()
+            if (s != null) {
+                scope.launch {
+                    delay(2_000) // let relay connections settle
+                    try {
+                        val jsonContent = """{"name":"$anonName","display_name":"$anonName"}"""
+                        val event = s.signEvent(kind = 0, content = jsonContent)
+                        val msg = ClientMessage.event(event)
+                        relayPool.sendToWriteRelays(msg)
+                    } catch (e: Exception) {
+                        Log.e("StartupCoord", "Failed to publish anon profile", e)
+                    }
+                }
+            }
+        }
+
+        relaysInitialized = true
+    }
+
     fun reloadForNewAccount() {
         val newPubkey = getUserPubkey()
 
@@ -206,6 +333,21 @@ class StartupCoordinator(
 
     fun initRelays() {
         Log.d("StartupCoord", "initRelays() called, relaysInitialized=$relaysInitialized")
+
+        // Anon mode: use lightweight init that skips self-data, DMs, and follows
+        if (keyRepo.getAnonSessionPubkey() != null) {
+            Log.d("StartupCoord", "initRelays: anon mode detected, using initForAnonMode")
+            if (TorPreferences.isEnabled()) {
+                scope.launch {
+                    TorManager.awaitOnIfEnabled()
+                    initForAnonMode()
+                }
+            } else {
+                initForAnonMode()
+            }
+            return
+        }
+
         if (relaysInitialized) { Log.d("StartupCoord", "initRelays: already initialized, returning"); return }
         relaysInitialized = true
 


### PR DESCRIPTION
Adds a temporary anonymous "mask" from the account switcher dropdown. Generates an ephemeral secp256k1 keypair + random pseudonym (e.g. GhostSignal482), fully isolates at the relay and subscription layers, and publishes a kind-0 profile so the name appears on the network.

*How it works*
- Entry: drawer "Anon Mode" entry → Tor prompt → generates keypair + pseudonym → tears down all relay connections → fresh connections to only RelayConfig.DEFAULTS → global feed subscription (no DMs/notifications) → kind-0 published with generated name → wallet tab hidden from bottom bar
- Exit: restores original signer → tears down anon relays → clears all repos → fresh full init with real account's relay list
- Process death: stale anon flag detected on next cold start → silently cleaned, main account loads normally

(This was just an idea I had, maybe its not worth adding idk, was cool in my head) 