### PR TITLE
fix(richcontent): preserve blank lines before inline profile/hashtag segments

### DIFF
--- a/app/src/main/kotlin/com/darkwisp/app/ui/component/RichContent.kt
+++ b/app/src/main/kotlin/com/darkwisp/app/ui/component/RichContent.kt
@@ -394,7 +394,7 @@ internal fun parseContent(content: String, emojiMap: Map<String, String> = empty
     if (trimBlankLines) for (i in 0 until finalResult.size - 1) {
         val segment = finalResult[i]
         val next = finalResult[i + 1]
-        if (segment is ContentSegment.TextSegment && next !is ContentSegment.TextSegment && next !is ContentSegment.InlineLinkSegment && next !is ContentSegment.CustomEmojiSegment) {
+        if (segment is ContentSegment.TextSegment && next !is ContentSegment.TextSegment && next !is ContentSegment.InlineLinkSegment && next !is ContentSegment.CustomEmojiSegment && next !is ContentSegment.NostrProfileSegment && next !is ContentSegment.HashtagSegment) {
             val trimmed = segment.text.trimEnd('\n')
             if (trimmed != segment.text) {
                 finalResult[i] = ContentSegment.TextSegment(if (trimmed.isEmpty()) trimmed else "$trimmed\n")


### PR DESCRIPTION
## Summary

Notes whose paragraphs start with a \`nostr:\` profile mention were missing blank lines between paragraphs on Android. iOS was unaffected because it renders note content through a different path.

## Root cause

\`parseContent()\` has a final pass (\`trimBlankLines\`) that trims trailing \`\n\n\` from a \`TextSegment\` when the next segment is a block-level element (image, embed, standalone link). This prevents double-spacing when a \`Column\` with \`Arrangement.spacedBy(8.dp)\` adds its own gap before the block.

However, \`NostrProfileSegment\` and \`HashtagSegment\` were **not** in the exclusion list, even though they are **inline** — they share a single \`Text()\` composable with surrounding text and receive no extra Column spacing. Any \`\n\n\` before them was silently collapsed to \`\n\`.

A note crediting several people (each paragraph starting with a \`nostr:npub\` mention) lost every blank line between paragraphs.

## Fix

One-line change: add \`NostrProfileSegment\` and \`HashtagSegment\` to the same exclusion list already used for \`TextSegment\`, \`InlineLinkSegment\`, and \`CustomEmojiSegment\`.

## Test plan

- [ ] Open a note where paragraphs start with \`nostr:\` profile mentions — blank lines now visible
- [ ] Notes with images/videos still show no double-spacing before media
- [ ] Notes with embedded quoted notes still trim correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)