### PR TITLE
feat(accounts): multi-account switcher + cancel add-account flow

### DIFF
--- a/app/src/main/kotlin/com/darkwisp/app/Navigation.kt
+++ b/app/src/main/kotlin/com/darkwisp/app/Navigation.kt
@@ -330,6 +330,7 @@ fun WispNavHost(
 
     val onAddAccount: () -> Unit = {
         if (anonMode != null) feedViewModel.exitAnonMode()
+        authViewModel.previousAccountPubkey = authViewModel.keyRepo.getPubkeyHex()
         authViewModel.isAddingAccount = true
         feedViewModel.resetForAccountSwitch()
         walletViewModel.suspendForAccountSwitch()  // disconnect only, preserve credentials
@@ -703,7 +704,28 @@ fun WispNavHost(
                 onLogIn = {
                     navController.navigate(Routes.AUTH)
                 },
-                onToggleTor = { feedViewModel.setTorEnabled(it) }
+                onToggleTor = { feedViewModel.setTorEnabled(it) },
+                onCancel = if (authViewModel.isAddingAccount) {
+                    {
+                        val prev = authViewModel.previousAccountPubkey
+                        authViewModel.isAddingAccount = false
+                        authViewModel.previousAccountPubkey = null
+                        if (anonMode != null) feedViewModel.exitAnonMode()
+                        if (prev != null) {
+                            authViewModel.keyRepo.switchToAccount(prev)
+                            authViewModel.keyRepo.reloadPrefs(prev)
+                        }
+                        feedViewModel.reloadForNewAccount()
+                        relayViewModel.reload()
+                        blossomServersViewModel.reload()
+                        composeViewModel.reloadBlossomRepo()
+                        feedViewModel.initRelays()
+                        walletViewModel.refreshState()
+                        navController.navigate(Routes.LOADING) {
+                            popUpTo(Routes.SPLASH) { inclusive = true }
+                        }
+                    }
+                } else null
             )
         }
 

--- a/app/src/main/kotlin/com/darkwisp/app/ui/component/WispDrawerContent.kt
+++ b/app/src/main/kotlin/com/darkwisp/app/ui/component/WispDrawerContent.kt
@@ -3,6 +3,7 @@ package com.darkwisp.app.ui.component
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.foundation.background
 import androidx.compose.material3.HorizontalDivider
+import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
@@ -155,6 +156,54 @@ fun WispDrawerContent(
                 }) {
                     ProfilePicture(url = profile?.picture, size = 64)
                 }
