### PR TITLE
feat(zap): fiat currency input + inline images in zap messages

### DIFF
--- a/app/src/main/kotlin/com/darkwisp/app/nostr/Event.kt
+++ b/app/src/main/kotlin/com/darkwisp/app/nostr/Event.kt
@@ -188,6 +188,8 @@ fun ByteArray.toHex(): String {
     return String(result)
 }
 
+fun String.toNpub(): String = Nip19.npubEncode(hexToByteArray())
+
 fun String.hexToByteArray(): ByteArray {
     require(length % 2 == 0) { "Hex string must have even length" }
     return ByteArray(length / 2) { i ->

--- a/app/src/main/kotlin/com/darkwisp/app/repo/ExchangeRateRepository.kt
+++ b/app/src/main/kotlin/com/darkwisp/app/repo/ExchangeRateRepository.kt
@@ -129,6 +129,17 @@ object ExchangeRateRepository {
         return sats.toDouble() / 100_000_000.0 * btcPrice
     }
 
+    /**
+     * Inverse of [satsToFiat] — convert a fiat amount expressed in the
+     * currency's major unit (dollars, euros, etc.) into sats. Returns null
+     * when no rate is cached. Used by the zap sheet's custom-amount input
+     * in fiat mode where the user types `1.50` for a $1.50 zap.
+     */
+    fun fiatToSats(majorAmount: Double, currency: String): Long? {
+        val btcPrice = _rates.value[currency.uppercase()] ?: return null
+        return (majorAmount / btcPrice * 100_000_000.0).toLong()
+    }
+
     fun currencyFor(code: String): FiatCurrency =
         SUPPORTED.firstOrNull { it.code.equals(code, ignoreCase = true) } ?: SUPPORTED[0]
 

--- a/app/src/main/kotlin/com/darkwisp/app/ui/component/PostCard.kt
+++ b/app/src/main/kotlin/com/darkwisp/app/ui/component/PostCard.kt
@@ -1223,11 +1223,14 @@ internal fun TopZapperBanner(
                 color = orange
             )
 
-            // Message (if present)
+            // Message (if present) — image URLs collapse to "[image]"
+            // since the banner only has room for a single line and a
+            // dumped URL crowds out the sats amount. Full image renders
+            // inline in the engagement drawer below.
             if (message.isNotBlank()) {
                 Spacer(Modifier.width(6.dp))
                 Text(
-                    text = message,
+                    text = com.darkwisp.app.ui.util.ZapMessageImage.previewText(message),
                     style = MaterialTheme.typography.labelSmall,
                     color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.7f),
                     maxLines = 1,

--- a/app/src/main/kotlin/com/darkwisp/app/ui/component/ReactionDetailsSection.kt
+++ b/app/src/main/kotlin/com/darkwisp/app/ui/component/ReactionDetailsSection.kt
@@ -12,6 +12,7 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
@@ -35,6 +36,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontWeight
@@ -48,6 +50,7 @@ import com.darkwisp.app.R
 import com.darkwisp.app.ui.util.AmountFormatter
 import com.darkwisp.app.nostr.NostrEvent
 import com.darkwisp.app.nostr.ProfileData
+import com.darkwisp.app.nostr.toNpub
 import com.darkwisp.app.repo.EventRepository
 import com.darkwisp.app.repo.ZapDetail
 import com.darkwisp.app.ui.theme.WispThemeColors
@@ -132,8 +135,24 @@ fun ZapRow(
     onProfileClick: (String) -> Unit,
     modifier: Modifier = Modifier,
     isPrivate: Boolean = false,
-    onLongPress: (() -> Unit)? = null
+    onLongPress: (() -> Unit)? = null,
+    // Passed to `RichContent` so inline links, hashtags, note/profile
+    // references inside a zap message stay interactive. All optional —
+    // when null, RichContent renders them as plain text.
+    eventRepo: EventRepository? = null,
+    onHashtagClick: ((String) -> Unit)? = null,
+    onNoteClick: ((String) -> Unit)? = null
 ) {
+    // Renders the zap row as a mini-post so "zapvertising" payloads —
+    // body text + links + inline images — surface intact in the
+    // engagement drawer. Single-line truncation was too lossy: a long
+    // promotional message + image got chopped, and only the image
+    // attachment was readable. Using `RichContent` here gives the
+    // message text + media the same treatment as a regular post body.
+    val displayName = remember(profile, pubkey) {
+        profile?.displayString
+            ?: pubkey.toNpub().let { "${it.take(12)}...${it.takeLast(4)}" }
+    }
     Row(
         modifier = modifier
             .fillMaxWidth()
@@ -147,46 +166,64 @@ fun ZapRow(
                     Modifier.clickable { onProfileClick(pubkey) }
                 }
             )
-            .padding(vertical = 4.dp),
-        verticalAlignment = Alignment.CenterVertically
+            .padding(vertical = 6.dp),
+        verticalAlignment = Alignment.Top
     ) {
         ProfilePicture(
             url = profile?.picture,
             size = 30
         )
         Spacer(Modifier.width(8.dp))
-        Text(
-            text = message.ifBlank { profile?.displayString ?: (pubkey.take(8) + "...") },
-            style = MaterialTheme.typography.bodySmall,
-            color = MaterialTheme.colorScheme.onSurface,
-            maxLines = 1,
-            overflow = TextOverflow.Ellipsis,
-            modifier = Modifier.weight(1f)
-        )
-        Spacer(Modifier.width(8.dp))
-        if (isPrivate) {
-            Icon(
-                painter = androidx.compose.ui.res.painterResource(com.darkwisp.app.R.drawable.ic_private_zap),
-                contentDescription = "Private zap",
-                modifier = Modifier.size(16.dp),
-                tint = Color(0xFFFF8C00)
-            )
-            Spacer(Modifier.width(2.dp))
+        Column(modifier = Modifier.weight(1f)) {
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                Text(
+                    text = displayName,
+                    style = MaterialTheme.typography.labelMedium,
+                    fontWeight = FontWeight.SemiBold,
+                    color = MaterialTheme.colorScheme.onSurface,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                    modifier = Modifier.weight(1f)
+                )
+                Spacer(Modifier.width(8.dp))
+                if (isPrivate) {
+                    Icon(
+                        painter = androidx.compose.ui.res.painterResource(com.darkwisp.app.R.drawable.ic_private_zap),
+                        contentDescription = "Private zap",
+                        modifier = Modifier.size(16.dp),
+                        tint = Color(0xFFFF8C00)
+                    )
+                    Spacer(Modifier.width(2.dp))
+                }
+                Icon(
+                    painter = androidx.compose.ui.res.painterResource(
+                        if (com.darkwisp.app.ui.util.isFiatMode()) R.drawable.ic_coin_stack else R.drawable.ic_bolt
+                    ),
+                    contentDescription = null,
+                    tint = Color(0xFFFF8C00),
+                    modifier = Modifier.size(14.dp)
+                )
+                Spacer(Modifier.width(2.dp))
+                Text(
+                    text = AmountFormatter.formatFull(sats, LocalContext.current),
+                    style = MaterialTheme.typography.labelLarge,
+                    color = Color(0xFFFF8C00),
+                    maxLines = 1
+                )
+            }
+            if (message.isNotBlank()) {
+                Spacer(Modifier.height(4.dp))
+                RichContent(
+                    content = message,
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurface,
+                    eventRepo = eventRepo,
+                    onProfileClick = onProfileClick,
+                    onNoteClick = onNoteClick,
+                    onHashtagClick = onHashtagClick
+                )
+            }
         }
-        Icon(
-            painter = androidx.compose.ui.res.painterResource(
-                if (com.darkwisp.app.ui.util.isFiatMode()) R.drawable.ic_coin_stack else R.drawable.ic_bolt
-            ),
-            contentDescription = null,
-            tint = Color(0xFFFF8C00),
-            modifier = Modifier.size(14.dp)
-        )
-        Spacer(Modifier.width(2.dp))
-        Text(
-            text = AmountFormatter.formatFull(sats, LocalContext.current),
-            style = MaterialTheme.typography.labelLarge,
-            color = Color(0xFFFF8C00)
-        )
     }
 }
 
@@ -225,7 +262,8 @@ fun ReactionDetailsSection(
                     isPrivate = zap.isPrivate,
                     onLongPress = if (zap.receiptEventId != null) {
                         { inspectedZap = zap }
-                    } else null
+                    } else null,
+                    eventRepo = eventRepo
                 )
             }
         }

