### PR TITLE
chore: remove orphan wallet_spark translations

### DIFF
--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -591,7 +591,6 @@
     <string name="wallet_nwc_description">Verbinden Sie eine externe Lightning-Brieftasche mit einer NWC-Verbindungszeichenfolge.</string>
     <string name="wallet_nwc_connection_string">NWC-Verbindungszeichenfolge</string>
     <string name="wallet_connect">Verbinden</string>
-    <string name="wallet_spark">Spark Brieftasche</string>
     <string name="wallet_set_up_lightning">Lightning-Adresse Einrichten</string>
     <string name="wallet_send">Senden</string>
     <string name="wallet_receive">Empfangen</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -591,7 +591,6 @@
     <string name="wallet_nwc_description">Conecta una billetera Lightning externa usando una cadena de conexión NWC.</string>
     <string name="wallet_nwc_connection_string">Cadena de Conexión NWC</string>
     <string name="wallet_connect">Conectar</string>
-    <string name="wallet_spark">Billetera Spark</string>
     <string name="wallet_set_up_lightning">Configurar tu Dirección Lightning</string>
     <string name="wallet_send">Enviar</string>
     <string name="wallet_receive">Recibir</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -591,7 +591,6 @@
     <string name="wallet_nwc_description">Connectez un portefeuille Lightning externe utilisant une chaîne de connexion NWC.</string>
     <string name="wallet_nwc_connection_string">Chaîne de Connexion NWC</string>
     <string name="wallet_connect">Connecter</string>
-    <string name="wallet_spark">Portefeuille Spark</string>
     <string name="wallet_set_up_lightning">Configurer votre Adresse Lightning</string>
     <string name="wallet_send">Envoyer</string>
     <string name="wallet_receive">Recevoir</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -591,7 +591,6 @@
     <string name="wallet_nwc_description">Connetti un portafoglio Lightning esterno usando una stringa di connessione NWC.</string>
     <string name="wallet_nwc_connection_string">Stringa di Connessione NWC</string>
     <string name="wallet_connect">Connetti</string>
-    <string name="wallet_spark">Portafoglio Spark</string>
     <string name="wallet_set_up_lightning">Configura il tuo Indirizzo Lightning</string>
     <string name="wallet_send">Invia</string>
     <string name="wallet_receive">Ricevi</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -591,7 +591,6 @@
     <string name="wallet_nwc_description">NWC接続文字列を使用して外部Lightningウォレットを接続。</string>
     <string name="wallet_nwc_connection_string">NWC接続文字列</string>
     <string name="wallet_connect">接続</string>
-    <string name="wallet_spark">Sparkウォレット</string>
     <string name="wallet_set_up_lightning">Lightningアドレスを設定</string>
     <string name="wallet_send">送る</string>
     <string name="wallet_receive">受け取る</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -591,7 +591,6 @@
     <string name="wallet_nwc_description">NWC 연결 문자열을 사용하여 외부 라이트닝 지갑을 연결합니다.</string>
     <string name="wallet_nwc_connection_string">NWC 연결 문자열</string>
     <string name="wallet_connect">연결</string>
-    <string name="wallet_spark">Spark 지갑</string>
     <string name="wallet_set_up_lightning">라이트닝 주소 설정</string>
     <string name="wallet_send">보내기</string>
     <string name="wallet_receive">받기</string>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -591,7 +591,6 @@
     <string name="wallet_nwc_description">Verbind een externe Lightning portemonnee met een NWC verbindingsreeks.</string>
     <string name="wallet_nwc_connection_string">NWC Verbindingsreeks</string>
     <string name="wallet_connect">Verbinden</string>
-    <string name="wallet_spark">Spark Portemonnee</string>
     <string name="wallet_set_up_lightning">Lightning Adres Instellen</string>
     <string name="wallet_send">Verzenden</string>
     <string name="wallet_receive">Ontvangen</string>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -591,7 +591,6 @@
     <string name="wallet_nwc_description">Conecte uma carteira Lightning externa usando uma string de conexão NWC.</string>
     <string name="wallet_nwc_connection_string">String de Conexão NWC</string>
     <string name="wallet_connect">Conectar</string>
-    <string name="wallet_spark">Carteira Spark</string>
     <string name="wallet_set_up_lightning">Configurar seu Endereço Lightning</string>
     <string name="wallet_send">Enviar</string>
     <string name="wallet_receive">Receber</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -552,7 +552,6 @@
     <string name="wallet_nwc_description">Подключите внешний кошелёк Lightning с помощью строки подключения NWC.</string>
     <string name="wallet_nwc_connection_string">Строка Подключения NWC</string>
     <string name="wallet_connect">Подключить</string>
-    <string name="wallet_spark">Кошелёк Spark</string>
     <string name="wallet_set_up_lightning">Настроить Адрес Lightning</string>
     <string name="wallet_send">Отправить</string>
     <string name="wallet_receive">Получить</string>

--- a/app/src/main/res/values-zh/strings.xml
+++ b/app/src/main/res/values-zh/strings.xml
@@ -591,7 +591,6 @@
     <string name="wallet_nwc_description">使用NWC连接字符串连接外部Lightning钱包。</string>
     <string name="wallet_nwc_connection_string">NWC连接字符串</string>
     <string name="wallet_connect">连接</string>
-    <string name="wallet_spark">Spark钱包</string>
     <string name="wallet_set_up_lightning">设置Lightning地址</string>
     <string name="wallet_send">发送</string>
     <string name="wallet_receive">接收</string>


### PR DESCRIPTION
The bare `wallet_spark` string existed in all 10 translated locales but not in the default `values/strings.xml`, and is not referenced in code (only `wallet_spark_title`, `wallet_spark_subtitle_recommended`, and `wallet_spark_sdk` are used).

This tripped lint's `ExtraTranslation` check, failing `lintVitalRelease` / `lintVitalStaging` and blocking release/staging builds.

Removes the orphan line from all 10 locales. `lintVitalRelease` now passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)