### PR TITLE
fix: move spam scoring out of NotificationRepository lock

### DIFF
--- a/app/src/main/kotlin/com/darkwisp/app/repo/NotificationRepository.kt
+++ b/app/src/main/kotlin/com/darkwisp/app/repo/NotificationRepository.kt
@@ -238,6 +238,12 @@ class NotificationRepository(
             }
         }
 
+        // Score reply authors for spam *before* taking the lock. Feature
+        // extraction runs several regex passes over up to ten notes per
+        // author; doing it under the lock stalls every caller — including
+        // the main thread — long enough to trip the input-dispatch ANR.
+        if (event.kind == 1) warmSpamScore(event)
+
         synchronized(lock) {
             // Atomic check-then-put inside lock to prevent race when the same
             // event arrives from multiple relays concurrently (e.g. user-engage
@@ -688,32 +694,43 @@ class NotificationRepository(
         return mergeMention(event)
     }
 
+    /**
+     * Run the spam classifier for a reply author and cache the score.
+     * Called from addEvent before synchronized(lock) — classifier feature
+     * extraction is regex-heavy and must never run while holding the lock,
+     * or main-thread callers (markRead, getAllPostCardEventIds) block past
+     * the 5s input-dispatch deadline. SpamAuthorCache wraps LruCache, which
+     * is thread-safe; a concurrent duplicate scoring is harmless.
+     */
+    private fun warmSpamScore(event: NostrEvent) {
+        if (safetyPrefs?.spamFilterEnabled?.value != true) return
+        if (contactRepo?.isFollowing(event.pubkey) == true) return
+        if (safetyPrefs?.isSpamSafelisted(event.pubkey) == true) return
+        // Only replies are spam-scored (see mergeReply); skip quotes/mentions
+        if (event.tags.any { it.size >= 2 && it[0] == "q" }) return
+        if (Nip10.getReplyTargetWithHint(event) == null) return
+        val classifier = spamClassifier ?: return
+        val cache = spamAuthorCache ?: return
+        val repo = eventRepo ?: return
+        val notes = repo.getCachedEventsByAuthor(event.pubkey, 1, 10)
+        if (notes.isEmpty()) return
+        if (cache.get(event.pubkey, notes.size) != null) return
+        val inputs = notes.map { e ->
+            com.darkwisp.app.ml.NoteInput(e.content, e.tags, e.created_at)
+        }
+        val score = classifier.score(inputs)
+        if (score != null) cache.put(event.pubkey, score, inputs.size)
+    }
+
     private fun mergeReply(event: NostrEvent, replyTarget: String, replyTargetHint: String?): Boolean {
         if (safetyPrefs?.spamFilterEnabled?.value == true &&
             contactRepo?.isFollowing(event.pubkey) != true &&
             safetyPrefs?.isSpamSafelisted(event.pubkey) != true
         ) {
-            val repo = eventRepo
-            val noteCount = repo?.getCachedEventsByAuthor(event.pubkey, 1, 10)?.size ?: 0
+            // Score was computed off-lock in warmSpamScore; only consult the cache here
+            val noteCount = eventRepo?.getCachedEventsByAuthor(event.pubkey, 1, 10)?.size ?: 0
             val cached = spamAuthorCache?.get(event.pubkey, noteCount)
             if (cached != null && cached >= 0.7f) return false
-            if (cached == null) {
-                val classifier = spamClassifier
-                val cache = spamAuthorCache
-                if (classifier != null && cache != null && repo != null) {
-                    val notes = repo.getCachedEventsByAuthor(event.pubkey, 1, 10)
-                    if (notes.isNotEmpty()) {
-                        val inputs = notes.map { e ->
-                            com.darkwisp.app.ml.NoteInput(e.content, e.tags, e.created_at)
-                        }
-                        val score = classifier.score(inputs)
-                        if (score != null) {
-                            cache.put(event.pubkey, score, inputs.size)
-                            if (score >= 0.7f) return false
-                        }
-                    }
-                }
-            }
         }
         val key = "reply:${event.id}"
         val hints = listOfNotNull(replyTargetHint)


### PR DESCRIPTION
While scoring runs, every other caller of `lock` blocks, including main-thread coroutines calling `markRead()` / `getAllPostCardEventIds()`. During a notification burst, each new author serializes another scoring pass under the lock, and the main thread queues behind it past the 5-second input-dispatch deadline.

Was going to attach the ANR trace from my device (Pixel 9a, GrapheneOS, Android 16), but here is the relevant frames:

```
"main" tid=1 Blocked
  - waiting to lock <0x0ce79bc4> held by thread 227

"DefaultDispatcher-worker-24" tid=227 Runnable   (~35s accumulated CPU)
  at com.android.icu.util.regex.MatcherNative.setInputImpl(Native method)
  ...
  at java.util.regex.Pattern.matcher(Pattern.java:983)
  ...kotlin Regex.findAll sequence iteration...
  - locked <0x0ce79bc4>
```

Since this is plain Java lock contention it reproduces on stock Android too and is possibly relevant to `docs/grapheneos-perf-investigation.md` as a freeze source the MTE/packaging/secp variant matrix wouldn't isolate.

## Fix

Hoist the scoring out of the lock: `addEvent()` now calls `warmSpamScore(event)` before `synchronized(lock)`. It applies the same guards as `mergeReply` (spam filter enabled, not following, not safelisted, is a reply), scores the author, and populates `SpamAuthorCache`. Inside the lock, `mergeReply()` only consults the cache.

- Scoring reads only `EventRepository`'s cache and `SpamAuthorCache`.
- `SpamAuthorCache` wraps `android.util.LruCache`, which is internally synchronized; the worst case from two threads racing on the same author is one redundant scoring, and the put is idempotent.
- Filtering semantics are unchanged: the same authors get scored under the same conditions, the same 0.7 threshold rejects inside the lock. The only behavioral difference is where the CPU time is spent.