+                Spacer(modifier = Modifier.width(8.dp))
+                val otherAccountCount = (accounts.size - 1).coerceAtLeast(0)
+                if (otherAccountCount == 0) {
+                    Box(
+                        modifier = Modifier
+                            .size(26.dp)
+                            .clip(CircleShape)
+                            .background(MaterialTheme.colorScheme.surfaceVariant)
+                            .clickable { onAddAccount() },
+                        contentAlignment = Alignment.Center
+                    ) {
+                        Icon(
+                            Icons.Filled.Add,
+                            contentDescription = "Add account",
+                            modifier = Modifier.size(16.dp),
+                            tint = MaterialTheme.colorScheme.onSurfaceVariant
+                        )
+                    }
+                } else {
+                    Row(
+                        verticalAlignment = Alignment.CenterVertically,
+                        modifier = Modifier.clickable { accountPickerExpanded = !accountPickerExpanded }
+                    ) {
+                        Box(
+                            modifier = Modifier
+                                .height(26.dp)
+                                .clip(CircleShape)
+                                .background(MaterialTheme.colorScheme.surfaceVariant)
+                                .padding(horizontal = 10.dp),
+                            contentAlignment = Alignment.Center
+                        ) {
+                            Text(
+                                text = "+ $otherAccountCount",
+                                style = MaterialTheme.typography.labelSmall,
+                                fontWeight = androidx.compose.ui.text.font.FontWeight.Bold,
+                                color = MaterialTheme.colorScheme.onSurfaceVariant
+                            )
+                        }
+                        Spacer(modifier = Modifier.width(2.dp))
+                        Icon(
+                            if (accountPickerExpanded) Icons.Outlined.KeyboardArrowDown
+                            else Icons.Outlined.KeyboardArrowRight,
+                            contentDescription = null,
+                            modifier = Modifier.size(18.dp),
+                            tint = MaterialTheme.colorScheme.onSurfaceVariant
+                        )
+                    }
+                }
                 Spacer(modifier = Modifier.weight(1f))
                 IconButton(onClick = onToggleTheme) {
                     Icon(
@@ -176,7 +225,7 @@ fun WispDrawerContent(
             Row(
                 modifier = Modifier
                     .fillMaxWidth()
-                    .clickable(enabled = accounts.size > 1 || accounts.isNotEmpty()) {
+                    .clickable(enabled = accounts.isNotEmpty()) {
                         accountPickerExpanded = !accountPickerExpanded
                     },
                 verticalAlignment = Alignment.CenterVertically
@@ -187,15 +236,6 @@ fun WispDrawerContent(
                     color = MaterialTheme.colorScheme.onSurface,
                     modifier = Modifier.weight(1f, fill = false)
                 )
-                if (accounts.size > 1 || accounts.isNotEmpty()) {
-                        Icon(
-                            if (accountPickerExpanded) Icons.Outlined.KeyboardArrowDown
-                            else Icons.Outlined.KeyboardArrowRight,
-                            contentDescription = stringResource(R.string.cd_switch_account),
-                        modifier = Modifier.size(20.dp),
-                        tint = MaterialTheme.colorScheme.onSurfaceVariant
-                    )
-                }
             }
             Spacer(Modifier.height(2.dp))
             if (!profile?.nip05.isNullOrBlank()) {

--- a/app/src/main/kotlin/com/darkwisp/app/ui/screen/SplashScreen.kt
+++ b/app/src/main/kotlin/com/darkwisp/app/ui/screen/SplashScreen.kt
@@ -1,6 +1,7 @@
 package com.darkwisp.app.ui.screen
 
 import androidx.compose.foundation.Image
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.BoxWithConstraints
@@ -59,7 +60,8 @@ fun SplashScreen(
     viewModel: SplashViewModel,
     onSignUp: () -> Unit,
     onLogIn: () -> Unit,
-    onToggleTor: (Boolean) -> Unit = {}
+    onToggleTor: (Boolean) -> Unit = {},
+    onCancel: (() -> Unit)? = null
 ) {
     val profilePictures by viewModel.profilePictures.collectAsState()
     val liveMetrics by viewModel.liveMetrics.collectAsState()
@@ -122,6 +124,21 @@ fun SplashScreen(
                     )
                 )
         )
+
+        if (onCancel != null) {
+            Text(
+                text = "Cancel",
+                style = MaterialTheme.typography.labelLarge,
+                color = androidx.compose.ui.graphics.Color.White,
+                modifier = Modifier
+                    .align(Alignment.BottomCenter)
+                    .padding(bottom = 120.dp)
+                    .clip(androidx.compose.foundation.shape.CircleShape)
+                    .background(androidx.compose.ui.graphics.Color.White.copy(alpha = 0.15f))
+                    .clickable(onClick = onCancel)
+                    .padding(horizontal = 28.dp, vertical = 12.dp)
+            )
+        }
 
         // Logo, tagline, and action buttons pinned to bottom
         Column(

--- a/app/src/main/kotlin/com/darkwisp/app/viewmodel/AuthViewModel.kt
+++ b/app/src/main/kotlin/com/darkwisp/app/viewmodel/AuthViewModel.kt
@@ -31,6 +31,7 @@ class AuthViewModel(app: Application) : AndroidViewModel(app) {
     val accountsFlow: StateFlow<List<AccountInfo>> = keyRepo.accountsFlow
 
     var isAddingAccount: Boolean = false
+    var previousAccountPubkey: String? = null
 
     val isLoggedIn: Boolean get() = keyRepo.isLoggedIn()
 


### PR DESCRIPTION
## Summary

- **Drawer header**: persistent `+` circle (solo account) or `+ N` pill + chevron (multiple accounts) next to avatar, replacing the chevron beside the username — gives users an immediate affordance to add or switch accounts
- **Cancel flow**: when adding an account over an existing session, a frosted `Cancel` pill appears at the bottom of the splash screen; tapping it fully restores the previous account (switches back, reloads all ViewModels, navigates to LOADING)
- **AuthViewModel**: adds `previousAccountPubkey` field to track which account to restore on cancel

## Test plan

- [ ] Single account: `+` circle appears next to avatar in drawer header; tapping navigates to add-account splash
- [ ] Multiple accounts: `+ N` pill + chevron appears; tapping expands the account picker
- [ ] Adding account: Cancel pill appears at bottom of splash; tapping fully restores the previous session
- [ ] Drawer: no duplicate chevron beside username

🍳 Cooked by [Claude Code](https://claude.com/claude-code)