### PR TITLE
feat(ui): align profile, edit-profile & QR sheet with iOS

### DIFF
--- a/app/src/main/kotlin/com/darkwisp/app/ui/component/ProfileQrSheet.kt
+++ b/app/src/main/kotlin/com/darkwisp/app/ui/component/ProfileQrSheet.kt
@@ -2,14 +2,19 @@ package com.darkwisp.app.ui.component
 
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.statusBarsPadding
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.pager.HorizontalPager
 import androidx.compose.foundation.pager.rememberPagerState
@@ -88,58 +93,68 @@ fun ProfileQrSheet(
 
     ModalBottomSheet(
         onDismissRequest = onDismiss,
-        sheetState = sheetState
+        sheetState = sheetState,
+        // Full-height sheet matching NofferPaySheet, inset below the status
+        // bar so the drag handle clears the camera cutout.
+        modifier = Modifier
+            .fillMaxHeight()
+            .statusBarsPadding()
     ) {
         Column(
             horizontalAlignment = Alignment.CenterHorizontally,
             modifier = Modifier
-                .fillMaxWidth()
+                .fillMaxSize()
                 .padding(bottom = 32.dp)
         ) {
-            TabRow(
-                selectedTabIndex = pagerState.currentPage,
-                containerColor = MaterialTheme.colorScheme.surface,
-                contentColor = MaterialTheme.colorScheme.primary,
-                divider = {}
+            // iOS-style segmented control: rounded container with a pill
+            // highlight on the selected segment.
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 20.dp)
+                    .clip(RoundedCornerShape(26.dp))
+                    .background(MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.45f))
+                    .padding(4.dp)
             ) {
-                Tab(
+                SegmentedTab(
+                    label = "Nostr",
                     selected = pagerState.currentPage == 0,
-                    onClick = { scope.launch { pagerState.animateScrollToPage(0) } },
-                    text = { Text("Nostr") },
-                    icon = { Icon(Icons.Outlined.Person, null, modifier = Modifier.size(18.dp)) }
+                    modifier = Modifier.weight(1f),
+                    onClick = { scope.launch { pagerState.animateScrollToPage(0) } }
                 )
-                if (hasLightning) {
-                    Tab(
+                if (hasPayment) {
+                    SegmentedTab(
+                        label = "Lightning",
                         selected = pagerState.currentPage == lightningPage,
-                        onClick = { scope.launch { pagerState.animateScrollToPage(lightningPage) } },
-                        text = { Text("Lightning") },
-                        icon = {
-                            if (useZapBolt) {
-                                Icon(painterResource(R.drawable.ic_bolt), null, modifier = Modifier.size(18.dp))
-                            } else {
-                                Icon(Icons.Outlined.CurrencyBitcoin, null, modifier = Modifier.size(18.dp))
-                            }
-                        }
+                        modifier = Modifier.weight(1f),
+                        onClick = { scope.launch { pagerState.animateScrollToPage(lightningPage) } }
                     )
                 }
-                Tab(
+                SegmentedTab(
+                    label = "Scan",
+                    icon = { Icon(Icons.Outlined.QrCodeScanner, null, modifier = Modifier.size(16.dp)) },
                     selected = pagerState.currentPage == scanPage,
-                    onClick = { scope.launch { pagerState.animateScrollToPage(scanPage) } },
-                    text = { Text("Scan") },
-                    icon = { Icon(Icons.Outlined.QrCodeScanner, null, modifier = Modifier.size(18.dp)) }
+                    modifier = Modifier.weight(1f),
+                    onClick = { scope.launch { pagerState.animateScrollToPage(scanPage) } }
                 )
             }
 
             Spacer(Modifier.height(16.dp))
 
+            // Fill the remaining sheet height and top-align every page so the
+            // pager doesn't resize/re-center when pages of different heights
+            // compose in — that's what made the content shift on tab change.
             HorizontalPager(
                 state = pagerState,
-                modifier = Modifier.fillMaxWidth()
+                verticalAlignment = Alignment.Top,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .weight(1f)
             ) { page ->
                 Column(
                     horizontalAlignment = Alignment.CenterHorizontally,
                     modifier = Modifier
-                        .fillMaxWidth()
+                        .fillMaxSize()
                         .padding(horizontal = 24.dp)
                 ) {
                     when (page) {
@@ -210,27 +225,35 @@ fun ProfileQrSheet(
                                         contentDescription = "Lightning QR Code",
                                         modifier = Modifier.matchParentSize()
                                     )
+                                    // Avatar in the QR center, matching iOS's
+                                    // qrWithCenterAvatar and the Nostr pane.
                                     Box(
-                                        contentAlignment = Alignment.Center,
                                         modifier = Modifier
                                             .size(44.dp)
                                             .clip(CircleShape)
                                             .background(androidx.compose.ui.graphics.Color.White)
-                                            .padding(4.dp)
+                                            .padding(3.dp)
                                     ) {
-                                        if (useZapBolt) {
+                                        if (avatarUrl != null) {
+                                            AsyncImage(
+                                                model = avatarUrl,
+                                                contentDescription = "Avatar",
+                                                contentScale = ContentScale.Crop,
+                                                modifier = Modifier.matchParentSize().clip(CircleShape)
+                                            )
+                                        } else if (useZapBolt) {
                                             Icon(
                                                 painter = painterResource(R.drawable.ic_bolt),
                                                 contentDescription = "Lightning",
                                                 tint = WispThemeColors.zapColor,
-                                                modifier = Modifier.size(28.dp)
+                                                modifier = Modifier.matchParentSize().padding(4.dp)
                                             )
                                         } else {
                                             Icon(
                                                 Icons.Outlined.CurrencyBitcoin,
                                                 contentDescription = "Bitcoin",
                                                 tint = WispThemeColors.zapColor,
-                                                modifier = Modifier.size(28.dp)
+                                                modifier = Modifier.matchParentSize().padding(4.dp)
                                             )
                                         }
                                     }
@@ -276,6 +299,39 @@ fun ProfileQrSheet(
                 }
             }
         }
+    }
+}
+
+@Composable
+private fun SegmentedTab(
+    label: String,
+    selected: Boolean,
+    modifier: Modifier = Modifier,
+    icon: (@Composable () -> Unit)? = null,
+    onClick: () -> Unit
+) {
+    Row(
+        horizontalArrangement = Arrangement.Center,
+        verticalAlignment = Alignment.CenterVertically,
+        modifier = modifier
+            .clip(RoundedCornerShape(22.dp))
+            .background(
+                if (selected) MaterialTheme.colorScheme.surfaceVariant
+                else androidx.compose.ui.graphics.Color.Transparent
+            )
+            .clickable(onClick = onClick)
+            .padding(vertical = 12.dp)
+    ) {
+        if (icon != null) {
+            icon()
+            Spacer(Modifier.width(6.dp))
+        }
+        Text(
+            label,
+            style = MaterialTheme.typography.labelLarge,
+            color = if (selected) MaterialTheme.colorScheme.onSurface
+            else MaterialTheme.colorScheme.onSurfaceVariant
+        )
     }
 }
 

--- a/app/src/main/kotlin/com/darkwisp/app/ui/screen/ProfileEditScreen.kt
+++ b/app/src/main/kotlin/com/darkwisp/app/ui/screen/ProfileEditScreen.kt
@@ -3,8 +3,14 @@ package com.darkwisp.app.ui.screen
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.PickVisualMediaRequest
 import androidx.activity.result.contract.ActivityResultContracts
+import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.foundation.ExperimentalFoundationApi
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
@@ -19,7 +25,11 @@ import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.KeyboardArrowDown
+import androidx.compose.material.icons.filled.KeyboardArrowUp
+import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material.icons.outlined.FileUpload
+import androidx.compose.material.icons.outlined.PhotoCamera
 import androidx.compose.material3.Button
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ExperimentalMaterial3Api
@@ -34,14 +44,20 @@ import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.focus.onFocusChanged
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.res.stringResource
+import coil3.compose.AsyncImage
 import com.darkwisp.app.R
 import com.darkwisp.app.relay.RelayPool
 import com.darkwisp.app.viewmodel.ProfileViewModel
@@ -67,6 +83,7 @@ fun ProfileEditScreen(
     val error by viewModel.error.collectAsState()
     val context = LocalContext.current
     val scope = rememberCoroutineScope()
+    var advancedExpanded by remember { mutableStateOf(false) }
 
     @Composable
     fun Modifier.scrollOnFocus(): Modifier {
@@ -108,10 +125,90 @@ fun ProfileEditScreen(
             modifier = Modifier
                 .fillMaxSize()
                 .padding(padding)
-                .padding(16.dp)
                 .verticalScroll(rememberScrollState())
                 .imePadding()
         ) {
+            // Tappable banner + avatar preview, matching iOS — tap either to
+            // pick a new image from the gallery.
+            Box(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .height(140.dp)
+                    .background(MaterialTheme.colorScheme.surfaceVariant)
+                    .clickable(enabled = uploading == null) {
+                        bannerPickerLauncher.launch(
+                            PickVisualMediaRequest(ActivityResultContracts.PickVisualMedia.ImageOnly)
+                        )
+                    }
+            ) {
+                if (banner.isNotBlank()) {
+                    AsyncImage(
+                        model = banner,
+                        contentDescription = stringResource(R.string.cd_upload_banner),
+                        contentScale = ContentScale.Crop,
+                        modifier = Modifier.fillMaxSize()
+                    )
+                }
+                if (uploading != null && uploading!!.contains("banner")) {
+                    CircularProgressIndicator(
+                        modifier = Modifier.size(28.dp).align(Alignment.Center),
+                        strokeWidth = 2.dp
+                    )
+                } else {
+                    Icon(
+                        Icons.Outlined.PhotoCamera,
+                        contentDescription = stringResource(R.string.cd_upload_banner),
+                        tint = Color.White.copy(alpha = 0.85f),
+                        modifier = Modifier
+                            .align(Alignment.Center)
+                            .size(32.dp)
+                            .background(Color.Black.copy(alpha = 0.35f), CircleShape)
+                            .padding(6.dp)
+                    )
+                }
+            }
+            Box(
+                modifier = Modifier
+                    .padding(start = 16.dp)
+                    .offset(y = (-32).dp)
+                    .size(72.dp)
+                    .clip(CircleShape)
+                    .background(MaterialTheme.colorScheme.surfaceVariant)
+                    .border(2.dp, MaterialTheme.colorScheme.background, CircleShape)
+                    .clickable(enabled = uploading == null) {
+                        avatarPickerLauncher.launch(
+                            PickVisualMediaRequest(ActivityResultContracts.PickVisualMedia.ImageOnly)
+                        )
+                    }
+            ) {
+                if (picture.isNotBlank()) {
+                    AsyncImage(
+                        model = picture,
+                        contentDescription = stringResource(R.string.cd_upload_avatar),
+                        contentScale = ContentScale.Crop,
+                        modifier = Modifier.matchParentSize().clip(CircleShape)
+                    )
+                }
+                if (uploading != null && uploading!!.contains("avatar")) {
+                    CircularProgressIndicator(
+                        modifier = Modifier.size(24.dp).align(Alignment.Center),
+                        strokeWidth = 2.dp
+                    )
+                } else {
+                    Icon(
+                        Icons.Outlined.PhotoCamera,
+                        contentDescription = stringResource(R.string.cd_upload_avatar),
+                        tint = Color.White.copy(alpha = 0.85f),
+                        modifier = Modifier
+                            .align(Alignment.Center)
+                            .size(26.dp)
+                            .background(Color.Black.copy(alpha = 0.35f), CircleShape)
+                            .padding(5.dp)
+                    )
+                }
+            }
+
+            Column(modifier = Modifier.padding(horizontal = 16.dp).offset(y = (-16).dp)) {
             OutlinedTextField(
                 value = name,
                 onValueChange = { viewModel.updateName(it) },
@@ -127,60 +224,6 @@ fun ProfileEditScreen(
                 minLines = 3,
                 modifier = Modifier.fillMaxWidth().scrollOnFocus()
             )
-            Spacer(Modifier.height(12.dp))
-            Row(
-                verticalAlignment = Alignment.CenterVertically,
-                modifier = Modifier.fillMaxWidth()
-            ) {
-                OutlinedTextField(
-                    value = picture,
-                    onValueChange = { viewModel.updatePicture(it) },
-                    label = { Text(stringResource(R.string.placeholder_profile_picture_url)) },
-                    singleLine = true,
-                    modifier = Modifier.weight(1f).scrollOnFocus()
-                )
-                IconButton(
-                    onClick = {
-                        avatarPickerLauncher.launch(
-                            PickVisualMediaRequest(ActivityResultContracts.PickVisualMedia.ImageOnly)
-                        )
-                    },
-                    enabled = uploading == null
-                ) {
-                    if (uploading != null && uploading!!.contains("avatar")) {
-                        CircularProgressIndicator(modifier = Modifier.size(20.dp), strokeWidth = 2.dp)
-                    } else {
-                        Icon(Icons.Outlined.FileUpload, contentDescription = stringResource(R.string.cd_upload_avatar))
-                    }
-                }
-            }
-            Spacer(Modifier.height(12.dp))
-            Row(
-                verticalAlignment = Alignment.CenterVertically,
-                modifier = Modifier.fillMaxWidth()
-            ) {
-                OutlinedTextField(
-                    value = banner,
-                    onValueChange = { viewModel.updateBanner(it) },
-                    label = { Text(stringResource(R.string.placeholder_banner_url)) },
-                    singleLine = true,
-                    modifier = Modifier.weight(1f).scrollOnFocus()
-                )
-                IconButton(
-                    onClick = {
-                        bannerPickerLauncher.launch(
-                            PickVisualMediaRequest(ActivityResultContracts.PickVisualMedia.ImageOnly)
-                        )
-                    },
-                    enabled = uploading == null
-                ) {
-                    if (uploading != null && uploading!!.contains("banner")) {
-                        CircularProgressIndicator(modifier = Modifier.size(20.dp), strokeWidth = 2.dp)
-                    } else {
-                        Icon(Icons.Outlined.FileUpload, contentDescription = stringResource(R.string.cd_upload_banner))
-                    }
-                }
-            }
             Spacer(Modifier.height(12.dp))
             OutlinedTextField(
                 value = nip05,
@@ -199,6 +242,98 @@ fun ProfileEditScreen(
             )
             Spacer(Modifier.height(16.dp))
 
+            // Advanced section — raw image URLs and the CLINK offer, matching iOS.
+            Row(
+                verticalAlignment = Alignment.CenterVertically,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .clickable { advancedExpanded = !advancedExpanded }
+                    .padding(vertical = 4.dp)
+            ) {
+                Text(
+                    "Advanced",
+                    style = MaterialTheme.typography.titleSmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+                Spacer(Modifier.weight(1f))
+                Icon(
+                    if (advancedExpanded) Icons.Default.KeyboardArrowUp else Icons.Default.KeyboardArrowDown,
+                    contentDescription = if (advancedExpanded) "Collapse" else "Expand",
+                    tint = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+            }
+            AnimatedVisibility(visible = advancedExpanded) {
+                Column {
+                    Spacer(Modifier.height(8.dp))
+                    Row(
+                        verticalAlignment = Alignment.CenterVertically,
+                        modifier = Modifier.fillMaxWidth()
+                    ) {
+                        OutlinedTextField(
+                            value = picture,
+                            onValueChange = { new -> if (!NsecPasteGuard.blockIfNsec(picture, new)) viewModel.updatePicture(new) },
+                            label = { Text(stringResource(R.string.placeholder_profile_picture_url)) },
+                            singleLine = true,
+                            modifier = Modifier.weight(1f).scrollOnFocus()
+                        )
+                        IconButton(
+                            onClick = {
+                                avatarPickerLauncher.launch(
+                                    PickVisualMediaRequest(ActivityResultContracts.PickVisualMedia.ImageOnly)
+                                )
+                            },
+                            enabled = uploading == null
+                        ) {
+                            if (uploading != null && uploading!!.contains("avatar")) {
+                                CircularProgressIndicator(modifier = Modifier.size(20.dp), strokeWidth = 2.dp)
+                            } else {
+                                Icon(Icons.Outlined.FileUpload, contentDescription = stringResource(R.string.cd_upload_avatar))
+                            }
+                        }
+                    }
+                    Spacer(Modifier.height(12.dp))
+                    Row(
+                        verticalAlignment = Alignment.CenterVertically,
+                        modifier = Modifier.fillMaxWidth()
+                    ) {
+                        OutlinedTextField(
+                            value = banner,
+                            onValueChange = { new -> if (!NsecPasteGuard.blockIfNsec(banner, new)) viewModel.updateBanner(new) },
+                            label = { Text(stringResource(R.string.placeholder_banner_url)) },
+                            singleLine = true,
+                            modifier = Modifier.weight(1f).scrollOnFocus()
+                        )
+                        IconButton(
+                            onClick = {
+                                bannerPickerLauncher.launch(
+                                    PickVisualMediaRequest(ActivityResultContracts.PickVisualMedia.ImageOnly)
+                                )
+                            },
+                            enabled = uploading == null
+                        ) {
+                            if (uploading != null && uploading!!.contains("banner")) {
+                                CircularProgressIndicator(modifier = Modifier.size(20.dp), strokeWidth = 2.dp)
+                            } else {
+                                Icon(Icons.Outlined.FileUpload, contentDescription = stringResource(R.string.cd_upload_banner))
+                            }
+                        }
+                    }
+                    Spacer(Modifier.height(12.dp))
+                    OutlinedTextField(
+                        value = clinkOffer,
+                        onValueChange = { new -> if (!NsecPasteGuard.blockIfNsec(clinkOffer, new)) viewModel.updateClinkOffer(new) },
+                        label = { Text("CLINK offer") },
+                        placeholder = { Text("noffer1…") },
+                        singleLine = true,
+                        supportingText = {
+                            Text("Self-custodial Lightning payments. Generate one with Zeus, ShockWallet or Lightning.Pub.")
+                        },
+                        modifier = Modifier.fillMaxWidth().scrollOnFocus()
+                    )
+                }
+            }
+            Spacer(Modifier.height(16.dp))
+
             error?.let {
                 Text(it, color = MaterialTheme.colorScheme.error, style = MaterialTheme.typography.bodySmall)
                 Spacer(Modifier.height(8.dp))
@@ -212,6 +347,7 @@ fun ProfileEditScreen(
                 modifier = Modifier.fillMaxWidth()
             ) {
                 Text(if (publishing) stringResource(R.string.onboarding_publishing) else stringResource(R.string.btn_save_profile))
+            }
             }
         }
     }

--- a/app/src/main/kotlin/com/darkwisp/app/ui/screen/UserProfileScreen.kt
+++ b/app/src/main/kotlin/com/darkwisp/app/ui/screen/UserProfileScreen.kt
@@ -119,8 +119,6 @@ import android.widget.Toast
 import androidx.compose.ui.platform.LocalContext
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.SharedFlow
-import kotlinx.serialization.json.buildJsonObject
-import kotlinx.serialization.json.put
 
 private sealed class ProfileZapStatus {
     object Idle : ProfileZapStatus()
@@ -457,23 +455,29 @@ fun UserProfileScreen(
                         onDismissRequest = { menuExpanded = false }
                     ) {
                         DropdownMenuItem(
-                            text = { Text(stringResource(R.string.profile_copy_json)) },
+                            text = { Text("Share Profile") },
                             onClick = {
                                 menuExpanded = false
-                                profile?.let { p ->
-                                    val json = buildJsonObject {
-                                        p.name?.let { put("name", it) }
-                                        p.displayName?.let { put("display_name", it) }
-                                        p.about?.let { put("about", it) }
-                                        p.picture?.let { put("picture", it) }
-                                        p.banner?.let { put("banner", it) }
-                                        p.nip05?.let { put("nip05", it) }
-                                        p.lud16?.let { put("lud16", it) }
-                                    }.toString()
+                                try {
+                                    val npub = profilePubkey.toNpub()
+                                    val intent = android.content.Intent(android.content.Intent.ACTION_SEND).apply {
+                                        type = "text/plain"
+                                        putExtra(android.content.Intent.EXTRA_TEXT, "https://njump.me/$npub")
+                                    }
+                                    context.startActivity(android.content.Intent.createChooser(intent, null))
+                                } catch (_: Exception) {}
+                            }
+                        )
+                        DropdownMenuItem(
+                            text = { Text("Copy npub") },
+                            onClick = {
+                                menuExpanded = false
+                                try {
+                                    val npub = profilePubkey.toNpub()
                                     val clipboard = context.getSystemService(Context.CLIPBOARD_SERVICE) as ClipboardManager
-                                    clipboard.setPrimaryClip(ClipData.newPlainText("Profile JSON", json))
-                                    Toast.makeText(context, context.getString(R.string.profile_json_copied), Toast.LENGTH_SHORT).show()
-                                }
+                                    clipboard.setPrimaryClip(ClipData.newPlainText("npub", npub))
+                                    Toast.makeText(context, "npub copied", Toast.LENGTH_SHORT).show()
+                                } catch (_: Exception) {}
                             }
                         )
                         if (!isOwnProfile) {


### PR DESCRIPTION
Port of wisp 39c4ac2 (PR #589): circle action buttons on the profile header (DM, zap, pay offer, follow, mute), tap-to-upload avatar/banner replacing URL fields, QR sheet refresh.

**Stack 6/15** (mirrors dmnyc/dark-wisp#6) — merge after stack 5.