### PR TITLE
chore: bump version to v1.1.0

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -26,8 +26,8 @@ android {
         applicationId = baseApplicationId
         minSdk = 26
         targetSdk = 35
-        versionCode = 1
-        versionName = "1.0.0"
+        versionCode = 2
+        versionName = "1.1.0"
         resValue("string", "app_name", "Dark Wisp")
 
         ndk {


### PR DESCRIPTION
Bump app version for the v1.1.0 release.

- `versionName`: `1.0.0` → `1.1.0`
- `versionCode`: `1` → `2`

🤖 Generated with [Claude Code](https://claude.com/claude-code)