### PR TITLE
feat(auth): Continue with Nostr sign-in sheet, QR scan & key QR codes (port wisp #536, #552)

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -114,6 +114,7 @@ dependencies {
     implementation(libs.compose.icons.extended)
     implementation(libs.activity.compose)
     implementation(libs.navigation.compose)
+    implementation(libs.androidx.credentials)
     implementation(libs.lifecycle.viewmodel.compose)
     implementation(libs.lifecycle.runtime.compose)
     implementation(libs.okhttp)

--- a/app/src/main/kotlin/com/darkwisp/app/Navigation.kt
+++ b/app/src/main/kotlin/com/darkwisp/app/Navigation.kt
@@ -2948,9 +2948,12 @@ fun WispNavHost(
         }
 
         composable(Routes.KEYS) {
+            val keysAvatarUrl = feedViewModel.getUserPubkey()
+                ?.let { feedViewModel.eventRepo.getProfileData(it)?.picture }
             KeysScreen(
                 keyRepository = authViewModel.keyRepo,
-                onBack = { navController.popBackStack() }
+                onBack = { navController.popBackStack() },
+                avatarUrl = keysAvatarUrl
             )
         }
 

--- a/app/src/main/kotlin/com/darkwisp/app/Navigation.kt
+++ b/app/src/main/kotlin/com/darkwisp/app/Navigation.kt
@@ -693,15 +693,50 @@ fun WispNavHost(
         composable(Routes.SPLASH) {
             SplashScreen(
                 viewModel = splashViewModel,
-                onSignUp = {
-                    if (authViewModel.signUp()) {
-                        navController.navigate(Routes.ONBOARDING_PROFILE) {
+                authViewModel = authViewModel,
+                // Account creation (signUp) already happened inside the sheet.
+                onAccountCreated = {
+                    navController.navigate(Routes.ONBOARDING_PROFILE) {
+                        popUpTo(Routes.SPLASH) { inclusive = true }
+                    }
+                },
+                // Mirrors AuthScreen's onAuthenticated(false) routing, but pops
+                // up to SPLASH since both first-login and add-account flow
+                // through the splash sheet now.
+                onLoggedIn = {
+                    val wasAddingAccount = authViewModel.isAddingAccount
+                    authViewModel.isAddingAccount = false
+
+                    if (wasAddingAccount && authViewModel.keyRepo.isOnboardingComplete()) {
+                        feedViewModel.reloadForNewAccount()
+                        relayViewModel.reload()
+                        blossomServersViewModel.reload()
+                        composeViewModel.reloadBlossomRepo()
+                        feedViewModel.initRelays()
+                        walletViewModel.refreshState()
+                        navController.navigate(Routes.LOADING) {
+                            popUpTo(Routes.SPLASH) { inclusive = true }
+                        }
+                    } else if (authViewModel.keyRepo.isReadOnly()) {
+                        feedViewModel.reloadForNewAccount()
+                        relayViewModel.reload()
+                        feedViewModel.initRelays()
+                        authViewModel.keyRepo.markOnboardingComplete()
+                        navController.navigate(Routes.LOADING) {
+                            popUpTo(Routes.SPLASH) { inclusive = true }
+                        }
+                    } else {
+                        feedViewModel.reloadForNewAccount()
+                        relayViewModel.reload()
+                        blossomServersViewModel.reload()
+                        composeViewModel.reloadBlossomRepo()
+                        feedViewModel.initRelays()
+                        walletViewModel.refreshState()
+                        authViewModel.keyRepo.markOnboardingComplete()
+                        navController.navigate(Routes.EXISTING_USER_ONBOARDING) {
                             popUpTo(Routes.SPLASH) { inclusive = true }
                         }
                     }
-                },
-                onLogIn = {
-                    navController.navigate(Routes.AUTH)
                 },
                 onToggleTor = { feedViewModel.setTorEnabled(it) }
             )

--- a/app/src/main/kotlin/com/darkwisp/app/auth/NostrCredentialSaver.kt
+++ b/app/src/main/kotlin/com/darkwisp/app/auth/NostrCredentialSaver.kt
@@ -1,0 +1,63 @@
+package com.darkwisp.app.auth
+
+import android.content.Context
+import android.util.Log
+import androidx.credentials.CreatePasswordRequest
+import androidx.credentials.CredentialManager
+import androidx.credentials.GetCredentialRequest
+import androidx.credentials.GetPasswordOption
+import androidx.credentials.PasswordCredential
+import androidx.credentials.exceptions.CreateCredentialCancellationException
+import androidx.credentials.exceptions.CreateCredentialException
+import androidx.credentials.exceptions.GetCredentialCancellationException
+import androidx.credentials.exceptions.GetCredentialException
+import androidx.credentials.exceptions.NoCredentialException
+
+object NostrCredentialSaver {
+    private const val TAG = "NostrCredentialSaver"
+
+    suspend fun saveNsec(context: Context, npub: String, nsec: String): Boolean {
+        return try {
+            val cm = CredentialManager.create(context)
+            val request = CreatePasswordRequest(id = npub, password = nsec)
+            cm.createCredential(context, request)
+            true
+        } catch (e: CreateCredentialCancellationException) {
+            Log.d(TAG, "User dismissed the save-credential prompt")
+            false
+        } catch (e: CreateCredentialException) {
+            Log.w(TAG, "Credential Manager could not save the nsec: ${e.type} ${e.message}")
+            false
+        } catch (e: Exception) {
+            Log.w(TAG, "Unexpected error saving nsec to password manager", e)
+            false
+        }
+    }
+
+    /**
+     * Asks Credential Manager for a saved password (nsec). Shows the system
+     * picker if any saved credentials match this app, otherwise returns null
+     * silently. The returned string is the password field of the chosen
+     * PasswordCredential — for accounts created through Wisp this is the nsec.
+     */
+    suspend fun loadSavedNsec(context: Context): String? {
+        return try {
+            val cm = CredentialManager.create(context)
+            val request = GetCredentialRequest(listOf(GetPasswordOption()))
+            val response = cm.getCredential(context, request)
+            (response.credential as? PasswordCredential)?.password
+        } catch (e: GetCredentialCancellationException) {
+            Log.d(TAG, "User dismissed the credential picker")
+            null
+        } catch (e: NoCredentialException) {
+            Log.d(TAG, "No saved credentials available")
+            null
+        } catch (e: GetCredentialException) {
+            Log.w(TAG, "Credential Manager could not load credentials: ${e.type} ${e.message}")
+            null
+        } catch (e: Exception) {
+            Log.w(TAG, "Unexpected error loading credentials", e)
+            null
+        }
+    }
+}

--- a/app/src/main/kotlin/com/darkwisp/app/ui/screen/KeysScreen.kt
+++ b/app/src/main/kotlin/com/darkwisp/app/ui/screen/KeysScreen.kt
@@ -44,9 +44,30 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.core.content.ContextCompat
 import androidx.fragment.app.FragmentActivity
+import android.graphics.Bitmap
+import android.graphics.Color as AndroidColor
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.outlined.QrCode
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.TextButton
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.asImageBitmap
+import androidx.compose.ui.layout.ContentScale
+import coil3.compose.AsyncImage
+import com.google.zxing.BarcodeFormat
+import com.google.zxing.EncodeHintType
+import com.google.zxing.qrcode.QRCodeWriter
+import com.google.zxing.qrcode.decoder.ErrorCorrectionLevel
 import com.darkwisp.app.R
 import com.darkwisp.app.nostr.Nip19
+import com.darkwisp.app.nostr.toHex
 import com.darkwisp.app.repo.KeyRepository
+import com.darkwisp.app.ui.component.QrCodeDialog
 
 private fun android.content.Context.findFragmentActivity(): FragmentActivity? {
     var ctx = this
@@ -61,11 +82,15 @@ private fun android.content.Context.findFragmentActivity(): FragmentActivity? {
 @Composable
 fun KeysScreen(
     keyRepository: KeyRepository,
-    onBack: () -> Unit
+    onBack: () -> Unit,
+    avatarUrl: String? = null
 ) {
     val keypair = remember { keyRepository.getKeypair() }
     val npub = remember { keypair?.let { Nip19.npubEncode(it.pubkey) } }
+    val pubkeyHex = remember { keypair?.pubkey?.toHex() }
     var nsec by remember { mutableStateOf<String?>(null) }
+    var showNpubQr by remember { mutableStateOf(false) }
+    var showNsecQr by remember { mutableStateOf(false) }
     val clipboardManager = LocalClipboardManager.current
     val context = LocalContext.current
 
@@ -118,7 +143,14 @@ fun KeysScreen(
                         maxLines = 1,
                         overflow = TextOverflow.Ellipsis
                     )
-                    Spacer(modifier = Modifier.width(8.dp))
+                    Spacer(modifier = Modifier.width(4.dp))
+                    IconButton(onClick = { if (pubkeyHex != null) showNpubQr = true }) {
+                        Icon(
+                            Icons.Outlined.QrCode,
+                            contentDescription = stringResource(R.string.cd_show_qr_code),
+                            tint = MaterialTheme.colorScheme.primary
+                        )
+                    }
                     IconButton(onClick = {
                         npub?.let {
                             clipboardManager.setText(AnnotatedString(it))
@@ -132,6 +164,14 @@ fun KeysScreen(
                         )
                     }
                 }
+            }
+
+            if (showNpubQr && pubkeyHex != null) {
+                QrCodeDialog(
+                    pubkeyHex = pubkeyHex,
+                    avatarUrl = avatarUrl,
+                    onDismiss = { showNpubQr = false }
+                )
             }
 
             Spacer(modifier = Modifier.height(24.dp))
@@ -161,7 +201,14 @@ fun KeysScreen(
                             maxLines = 1,
                             overflow = TextOverflow.Ellipsis
                         )
-                        Spacer(modifier = Modifier.width(8.dp))
+                        Spacer(modifier = Modifier.width(4.dp))
+                        IconButton(onClick = { showNsecQr = true }) {
+                            Icon(
+                                Icons.Outlined.QrCode,
+                                contentDescription = stringResource(R.string.cd_show_qr_code),
+                                tint = MaterialTheme.colorScheme.primary
+                            )
+                        }
                         IconButton(onClick = {
                             nsec?.let { key ->
                                 val clip = ClipData.newPlainText("", key)
@@ -182,6 +229,10 @@ fun KeysScreen(
                             )
                         }
                     }
+                }
+
+                if (showNsecQr) {
+                    nsec?.let { NsecQrDialog(nsec = it, avatarUrl = avatarUrl, onDismiss = { showNsecQr = false }) }
                 }
             } else {
                 Button(
@@ -238,4 +289,73 @@ fun KeysScreen(
             )
         }
     }
+}
+
+@Composable
+private fun NsecQrDialog(nsec: String, avatarUrl: String? = null, onDismiss: () -> Unit) {
+    val qrBitmap = remember(nsec) {
+        val hints = mapOf(EncodeHintType.ERROR_CORRECTION to ErrorCorrectionLevel.M)
+        val writer = QRCodeWriter()
+        val size = 512
+        val matrix = writer.encode(nsec, BarcodeFormat.QR_CODE, size, size, hints)
+        val bmp = Bitmap.createBitmap(matrix.width, matrix.height, Bitmap.Config.RGB_565)
+        for (x in 0 until matrix.width)
+            for (y in 0 until matrix.height)
+                bmp.setPixel(x, y, if (matrix[x, y]) AndroidColor.BLACK else AndroidColor.WHITE)
+        bmp
+    }
+
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = { Text(stringResource(R.string.keys_nsec_qr_title)) },
+        text = {
+            Column(
+                horizontalAlignment = Alignment.CenterHorizontally,
+                modifier = Modifier.fillMaxWidth()
+            ) {
+                Text(
+                    text = stringResource(R.string.keys_nsec_qr_warning),
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.error
+                )
+                Spacer(Modifier.height(16.dp))
+                Box(
+                    contentAlignment = Alignment.Center,
+                    modifier = Modifier
+                        .size(240.dp)
+                        .clip(RoundedCornerShape(12.dp))
+                        .background(androidx.compose.ui.graphics.Color.White)
+                        .padding(8.dp)
+                ) {
+                    Image(
+                        bitmap = qrBitmap.asImageBitmap(),
+                        contentDescription = stringResource(R.string.keys_nsec_qr_title),
+                        contentScale = ContentScale.Fit,
+                        modifier = Modifier.matchParentSize()
+                    )
+                    if (avatarUrl != null) {
+                        Box(
+                            modifier = Modifier
+                                .size(44.dp)
+                                .clip(CircleShape)
+                                .background(androidx.compose.ui.graphics.Color.White)
+                                .padding(3.dp)
+                        ) {
+                            AsyncImage(
+                                model = avatarUrl,
+                                contentDescription = null,
+                                contentScale = ContentScale.Crop,
+                                modifier = Modifier
+                                    .matchParentSize()
+                                    .clip(CircleShape)
+                            )
+                        }
+                    }
+                }
+            }
+        },
+        confirmButton = {
+            TextButton(onClick = onDismiss) { Text(stringResource(R.string.btn_done)) }
+        }
+    )
 }

--- a/app/src/main/kotlin/com/darkwisp/app/ui/screen/SplashScreen.kt
+++ b/app/src/main/kotlin/com/darkwisp/app/ui/screen/SplashScreen.kt
@@ -1,6 +1,9 @@
 package com.darkwisp.app.ui.screen
 
-import androidx.compose.foundation.Image
+import androidx.activity.ComponentActivity
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.BoxWithConstraints
@@ -12,24 +15,46 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.statusBarsPadding
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.outlined.QrCodeScanner
+import androidx.compose.material.icons.outlined.Visibility
+import androidx.compose.material.icons.outlined.VisibilityOff
 import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.Card
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Text
+import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.draw.drawBehind
+import androidx.compose.ui.focus.onFocusChanged
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
 import androidx.compose.animation.core.LinearEasing
 import androidx.compose.animation.core.RepeatMode
@@ -37,34 +62,76 @@ import androidx.compose.animation.core.animateFloat
 import androidx.compose.animation.core.infiniteRepeatable
 import androidx.compose.animation.core.rememberInfiniteTransition
 import androidx.compose.animation.core.tween
-import androidx.compose.ui.draw.drawBehind
-import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.text.input.PasswordVisualTransformation
+import androidx.compose.ui.text.input.VisualTransformation
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.compose.ui.res.stringResource
 import coil3.compose.AsyncImage
-import androidx.compose.foundation.layout.statusBarsPadding
 import com.darkwisp.app.R
+import com.darkwisp.app.auth.NostrCredentialSaver
+import com.darkwisp.app.nostr.RemoteSignerBridge
+import com.darkwisp.app.nostr.toHex
+import com.darkwisp.app.ui.component.QrScanner
 import com.darkwisp.app.ui.component.TorCornerButton
+import com.darkwisp.app.viewmodel.AuthViewModel
 import com.darkwisp.app.viewmodel.LiveMetrics
 import com.darkwisp.app.viewmodel.SplashViewModel
+import kotlinx.coroutines.launch
 
 private val AVATAR_SIZE = 44.dp
 private val AVATAR_GAP = 4.dp
 
+// Permission set requested from a NIP-55 signer (Amber/Primal) at login.
+private const val SIGNER_PERMISSIONS =
+    """[{"type":"sign_event","kind":0},{"type":"sign_event","kind":1},{"type":"sign_event","kind":3},{"type":"sign_event","kind":5},{"type":"sign_event","kind":6},{"type":"sign_event","kind":7},{"type":"sign_event","kind":13},{"type":"sign_event","kind":9734},{"type":"sign_event","kind":10000},{"type":"sign_event","kind":10001},{"type":"sign_event","kind":10002},{"type":"sign_event","kind":10030},{"type":"sign_event","kind":10063},{"type":"sign_event","kind":22242},{"type":"sign_event","kind":24242},{"type":"sign_event","kind":30000},{"type":"sign_event","kind":30003},{"type":"sign_event","kind":30030},{"type":"nip44_encrypt"},{"type":"nip44_decrypt"}]"""
+
 @Composable
 fun SplashScreen(
     viewModel: SplashViewModel,
-    onSignUp: () -> Unit,
-    onLogIn: () -> Unit,
+    authViewModel: AuthViewModel,
+    onAccountCreated: () -> Unit,
+    onLoggedIn: () -> Unit,
     onToggleTor: (Boolean) -> Unit = {}
 ) {
     val profilePictures by viewModel.profilePictures.collectAsState()
     val liveMetrics by viewModel.liveMetrics.collectAsState()
     val backgroundColor = MaterialTheme.colorScheme.background
     val surfaceVariant = MaterialTheme.colorScheme.surfaceVariant
+    val context = LocalContext.current
+
+    var showNostrSheet by remember { mutableStateOf(false) }
+    var showQrScanner by remember { mutableStateOf(false) }
+
+    // Signer login completes during an activity-result callback (STARTED), so
+    // we defer navigation to the next RESUMED frame to avoid a dropped nav.
+    var signerLoginComplete by remember { mutableStateOf(false) }
+    if (signerLoginComplete) {
+        LaunchedEffect(Unit) {
+            signerLoginComplete = false
+            showNostrSheet = false
+            onLoggedIn()
+        }
+    }
+
+    val signerLauncher = rememberLauncherForActivityResult(
+        ActivityResultContracts.StartActivityForResult()
+    ) { result ->
+        val data = result.data ?: return@rememberLauncherForActivityResult
+        val payload = data.getStringExtra("result") ?: return@rememberLauncherForActivityResult
+        val pkg = data.getStringExtra("package")
+        // Amber returns npub bech32 — decode to hex.
+        val pubkeyHex = if (payload.startsWith("npub1")) {
+            try { com.darkwisp.app.nostr.Nip19.npubDecode(payload).toHex() } catch (_: Exception) { return@rememberLauncherForActivityResult }
+        } else {
+            payload
+        }
+        authViewModel.loginWithSigner(pubkeyHex, pkg)
+        signerLoginComplete = true
+    }
 
     BoxWithConstraints(modifier = Modifier.fillMaxSize().background(backgroundColor)) {
         val cols = ((maxWidth + AVATAR_GAP) / (AVATAR_SIZE + AVATAR_GAP)).toInt().coerceAtLeast(1)
@@ -86,8 +153,6 @@ fun SplashScreen(
                         val idx = row * cols + col
                         if (idx >= pics.size) break
                         val url = pics[idx]
-                        // Background circle always visible; image loads on top.
-                        // Slow or failed loads show the filled circle instead of a gap.
                         Box(
                             modifier = Modifier
                                 .size(AVATAR_SIZE)
@@ -123,7 +188,7 @@ fun SplashScreen(
                 )
         )
 
-        // Logo, tagline, and action buttons pinned to bottom
+        // Logo and primary action pinned to bottom
         Column(
             horizontalAlignment = Alignment.CenterHorizontally,
             modifier = Modifier
@@ -187,19 +252,32 @@ fun SplashScreen(
             Spacer(Modifier.height(32.dp))
 
             Button(
-                onClick = onSignUp,
-                modifier = Modifier.fillMaxWidth()
+                onClick = { showNostrSheet = true },
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .height(48.dp),
+                shape = RoundedCornerShape(24.dp),
+                colors = ButtonDefaults.buttonColors(
+                    containerColor = Color(0xFF1A0E2E),
+                    contentColor = Color(0xFFE9DDFF)
+                ),
+                border = BorderStroke(1.dp, Color(0xFF8E30EB))
             ) {
-                Text(stringResource(R.string.splash_create_account))
-            }
-
-            Spacer(Modifier.height(8.dp))
-
-            OutlinedButton(
-                onClick = onLogIn,
-                modifier = Modifier.fillMaxWidth()
-            ) {
-                Text(stringResource(R.string.splash_log_in))
+                Icon(
+                    painter = painterResource(R.drawable.ic_nostr_ostrich),
+                    contentDescription = null,
+                    tint = Color.Unspecified,
+                    modifier = Modifier.size(22.dp)
+                )
+                Spacer(Modifier.width(12.dp))
+                Text(
+                    text = stringResource(R.string.splash_continue_with_nostr),
+                    style = MaterialTheme.typography.labelLarge.copy(
+                        fontFamily = FontFamily.SansSerif,
+                        fontWeight = FontWeight.Medium,
+                        fontSize = 15.sp
+                    )
+                )
             }
         }
 
@@ -210,6 +288,228 @@ fun SplashScreen(
                 .statusBarsPadding()
                 .padding(8.dp)
         )
+    }
+
+    if (showNostrSheet) {
+        NostrLoginSheet(
+            authViewModel = authViewModel,
+            signerAvailable = remember { RemoteSignerBridge.isSignerAvailable(context) },
+            onDismiss = { showNostrSheet = false },
+            onAccountCreated = {
+                showNostrSheet = false
+                onAccountCreated()
+            },
+            onLoggedIn = {
+                showNostrSheet = false
+                onLoggedIn()
+            },
+            onScanQr = {
+                showNostrSheet = false
+                showQrScanner = true
+            },
+            onLoginWithSigner = {
+                signerLauncher.launch(RemoteSignerBridge.buildGetPublicKeyIntent(SIGNER_PERMISSIONS))
+            }
+        )
+    }
+
+    if (showQrScanner) {
+        androidx.compose.ui.window.Dialog(
+            onDismissRequest = { showQrScanner = false },
+            properties = androidx.compose.ui.window.DialogProperties(
+                usePlatformDefaultWidth = false,
+                dismissOnBackPress = true,
+                dismissOnClickOutside = false
+            )
+        ) {
+            Box(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .background(Color.Black)
+            ) {
+                QrScanner(
+                    onResult = { raw ->
+                        showQrScanner = false
+                        authViewModel.updateNsecInput(raw.trim())
+                        if (authViewModel.logIn()) onLoggedIn()
+                    },
+                    modifier = Modifier.fillMaxSize(),
+                    promptText = "Scan nsec, npub, or nprofile QR"
+                )
+            }
+        }
+    }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun NostrLoginSheet(
+    authViewModel: AuthViewModel,
+    signerAvailable: Boolean,
+    onDismiss: () -> Unit,
+    onAccountCreated: () -> Unit,
+    onLoggedIn: () -> Unit,
+    onScanQr: () -> Unit,
+    onLoginWithSigner: () -> Unit
+) {
+    val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
+    val context = LocalContext.current
+    val scope = rememberCoroutineScope()
+    val nsecInput by authViewModel.nsecInput.collectAsState()
+    val error by authViewModel.error.collectAsState()
+    var nsecVisible by remember { mutableStateOf(false) }
+    var isCreating by remember { mutableStateOf(false) }
+    var autofillRequested by remember { mutableStateOf(false) }
+
+    ModalBottomSheet(
+        onDismissRequest = { if (!isCreating) onDismiss() },
+        sheetState = sheetState
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 24.dp)
+                .padding(bottom = 32.dp),
+            horizontalAlignment = Alignment.CenterHorizontally
+        ) {
+            Icon(
+                painter = painterResource(R.drawable.ic_nostr_ostrich),
+                contentDescription = stringResource(R.string.cd_nostr_logo),
+                tint = Color.Unspecified,
+                modifier = Modifier.size(48.dp)
+            )
+            Spacer(Modifier.height(12.dp))
+            Text(
+                text = stringResource(R.string.nostr_sheet_title),
+                style = MaterialTheme.typography.titleLarge.copy(
+                    fontWeight = FontWeight.W600
+                ),
+                color = MaterialTheme.colorScheme.onSurface
+            )
+            Spacer(Modifier.height(6.dp))
+            Text(
+                text = stringResource(R.string.nostr_sheet_body),
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+
+            Spacer(Modifier.height(20.dp))
+
+            OutlinedTextField(
+                value = nsecInput,
+                onValueChange = { authViewModel.updateNsecInput(it) },
+                label = { Text(stringResource(R.string.auth_nsec_or_npub)) },
+                singleLine = true,
+                visualTransformation = if (nsecVisible) VisualTransformation.None else PasswordVisualTransformation(),
+                keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Password),
+                trailingIcon = {
+                    Row {
+                        IconButton(onClick = { nsecVisible = !nsecVisible }) {
+                            Icon(
+                                imageVector = if (nsecVisible) Icons.Outlined.VisibilityOff else Icons.Outlined.Visibility,
+                                contentDescription = if (nsecVisible) stringResource(R.string.auth_hide_key) else stringResource(R.string.auth_show_key)
+                            )
+                        }
+                        IconButton(onClick = onScanQr) {
+                            Icon(
+                                imageVector = Icons.Outlined.QrCodeScanner,
+                                contentDescription = stringResource(R.string.btn_scan_qr)
+                            )
+                        }
+                    }
+                },
+                enabled = !isCreating,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .onFocusChanged { focusState ->
+                        if (focusState.isFocused && !autofillRequested && nsecInput.isBlank()) {
+                            autofillRequested = true
+                            val activity = context as? ComponentActivity
+                                ?: return@onFocusChanged
+                            scope.launch {
+                                val saved = NostrCredentialSaver.loadSavedNsec(activity)
+                                if (!saved.isNullOrBlank() && authViewModel.nsecInput.value.isBlank()) {
+                                    authViewModel.updateNsecInput(saved)
+                                }
+                            }
+                        }
+                    }
+            )
+
+            Spacer(Modifier.height(12.dp))
+
+            Button(
+                onClick = {
+                    if (authViewModel.logIn()) onLoggedIn()
+                },
+                enabled = nsecInput.isNotBlank() && !isCreating,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .height(48.dp),
+                shape = RoundedCornerShape(24.dp)
+            ) {
+                Text(stringResource(R.string.auth_log_in))
+            }
+
+            if (signerAvailable) {
+                Spacer(Modifier.height(8.dp))
+                OutlinedButton(
+                    onClick = onLoginWithSigner,
+                    enabled = !isCreating,
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .height(48.dp),
+                    shape = RoundedCornerShape(24.dp)
+                ) {
+                    Text(stringResource(R.string.auth_login_with_signer))
+                }
+            }
+
+            Spacer(Modifier.height(20.dp))
+            HorizontalDivider(color = MaterialTheme.colorScheme.outline.copy(alpha = 0.5f))
+            Spacer(Modifier.height(20.dp))
+
+            OutlinedButton(
+                onClick = {
+                    if (isCreating) return@OutlinedButton
+                    scope.launch {
+                        isCreating = true
+                        try {
+                            if (authViewModel.signUp()) {
+                                val nsec = authViewModel.getCurrentNsec()
+                                val npub = authViewModel.npub.value
+                                val activity = context as? ComponentActivity
+                                if (activity != null && nsec != null && npub != null) {
+                                    NostrCredentialSaver.saveNsec(activity, npub, nsec)
+                                }
+                                onAccountCreated()
+                            }
+                        } finally {
+                            isCreating = false
+                        }
+                    }
+                },
+                enabled = !isCreating,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .height(48.dp),
+                shape = RoundedCornerShape(24.dp)
+            ) {
+                Text(
+                    if (isCreating) stringResource(R.string.nostr_sheet_creating)
+                    else stringResource(R.string.nostr_sheet_create)
+                )
+            }
+
+            error?.let {
+                Spacer(Modifier.height(12.dp))
+                Text(
+                    text = it,
+                    color = MaterialTheme.colorScheme.error,
+                    style = MaterialTheme.typography.bodySmall
+                )
+            }
+        }
     }
 }
 
@@ -235,10 +535,4 @@ private fun OnlineCard(metrics: LiveMetrics) {
             )
         }
     }
-}
-
-private fun formatCount(n: Int): String = when {
-    n >= 1_000_000 -> "${"%.1f".format(n / 1_000_000f)}M"
-    n >= 1_000 -> "${"%.1f".format(n / 1_000f)}k"
-    else -> n.toString()
 }

--- a/app/src/main/kotlin/com/darkwisp/app/viewmodel/AuthViewModel.kt
+++ b/app/src/main/kotlin/com/darkwisp/app/viewmodel/AuthViewModel.kt
@@ -39,6 +39,12 @@ class AuthViewModel(app: Application) : AndroidViewModel(app) {
         _error.value = null
     }
 
+    /** nsec for the active local account, or null when read-only / signer-backed. */
+    fun getCurrentNsec(): String? {
+        val keypair = keyRepo.getKeypair() ?: return null
+        return Nip19.nsecEncode(keypair.privkey)
+    }
+
     fun signUp(): Boolean {
         return try {
             val keypair = Keys.generate()

--- a/app/src/main/res/drawable/ic_nostr_ostrich.xml
+++ b/app/src/main/res/drawable/ic_nostr_ostrich.xml
@@ -1,0 +1,22 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="27dp"
+    android:viewportWidth="240"
+    android:viewportHeight="270">
+
+    <path
+        android:fillColor="#FD962C"
+        android:pathData="M105,225 L135,225 L135,255 L105,255 Z" />
+
+    <path
+        android:fillColor="#FD962C"
+        android:pathData="M165,225 L195,225 L195,255 L165,255 Z" />
+
+    <path
+        android:fillColor="#FD962C"
+        android:pathData="M195,75 L225,75 L225,105 L195,105 Z" />
+
+    <path
+        android:fillColor="#A223E9"
+        android:pathData="M165,45 L165,15 L135,15 L135,45 L135,75 L135,105 L105,105 L75,105 L45,105 L15,105 L15,135 L45,135 L45,165 L75,165 L75,195 L105,195 L105,225 L135,225 L135,195 L165,195 L165,225 L195,225 L195,195 L195,165 L195,135 L195,105 L195,75 L195,45 L165,45 Z" />
+</vector>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -59,6 +59,12 @@
     <string name="cd_wisp_logo">Dark Wisp logo</string>
 
     <!-- Auth Screen -->
+    <string name="splash_continue_with_nostr">Continue with Nostr</string>
+    <string name="cd_nostr_logo">Nostr logo</string>
+    <string name="nostr_sheet_title">Continue with Nostr</string>
+    <string name="nostr_sheet_body">Enter your existing key, or create a new account. Your key never leaves the device.</string>
+    <string name="nostr_sheet_create">Create new account</string>
+    <string name="nostr_sheet_creating">Creating…</string>
     <string name="auth_sign_up">Sign Up</string>
     <string name="auth_log_in">Log In</string>
     <string name="auth_login_with_signer">Login with Signer</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -61,6 +61,8 @@
     <!-- Auth Screen -->
     <string name="splash_continue_with_nostr">Continue with Nostr</string>
     <string name="cd_nostr_logo">Nostr logo</string>
+    <string name="keys_nsec_qr_title">Private key QR</string>
+    <string name="keys_nsec_qr_warning">Only show this to devices you trust. Anyone who scans it gains full control of your account.</string>
     <string name="nostr_sheet_title">Continue with Nostr</string>
     <string name="nostr_sheet_body">Enter your existing key, or create a new account. Your key never leaves the device.</string>
     <string name="nostr_sheet_create">Create new account</string>

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -30,6 +30,7 @@ kmp-tor-resource = "408.16.4"
 activity-compose = "1.9.3"
 navigation-compose = "2.8.5"
 lifecycle = "2.8.7"
+credentials = "1.3.0"
 
 [libraries]
 compose-bom = { group = "androidx.compose", name = "compose-bom", version.ref = "compose-bom" }
@@ -39,6 +40,7 @@ compose-material3 = { group = "androidx.compose.material3", name = "material3" }
 compose-icons-extended = { group = "androidx.compose.material", name = "material-icons-extended" }
 activity-compose = { group = "androidx.activity", name = "activity-compose", version.ref = "activity-compose" }
 navigation-compose = { group = "androidx.navigation", name = "navigation-compose", version.ref = "navigation-compose" }
+androidx-credentials = { group = "androidx.credentials", name = "credentials", version.ref = "credentials" }
 lifecycle-viewmodel-compose = { group = "androidx.lifecycle", name = "lifecycle-viewmodel-compose", version.ref = "lifecycle" }
 lifecycle-runtime-compose = { group = "androidx.lifecycle", name = "lifecycle-runtime-compose", version.ref = "lifecycle" }
 okhttp = { group = "com.squareup.okhttp3", name = "okhttp", version.ref = "okhttp" }


### PR DESCRIPTION
## Summary

Ports the redesigned sign-in flow and key QR display from wisp (#536, #552), **without Google sign-in / Drive backup**. dark-wisp already ships zero Google code, so only the base `androidx.credentials` (Credential Manager) dependency was added — no Play Services.

### Continue with Nostr sheet
- Splash's two buttons collapse into a single purple **"Continue with Nostr"** action that opens a bottom sheet
- Sheet has: nsec/npub field with show/hide + **QR-scan icon**, **Log In**, **Login with Signer** (retained — upstream removed it), and **Create new account**
- QR scan reuses the existing `QrScanner`; a scanned `nsec`/`npub`/`nprofile` fills the field and logs in
- Key autofill via Android Credential Manager (no Google): saves nsec on account creation, offers it on field focus
- New pixel-ostrich logo; `getCurrentNsec()` added to `AuthViewModel`
- Splash now hosts login for both first-login and add-account; `onLoggedIn` mirrors the old `AuthScreen` routing with `popUpTo(SPLASH)`

### Keys screen QR codes
- QR icon beside the npub copy button → opens `QrCodeDialog`
- Once the private key is revealed (behind device-credential auth), a QR icon beside the nsec copy button → opens `NsecQrDialog` with a "only show to trusted devices" warning
- Both render the user's profile avatar in the QR center

## Notes
- Google sign-in, Drive backup, and watch-only-mode UI gating were intentionally **excluded**; nsec/npub manual entry and NIP-55 signer login are retained
- The old full-screen `AuthScreen`/`AUTH` route is now unreachable (left in place, harmless) — can delete in a follow-up if desired

## Test plan

- [ ] Paste nsec → Log In; paste npub → read-only login
- [ ] QR scan fills the key and logs in
- [ ] Login with Signer (Amber)
- [ ] Create new account → onboarding; nsec offered to save
- [ ] Add-account from the drawer routes through the same sheet
- [ ] Keys screen: npub QR shows; reveal key → nsec QR shows; both show avatar