--- a/app/src/main/kotlin/com/darkwisp/app/ui/component/ZapDialog.kt
+++ b/app/src/main/kotlin/com/darkwisp/app/ui/component/ZapDialog.kt
@@ -76,13 +76,19 @@ import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.text.input.OffsetMapping
+import androidx.compose.ui.text.input.TransformedText
+import androidx.compose.ui.text.input.VisualTransformation
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.compose.ui.window.Dialog
 import androidx.compose.ui.window.DialogProperties
 import com.darkwisp.app.R
 import com.darkwisp.app.nostr.NipA3
+import com.darkwisp.app.repo.ExchangeRateRepository
+import com.darkwisp.app.repo.FiatCurrency
 import com.darkwisp.app.repo.FiatPreferences
 import com.darkwisp.app.repo.ZapPreferences
 import com.darkwisp.app.repo.ZapPreset
@@ -178,7 +184,7 @@ fun ZapDialog(
     val context = LocalContext.current
     val fiatPrefs = remember { FiatPreferences.get(context) }
     val fiatMode by fiatPrefs.fiatMode.collectAsState()
-    @Suppress("unused_variable") val fiatCurrency by fiatPrefs.currency.collectAsState()
+    val fiatCurrency by fiatPrefs.currency.collectAsState()
     var presets by remember { mutableStateOf(ZapPreferences(context).getPresets().sortedBy { it.amountSats }) }
     var selectedPreset by remember { mutableStateOf<ZapPreset?>(presets.firstOrNull()) }
     var isCustom by remember { mutableStateOf(false) }
@@ -205,7 +211,17 @@ fun ZapDialog(
     }
 
     val effectiveAmount = if (isCustom) {
-        customAmount.toLongOrNull() ?: 0L
+        if (fiatMode) {
+            // Register-style: customAmount is a digit-only string that's
+            // interpreted as cents (last two digits). "21" → $0.21,
+            // "2100" → $21.00.
+            val cents = customAmount.toLongOrNull() ?: 0L
+            if (cents > 0) {
+                ExchangeRateRepository.fiatToSats(cents.toDouble() / 100.0, fiatCurrency) ?: 0L
+            } else 0L
+        } else {
+            customAmount.toLongOrNull() ?: 0L
+        }
     } else {
         selectedPreset?.amountSats ?: 0L
     }
@@ -236,8 +252,10 @@ fun ZapDialog(
                     modifier = Modifier.padding(24.dp),
                     horizontalAlignment = Alignment.CenterHorizontally
                 ) {
-                    // Header with animated bolt
-                    AnimatedBoltHeader()
+                    // Header with animated bolt — switches to a coin-stack
+                    // glyph in fiat mode so the icon reads as money rather
+                    // than zap. Mirrors the iOS dynamic `zapImage`.
+                    AnimatedBoltHeader(fiatMode = fiatMode)
 
                     Spacer(Modifier.height(8.dp))
 
@@ -252,11 +270,33 @@ fun ZapDialog(
 
                     Spacer(Modifier.height(4.dp))
 
-                    // Amount display — tap to edit directly
+                    // Amount display — tap to edit directly. In fiat mode the
+                    // input is interpreted register-style: digits fill from the
+                    // cents place ("21" → $0.21, "2100" → $21.00). The field
+                    // is bound to the raw digit string and a
+                    // `VisualTransformation` renders it as the formatted
+                    // dollar string with the cursor pinned to the end — that
+                    // way backspace removes the rightmost digit and Compose
+                    // can map cursor positions cleanly (binding the field
+                    // directly to the formatted string and rewriting it on
+                    // every keystroke broke backspace because Compose
+                    // couldn't map the cursor between the old and new
+                    // formatted strings).
+                    val currency = if (fiatMode) {
+                        ExchangeRateRepository.currencyFor(fiatCurrency)
+                    } else null
+                    val centsTransformation = remember(currency) {
+                        currency?.let { CentsVisualTransformation(it) }
+                    }
                     if (isCustom) {
                         BasicTextField(
                             value = customAmount,
-                            onValueChange = { customAmount = it.filter { c -> c.isDigit() } },
+                            onValueChange = { new ->
+                                customAmount = if (fiatMode) sanitizeFiatInput(new) else new.filter { c -> c.isDigit() }
+                            },
+                            visualTransformation = if (fiatMode && centsTransformation != null) {
+                                centsTransformation
+                            } else VisualTransformation.None,
                             textStyle = MaterialTheme.typography.displaySmall.copy(
                                 fontWeight = FontWeight.Bold,
                                 color = LightningOrange,
@@ -272,7 +312,7 @@ fun ZapDialog(
                                 Box(contentAlignment = Alignment.Center) {
                                     if (customAmount.isEmpty()) {
                                         Text(
-                                            text = "0",
+                                            text = if (fiatMode) "${currency?.symbol ?: ""}0.00" else "0",
                                             style = MaterialTheme.typography.displaySmall,
                                             fontWeight = FontWeight.Bold,
                                             color = LightningOrange.copy(alpha = 0.3f)
@@ -297,7 +337,15 @@ fun ZapDialog(
                             color = LightningOrange,
                             modifier = Modifier
                                 .clickable {
-                                    customAmount = effectiveAmount.toString()
+                                    // Seed the field with the equivalent cents
+                                    // digit string so the user can refine the
+                                    // selected preset rather than starting from
+                                    // empty in fiat mode.
+                                    customAmount = if (fiatMode) {
+                                        seedRegisterCents(effectiveAmount, fiatCurrency)
+                                    } else {
+                                        effectiveAmount.toString()
+                                    }
                                     isCustom = true
                                 }
                                 .padding(vertical = 4.dp)
@@ -392,8 +440,21 @@ fun ZapDialog(
                         Column {
                             OutlinedTextField(
                                 value = customAmount,
-                                onValueChange = { customAmount = it.filter { c -> c.isDigit() } },
-                                label = { Text(stringResource(R.string.placeholder_amount_sats)) },
+                                onValueChange = { new ->
+                                    customAmount = if (fiatMode) sanitizeFiatInput(new) else new.filter { c -> c.isDigit() }
+                                },
+                                visualTransformation = if (fiatMode && centsTransformation != null) {
+                                    centsTransformation
+                                } else VisualTransformation.None,
+                                label = {
+                                    Text(
+                                        if (fiatMode) {
+                                            stringResource(R.string.placeholder_amount_currency, currency?.symbol ?: "")
+                                        } else {
+                                            stringResource(R.string.placeholder_amount_sats)
+                                        }
+                                    )
+                                },
                                 keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
                                 modifier = Modifier.fillMaxWidth(),
                                 singleLine = true,
@@ -404,7 +465,10 @@ fun ZapDialog(
                                     cursorColor = LightningOrange
                                 )
                             )
-                            val saveAmount = customAmount.toLongOrNull() ?: 0L
+                            // Save-as-preset only makes sense for whole-sat
+                            // amounts; in fiat mode we always derive sats
+                            // through the exchange rate, which can drift.
+                            val saveAmount = if (fiatMode) 0L else (customAmount.toLongOrNull() ?: 0L)
                             if (saveAmount > 0) {
                                 Spacer(Modifier.height(6.dp))
                                 TextButton(
@@ -585,7 +649,9 @@ fun ZapDialog(
                             shape = RoundedCornerShape(16.dp)
                         ) {
                             Icon(
-                                painter = painterResource(R.drawable.ic_bolt),
+                                painter = painterResource(
+                                    if (fiatMode) R.drawable.ic_coin_stack else R.drawable.ic_bolt
+                                ),
                                 contentDescription = null,
                                 modifier = Modifier.size(15.dp)
                             )
@@ -690,8 +756,71 @@ private fun PaymentTargetChip(target: NipA3.PaymentTarget, onClick: () -> Unit) 
     )
 }
 
+/**
+ * Register-style sanitiser: digits only. The fiat-mode amount field is
+ * interpreted as integer cents (last two digits = cents place), so
+ * decimal points and other punctuation in user input are stripped — the
+ * decimal in the displayed string ("$0.21") is presentation-only.
+ */
+private fun sanitizeFiatInput(text: String): String =
+    text.filter { it.isDigit() }
+
+/**
+ * Format a digit-only string as `$X.XX` register-style — last two digits
+ * are cents, everything before them is whole dollars. "21" → "$0.21",
+ * "2100" → "$21.00". Used for the empty-field placeholder; the live
+ * field display goes through [CentsVisualTransformation] so Compose's
+ * cursor mapping works correctly.
+ */
+private fun formatRegisterCents(digits: String, currency: FiatCurrency): String {
+    val cents = digits.toLongOrNull() ?: 0L
+    val dollars = cents.toDouble() / 100.0
+    val formatter = java.text.DecimalFormat("#,##0.00")
+    return "${currency.symbol}${formatter.format(dollars)}"
+}
+
+/**
+ * Renders a digit-only field value as the formatted register-style
+ * dollar string and pegs the cursor to the end. The previous approach
+ * — binding the TextField directly to the formatted string and
+ * re-formatting in `onValueChange` — broke backspace on Android: when
+ * Compose's internal text changed from "$0.2" (after the user removed
+ * the last char) to our re-formatted "$0.02", Compose couldn't map the
+ * old cursor position into the new string and effectively snapped it
+ * to the start, so subsequent backspaces just moved the cursor instead
+ * of deleting. With a [VisualTransformation] the field is bound to the
+ * raw digits, the cursor lives in raw-string coordinates, and the
+ * `OffsetMapping` always points to the end of the formatted view.
+ */
+private class CentsVisualTransformation(
+    private val currency: FiatCurrency
+) : VisualTransformation {
+    override fun filter(text: AnnotatedString): TransformedText {
+        val formatted = formatRegisterCents(text.text, currency)
+        val rawLength = text.text.length
+        val transformedLength = formatted.length
+        val mapping = object : OffsetMapping {
+            override fun originalToTransformed(offset: Int): Int = transformedLength
+            override fun transformedToOriginal(offset: Int): Int = rawLength
+        }
+        return TransformedText(AnnotatedString(formatted), mapping)
+    }
+}
+
+/**
+ * Cents-as-digits seed for the custom-amount field. Converts the current
+ * sats amount through the cached rate, rounds to the nearest cent, and
+ * returns the digit string (e.g. 1234 cents → "1234"). Empty for zero
+ * or when no rate is cached.
+ */
+private fun seedRegisterCents(amountSats: Long, currencyCode: String): String {
+    val dollars = ExchangeRateRepository.satsToFiat(amountSats, currencyCode) ?: return ""
+    val cents = (dollars * 100.0).toLong()
+    return if (cents > 0) cents.toString() else ""
+}
+
 @Composable
-private fun AnimatedBoltHeader() {
+private fun AnimatedBoltHeader(fiatMode: Boolean = false) {
     val infiniteTransition = rememberInfiniteTransition(label = "bolt")
 
     val glowAlpha by infiniteTransition.animateFloat(
@@ -736,9 +865,11 @@ private fun AnimatedBoltHeader() {
                 )
         )
 
-        // Bolt icon
+        // Bolt / coin-stack icon depending on mode
         Icon(
-            painter = painterResource(R.drawable.ic_bolt),
+            painter = painterResource(
+                if (fiatMode) R.drawable.ic_coin_stack else R.drawable.ic_bolt
+            ),
             contentDescription = null,
             tint = zapColor,
             modifier = Modifier

--- a/app/src/main/kotlin/com/darkwisp/app/ui/screen/LiveStreamScreen.kt
+++ b/app/src/main/kotlin/com/darkwisp/app/ui/screen/LiveStreamScreen.kt
@@ -455,11 +455,18 @@ private fun StreamInfoBar(
                             )
                         }
                         Spacer(Modifier.width(4.dp))
+                        // In fiat mode the surrounding wallet UX uses
+                        // "Send Money" / "Send $X.XX" wording — match it
+                        // here so the user doesn't see "Zap" / "Zapping…"
+                        // alongside dollar amounts on the same screen.
+                        val ctx = LocalContext.current
+                        val zapFiatPrefs = remember { com.darkwisp.app.repo.FiatPreferences.get(ctx) }
+                        val zapFiatMode by zapFiatPrefs.fiatMode.collectAsState()
                         Text(
                             text = when {
                                 isZapAnimating -> "Sent!"
-                                isZapInProgress -> "Zapping..."
-                                else -> "Zap"
+                                isZapInProgress -> if (zapFiatMode) "Sending..." else "Zapping..."
+                                else -> if (zapFiatMode) "Send" else "Zap"
                             },
                             style = MaterialTheme.typography.labelMedium,
                             fontWeight = FontWeight.Bold,

--- a/app/src/main/kotlin/com/darkwisp/app/ui/util/AmountFormatter.kt
+++ b/app/src/main/kotlin/com/darkwisp/app/ui/util/AmountFormatter.kt
@@ -59,11 +59,16 @@ object AmountFormatter {
 
     private fun renderCurrency(amount: Double, currency: FiatCurrency): String {
         val abs = kotlin.math.abs(amount)
+        // Sub-dollar tiers use `#` (optional) past the decimal so trailing
+        // zeros drop — "$0.84" instead of "$0.840", "$0.8" instead of
+        // "$0.800". The cap grows as the value shrinks so we don't lose
+        // precision on tiny amounts. Whole-dollar amounts keep two decimal
+        // places (the expected retail convention: "$1.00", not "$1").
         val pattern = when {
             abs == 0.0 -> "#,##0.00"
-            abs < 0.001 -> "#,##0.000000"
-            abs < 0.01 -> "#,##0.0000"
-            abs < 1.0 -> "#,##0.000"
+            abs < 0.001 -> "#,##0.######"
+            abs < 0.01 -> "#,##0.####"
+            abs < 1.0 -> "#,##0.###"
             abs >= 1000.0 -> "#,##0"
             else -> "#,##0.00"
         }

--- a/app/src/main/kotlin/com/darkwisp/app/ui/util/ZapMessageImage.kt
+++ b/app/src/main/kotlin/com/darkwisp/app/ui/util/ZapMessageImage.kt
@@ -1,0 +1,56 @@
+package com.darkwisp.app.ui.util
+
+/**
+ * Helpers for surfacing image attachments inside zap-receipt messages.
+ *
+ * Zap receipts (kind-9735) carry a free-text message in the request's
+ * description field. People often paste an image URL there so the zap
+ * comes with an inline image (a tip + a meme). The post-card top-zap
+ * banner has a single line of room so it shows `[image]` in place of the
+ * URL, while the engagement drawer renders the image inline below the
+ * row.
+ *
+ * iOS counterpart: see `wisp-ios/Sources/.../ZapMessage.swift`.
+ */
+object ZapMessageImage {
+
+    /**
+     * Common image file extensions we treat as inline-renderable. Matches
+     * the set used elsewhere in the app (RichContent's `imageExtensions`)
+     * so behavior is consistent.
+     */
+    private val imageExtensions = setOf("jpg", "jpeg", "png", "gif", "webp", "heic", "heif", "bmp", "svg")
+
+    /**
+     * Bare URL matcher — http/https only, captures the URL up to the
+     * first whitespace. Path-segment extension is checked separately.
+     */
+    private val urlRegex = Regex("""https?://\S+""", RegexOption.IGNORE_CASE)
+
+    /**
+     * Returns the first URL inside [message] that looks like an inline
+     * image — i.e. the URL's path ends with a recognised image
+     * extension (after stripping query/fragment). Returns null if none.
+     */
+    fun firstImageUrl(message: String): String? {
+        if (message.isBlank()) return null
+        for (match in urlRegex.findAll(message)) {
+            val url = match.value.trimEnd('.', ',', ')', ']', '!', '?')
+            val path = url.substringAfter("://").substringBefore('?').substringBefore('#')
+            val ext = path.substringAfterLast('.', "").lowercase()
+            if (ext in imageExtensions) return url
+        }
+        return null
+    }
+
+    /**
+     * Replace the image URL inside [message] with the literal `[image]`
+     * token so a single-line preview (e.g. the top-zap banner) reads
+     * something like "nice post [image]" instead of dumping a long URL.
+     * Falls through unchanged when no image URL is present.
+     */
+    fun previewText(message: String): String {
+        val url = firstImageUrl(message) ?: return message
+        return message.replace(url, "[image]").trim()
+    }
+}

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -178,6 +178,7 @@
     <string name="placeholder_lightning_or_invoice">Lightning address or invoice</string>
     <string name="placeholder_user_domain">user@domain.com or lnbc…</string>
     <string name="placeholder_amount_sats">Amount (sats)</string>
+    <string name="placeholder_amount_currency">Amount (%1$s)</string>
     <string name="placeholder_message_optional">Message (optional)</string>
     <string name="placeholder_new_list_name">New list name</string>
     <string name="placeholder_add_word_phrase">Add a word or phrase</string>
@@ -844,7 +845,7 @@
     <string name="fiat_settings_rate_line">1 BTC ≈ %1$s %2$,.2f</string>
 
     <string name="zap_send_money">Send Money</string>
-    <string name="zap_x_amount">Zap %1$s</string>
+    <string name="zap_x_amount">Send %1$s</string>
 
     <string name="amount_sats_format">%1$s sats</string>
     <string name="wallet_fee_money">fee: %1$s</string>


### PR DESCRIPTION
Port of wisp #519 + #559 onto dark-wisp: register-style fiat amount entry with live sats conversion, zap messages render image URLs inline in the engagement drawer (collapsed to `[image]` on the banner), zap rows redesigned as mini-posts, adds `String.toNpub()`. Preserves NIP-A3 dialog and private-zap indicator.

**Stack 1/15** (mirrors dmnyc/dark-wisp#1). These 15 PRs are stacked — merge in order; each PR's diff shows its predecessors' commits until they land.