### PR TITLE
feat: add staging build type for release-performance on-device testing

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -63,6 +63,19 @@ android {
             // contributors without the keystore still get app-release-unsigned.apk
             signingConfig = signingConfigs.getByName("release").takeIf { it.storeFile != null }
         }
+
+        create("staging") {
+            // Release-performance build for on-device testing. debuggable=true (the
+            // debug type) makes ART ignore the baseline profile and run JIT-only with
+            // deoptimization support, which cripples the per-event hot path (JSON parse,
+            // hex decode, SHA-256, JNI Schnorr verify per relay event). This variant is
+            // non-debuggable + R8 like release, but debug-signed so anyone can install
+            // it without the release keystore. Installs alongside debug/release.
+            initWith(getByName("release"))
+            applicationIdSuffix = ".staging"
+            resValue("string", "app_name", "Dark Wisp Staging")
+            signingConfig = signingConfigs.getByName("debug")
+        }
     }
 
     compileOptions {


### PR DESCRIPTION
Debuggable builds make ART run JIT-only and ignore the baseline profile, which cripples the per-event hot path (JSON parse, hex decode, SHA-256, JNI Schnorr verify per relay event). The staging variant is non-debuggable with R8 like release, but debug-signed so anyone can install it without the release keystore. It installs alongside debug/release via the .staging applicationId suffix.