### PR TITLE
feat(wallet): on-chain receive/send, Receive redesign, tx history sheet

### DIFF
--- a/app/src/main/kotlin/com/darkwisp/app/nostr/Nip47.kt
+++ b/app/src/main/kotlin/com/darkwisp/app/nostr/Nip47.kt
@@ -49,7 +49,7 @@ object Nip47 {
         object GetBalance : NwcRequest()
         object GetInfo : NwcRequest()
         data class PayInvoice(val invoice: String) : NwcRequest()
-        data class MakeInvoice(val amountMsats: Long, val description: String) : NwcRequest()
+        data class MakeInvoice(val amountMsats: Long, val description: String, val expiry: Int? = null) : NwcRequest()
         data class ListTransactions(val limit: Int = 50, val offset: Int = 0) : NwcRequest()
     }
 
@@ -172,6 +172,7 @@ object Nip47 {
                 put("params", buildJsonObject {
                     put("amount", request.amountMsats)
                     put("description", request.description)
+                    request.expiry?.let { put("expiry", it) }
                 })
             }
             is NwcRequest.ListTransactions -> buildJsonObject {

--- a/app/src/main/kotlin/com/darkwisp/app/repo/NwcRepository.kt
+++ b/app/src/main/kotlin/com/darkwisp/app/repo/NwcRepository.kt
@@ -58,6 +58,9 @@ class NwcRepository(private val context: Context, private val relayPool: RelayPo
     private val _paymentReceived = MutableSharedFlow<Long>(extraBufferCapacity = 8)
     override val paymentReceived: SharedFlow<Long> = _paymentReceived
 
+    private val _transactionsChanged = MutableSharedFlow<Unit>(extraBufferCapacity = 8)
+    override val transactionsChanged: SharedFlow<Unit> = _transactionsChanged
+
     private fun emitStatus(msg: String) {
         Log.d(TAG, msg)
         _statusLog.tryEmit(msg)
@@ -348,10 +351,19 @@ class NwcRepository(private val context: Context, private val relayPool: RelayPo
         return result.map { (it as Nip47.NwcResponse.PayInvoiceResult).preimage }
     }
 
-    override suspend fun makeInvoice(amountMsats: Long, description: String): Result<String> {
-        val result = sendRequest(Nip47.NwcRequest.MakeInvoice(amountMsats, description))
+    override suspend fun makeInvoice(amountMsats: Long, description: String, expirySecs: Int): Result<String> {
+        val result = sendRequest(Nip47.NwcRequest.MakeInvoice(amountMsats, description, expirySecs))
         return result.map { (it as Nip47.NwcResponse.MakeInvoiceResult).invoice }
     }
+
+    override suspend fun getDepositAddress(): Result<String> =
+        Result.failure(UnsupportedOperationException("NWC does not support on-chain receive"))
+
+    override suspend fun prepareOnchainSend(address: String, amountSats: Long): Result<Pair<OnchainFeeQuote, Any>> =
+        Result.failure(UnsupportedOperationException("NWC does not support on-chain send"))
+
+    override suspend fun sendOnchain(prepareData: Any, speed: String): Result<String> =
+        Result.failure(UnsupportedOperationException("NWC does not support on-chain send"))
 
     suspend fun listNwcTransactions(limit: Int = 50, offset: Int = 0): Result<List<Nip47.Transaction>> {
         val result = sendRequest(Nip47.NwcRequest.ListTransactions(limit = limit, offset = offset))

--- a/app/src/main/kotlin/com/darkwisp/app/repo/SparkRepository.kt
+++ b/app/src/main/kotlin/com/darkwisp/app/repo/SparkRepository.kt
@@ -10,6 +10,7 @@ import breez_sdk_spark.EventListener
 import breez_sdk_spark.GetInfoRequest
 import breez_sdk_spark.ListPaymentsRequest
 import breez_sdk_spark.Network
+import breez_sdk_spark.OnchainConfirmationSpeed
 import breez_sdk_spark.PaymentDetails
 import breez_sdk_spark.PaymentType
 import breez_sdk_spark.PrepareSendPaymentRequest
@@ -100,6 +101,9 @@ class SparkRepository(
 
     private val _paymentReceived = MutableSharedFlow<Long>(extraBufferCapacity = 8)
     override val paymentReceived: SharedFlow<Long> = _paymentReceived
+
+    private val _transactionsChanged = MutableSharedFlow<Unit>(extraBufferCapacity = 8)
+    override val transactionsChanged: SharedFlow<Unit> = _transactionsChanged
 
     // Identity pubkey from the SDK's GetInfoResponse — exposed for the
     // Wallet Info expandable in settings. Populated on first balance fetch
@@ -267,15 +271,19 @@ class SparkRepository(
                             is SdkEvent.PaymentSucceeded -> {
                                 emitStatus("Payment succeeded")
                                 refreshBalanceInternal()
+                                _transactionsChanged.tryEmit(Unit)
                                 if (e.payment.paymentType == PaymentType.RECEIVE) {
                                     _paymentReceived.tryEmit(e.payment.amount.toLong() * 1000)
                                 }
                             }
                             is SdkEvent.PaymentFailed -> {
                                 emitStatus("Payment failed")
+                                _transactionsChanged.tryEmit(Unit)
                             }
                             is SdkEvent.PaymentPending -> {
                                 emitStatus("Payment pending")
+                                refreshBalanceInternal()
+                                _transactionsChanged.tryEmit(Unit)
                             }
                             else -> {}
                         }
@@ -425,7 +433,7 @@ class SparkRepository(
 
     // --- Receive ---
 
-    override suspend fun makeInvoice(amountMsats: Long, description: String): Result<String> =
+    override suspend fun makeInvoice(amountMsats: Long, description: String, expirySecs: Int): Result<String> =
         withContext(Dispatchers.IO) {
             try {
                 val instance = sdk ?: return@withContext Result.failure(Exception("Not connected"))
@@ -435,7 +443,7 @@ class SparkRepository(
                 val method = ReceivePaymentMethod.Bolt11Invoice(
                     description = description.ifEmpty { "Wisp wallet" },
                     amountSats = amountSats,
-                    expirySecs = 3600u,
+                    expirySecs = expirySecs.toUInt(),
                     paymentHash = null
                 )
                 val response = instance.receivePayment(ReceivePaymentRequest(method))
@@ -446,6 +454,58 @@ class SparkRepository(
                 Result.failure(e)
             }
         }
+
+    override suspend fun getDepositAddress(): Result<String> = withContext(Dispatchers.IO) {
+        try {
+            val instance = sdk ?: return@withContext Result.failure(Exception("Not connected"))
+            val response = instance.receivePayment(ReceivePaymentRequest(ReceivePaymentMethod.BitcoinAddress))
+            Result.success(response.paymentRequest)
+        } catch (e: Exception) {
+            Result.failure(e)
+        }
+    }
+
+    override suspend fun prepareOnchainSend(address: String, amountSats: Long): Result<Pair<OnchainFeeQuote, Any>> =
+        withContext(Dispatchers.IO) {
+            try {
+                val instance = sdk ?: return@withContext Result.failure(Exception("Not connected"))
+                val prepareReq = PrepareSendPaymentRequest(
+                    paymentRequest = address,
+                    amount = java.math.BigInteger.valueOf(amountSats)
+                )
+                val prepareResponse = instance.prepareSendPayment(prepareReq)
+                val method = prepareResponse.paymentMethod as? SendPaymentMethod.BitcoinAddress
+                    ?: return@withContext Result.failure(Exception("Not a Bitcoin address payment"))
+                val feeQuote = method.feeQuote
+                val quote = OnchainFeeQuote(
+                    fastFeeSats = (feeQuote.speedFast.userFeeSat + feeQuote.speedFast.l1BroadcastFeeSat).toLong(),
+                    mediumFeeSats = (feeQuote.speedMedium.userFeeSat + feeQuote.speedMedium.l1BroadcastFeeSat).toLong(),
+                    slowFeeSats = (feeQuote.speedSlow.userFeeSat + feeQuote.speedSlow.l1BroadcastFeeSat).toLong()
+                )
+                Result.success(Pair(quote, prepareResponse as Any))
+            } catch (e: Exception) {
+                Result.failure(e)
+            }
+        }
+
+    override suspend fun sendOnchain(prepareData: Any, speed: String): Result<String> = withContext(Dispatchers.IO) {
+        try {
+            val instance = sdk ?: return@withContext Result.failure(Exception("Not connected"))
+            val prepareResponse = prepareData as breez_sdk_spark.PrepareSendPaymentResponse
+            val confirmationSpeed = when (speed) {
+                "FAST" -> OnchainConfirmationSpeed.FAST
+                "SLOW" -> OnchainConfirmationSpeed.SLOW
+                else -> OnchainConfirmationSpeed.MEDIUM
+            }
+            val options = SendPaymentOptions.BitcoinAddress(confirmationSpeed = confirmationSpeed)
+            val sendResponse = instance.sendPayment(SendPaymentRequest(prepareResponse, options))
+            emitStatus("Bitcoin sent")
+            Result.success(sendResponse.payment.id)
+        } catch (e: Exception) {
+            emitStatus("Bitcoin send failed: ${e.message}")
+            Result.failure(e)
+        }
+    }
 
     // --- Sync polling ---
 

--- a/app/src/main/kotlin/com/darkwisp/app/repo/SparkRepository.kt
+++ b/app/src/main/kotlin/com/darkwisp/app/repo/SparkRepository.kt
@@ -533,17 +533,25 @@ class SparkRepository(
                 ))
                 val transactions = response.payments.map { payment ->
                     val lightningDetails = payment.details as? PaymentDetails.Lightning
+                    val depositDetails = payment.details as? PaymentDetails.Deposit
+                    val withdrawDetails = payment.details as? PaymentDetails.Withdraw
+                    val onchain = depositDetails != null || withdrawDetails != null
 
-                    // Prefer bolt11-decoded hash (matches ZapSender records), fall back to HTLC hash, then payment ID
-                    val decoded = lightningDetails?.invoice?.let {
-                        com.darkwisp.app.nostr.Bolt11.decode(it)
+                    val paymentHash = when {
+                        onchain -> depositDetails?.txId ?: withdrawDetails?.txId ?: payment.id
+                        else -> {
+                            // Prefer bolt11-decoded hash (matches ZapSender records), fall back to HTLC hash, then payment ID
+                            val decoded = lightningDetails?.invoice?.let {
+                                com.darkwisp.app.nostr.Bolt11.decode(it)
+                            }
+                            val htlcHash = lightningDetails?.htlcDetails?.paymentHash?.lowercase()
+                            decoded?.paymentHash ?: htlcHash ?: payment.id
+                        }
                     }
-                    val htlcHash = lightningDetails?.htlcDetails?.paymentHash?.lowercase()
-                    val paymentHash = decoded?.paymentHash ?: htlcHash ?: payment.id
                     // Prefer Spark's description, fall back to bolt11 description
                     // (bolt11 tag 13 may contain the kind 9734 zap request JSON)
                     val description = lightningDetails?.description
-                        ?: decoded?.description
+                        ?: lightningDetails?.invoice?.let { com.darkwisp.app.nostr.Bolt11.decode(it)?.description }
 
                     WalletTransaction(
                         type = when (payment.paymentType) {
@@ -555,7 +563,9 @@ class SparkRepository(
                         amountMsats = payment.amount.toLong() * 1000,
                         feeMsats = payment.fees.toLong() * 1000,
                         createdAt = payment.timestamp.toLong(),
-                        settledAt = payment.timestamp.toLong()
+                        settledAt = payment.timestamp.toLong(),
+                        pending = payment.status == breez_sdk_spark.PaymentStatus.PENDING,
+                        isOnchain = onchain
                     )
                 }
                 Result.success(transactions)

--- a/app/src/main/kotlin/com/darkwisp/app/repo/WalletProvider.kt
+++ b/app/src/main/kotlin/com/darkwisp/app/repo/WalletProvider.kt
@@ -3,6 +3,12 @@ package com.darkwisp.app.repo
 import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.StateFlow
 
+data class OnchainFeeQuote(
+    val fastFeeSats: Long,
+    val mediumFeeSats: Long,
+    val slowFeeSats: Long
+)
+
 interface WalletProvider {
     val balance: StateFlow<Long?>
     val isConnected: StateFlow<Boolean>
@@ -11,13 +17,25 @@ interface WalletProvider {
     /** Emits the amount in msats whenever an incoming payment is received. */
     val paymentReceived: SharedFlow<Long>
 
+    /** Emits Unit whenever the transaction list should be refreshed. */
+    val transactionsChanged: SharedFlow<Unit>
+
     fun hasConnection(): Boolean
     fun connect()
     fun disconnect()
     suspend fun fetchBalance(): Result<Long>
     suspend fun payInvoice(bolt11: String): Result<String>
-    suspend fun makeInvoice(amountMsats: Long, description: String): Result<String>
+    suspend fun makeInvoice(amountMsats: Long, description: String, expirySecs: Int = 3600): Result<String>
     suspend fun listTransactions(limit: Int = 50, offset: Int = 0): Result<List<WalletTransaction>>
+
+    /** Spark only — returns an on-chain deposit address. NWC returns failure. */
+    suspend fun getDepositAddress(): Result<String>
+
+    /** Spark only — prepares an on-chain send and returns fee quote + opaque prepare data. */
+    suspend fun prepareOnchainSend(address: String, amountSats: Long): Result<Pair<OnchainFeeQuote, Any>>
+
+    /** Spark only — broadcasts a prepared on-chain send. */
+    suspend fun sendOnchain(prepareData: Any, speed: String = "MEDIUM"): Result<String>
 }
 
 data class WalletTransaction(

--- a/app/src/main/kotlin/com/darkwisp/app/repo/WalletProvider.kt
+++ b/app/src/main/kotlin/com/darkwisp/app/repo/WalletProvider.kt
@@ -47,5 +47,7 @@ data class WalletTransaction(
     val createdAt: Long,
     val settledAt: Long?,
     /** Pubkey of the counterparty (recipient for outgoing, sender for incoming zaps). */
-    val counterpartyPubkey: String? = null
+    val counterpartyPubkey: String? = null,
+    val pending: Boolean = false,
+    val isOnchain: Boolean = false
 )

--- a/app/src/main/kotlin/com/darkwisp/app/ui/screen/WalletScreen.kt
+++ b/app/src/main/kotlin/com/darkwisp/app/ui/screen/WalletScreen.kt
@@ -71,6 +71,7 @@ import androidx.compose.material.icons.outlined.Visibility
 import androidx.compose.material.icons.outlined.VpnKey
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.automirrored.filled.KeyboardArrowRight
+import androidx.compose.material.icons.automirrored.filled.Send
 import androidx.compose.material3.Surface
 import androidx.compose.material.icons.filled.ArrowDownward
 import androidx.compose.material.icons.filled.ArrowUpward
@@ -516,6 +517,7 @@ fun WalletScreen(
                         onAmountChange = { viewModel.setReceiveAmount(it) },
                         onGenerate = { sats, note, expirySecs -> viewModel.generateInvoice(sats, note, expirySecs) },
                         onLoadDepositAddress = { viewModel.loadDepositAddress() },
+                        onShowAddressQR = { viewModel.navigateTo(WalletPage.LightningAddressQR) },
                         modifier = Modifier.padding(padding)
                     )
                     is WalletPage.ReceiveInvoice -> {
@@ -1778,46 +1780,60 @@ private fun SendInputContent(
         }
     }
 
+    val accent = WispThemeColors.zapColor
+    val fieldShape = RoundedCornerShape(14.dp)
+    val fieldBg = MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.4f)
+    val hint = if (walletMode == WalletMode.SPARK) {
+        stringResource(R.string.wallet_send_input_hint_onchain)
+    } else {
+        stringResource(R.string.wallet_lightning_address_invoice)
+    }
+
     Column(
         modifier = modifier
             .fillMaxSize()
-            .padding(horizontal = 16.dp)
-            .verticalScroll(rememberScrollState()),
-        horizontalAlignment = Alignment.CenterHorizontally
+            .padding(horizontal = 20.dp)
+            .verticalScroll(rememberScrollState())
     ) {
-        Spacer(Modifier.height(32.dp))
+        Spacer(Modifier.height(8.dp))
 
         Text(
             stringResource(R.string.wallet_send),
-            style = MaterialTheme.typography.headlineMedium,
-            color = MaterialTheme.colorScheme.onSurface
+            style = MaterialTheme.typography.titleLarge,
+            fontWeight = FontWeight.SemiBold,
+            color = MaterialTheme.colorScheme.onSurface,
+            textAlign = TextAlign.Center,
+            modifier = Modifier.fillMaxWidth()
         )
 
-        Spacer(Modifier.height(24.dp))
+        Spacer(Modifier.height(20.dp))
 
-        OutlinedTextField(
-            value = input,
-            onValueChange = onInputChange,
-            label = { Text(stringResource(R.string.wallet_lightning_address_invoice)) },
-            placeholder = {
-                Text(
-                    if (walletMode == WalletMode.SPARK)
-                        stringResource(R.string.placeholder_send_spark)
-                    else
-                        stringResource(R.string.placeholder_user_domain)
-                )
-            },
-            modifier = Modifier.fillMaxWidth(),
-            singleLine = false,
-            maxLines = 4,
-            trailingIcon = {
-                IconButton(onClick = {
-                    clipboardManager.getText()?.text?.let { onInputChange(it) }
-                }) {
-                    Icon(Icons.Default.ContentPaste, contentDescription = stringResource(R.string.wallet_paste))
+        Box(
+            modifier = Modifier
+                .fillMaxWidth()
+                .heightIn(min = 120.dp)
+                .background(fieldBg, fieldShape)
+                .padding(16.dp)
+        ) {
+            val entryStyle = MaterialTheme.typography.bodyLarge.copy(
+                color = MaterialTheme.colorScheme.onSurface
+            )
+            BasicTextField(
+                value = input,
+                onValueChange = { new ->
+                    if (!com.darkwisp.app.ui.component.NsecPasteGuard.blockIfNsec(input, new)) onInputChange(new)
+                },
+                textStyle = entryStyle,
+                cursorBrush = androidx.compose.ui.graphics.SolidColor(accent),
+                modifier = Modifier.fillMaxWidth(),
+                decorationBox = { inner ->
+                    if (input.isEmpty()) {
+                        Text(hint, style = entryStyle.copy(color = MaterialTheme.colorScheme.onSurfaceVariant))
+                    }
+                    inner()
                 }
-            }
-        )
+            )
+        }
 
         if (error != null) {
             Spacer(Modifier.height(8.dp))
@@ -1828,48 +1844,76 @@ private fun SendInputContent(
             )
         }
 
-        Spacer(Modifier.height(24.dp))
+        Spacer(Modifier.height(16.dp))
 
-        // Scan QR / Import from Gallery buttons
         Row(
-            modifier = Modifier.fillMaxWidth(),
-            horizontalArrangement = Arrangement.spacedBy(12.dp)
+            verticalAlignment = Alignment.CenterVertically,
+            modifier = Modifier
+                .fillMaxWidth()
+                .background(fieldBg, fieldShape)
         ) {
-            OutlinedButton(
+            SendInputAction(
+                icon = Icons.Default.QrCode,
+                label = stringResource(R.string.wallet_scan_qr),
                 onClick = onScanQR,
                 modifier = Modifier.weight(1f)
-            ) {
-                Icon(
-                    Icons.Default.QrCode,
-                    contentDescription = null,
-                    modifier = Modifier.size(18.dp)
-                )
-                Spacer(Modifier.width(8.dp))
-                Text(stringResource(R.string.wallet_scan_qr))
-            }
-            OutlinedButton(
+            )
+            VerticalDivider(modifier = Modifier.height(24.dp))
+            SendInputAction(
+                icon = Icons.Default.ContentPaste,
+                label = stringResource(R.string.wallet_paste),
+                onClick = {
+                    clipboardManager.getText()?.text?.let { new ->
+                        if (!com.darkwisp.app.ui.component.NsecPasteGuard.blockIfNsec(input, new)) onInputChange(new)
+                    }
+                },
+                modifier = Modifier.weight(1f)
+            )
+            VerticalDivider(modifier = Modifier.height(24.dp))
+            SendInputAction(
+                icon = Icons.Default.Image,
+                label = stringResource(R.string.wallet_gallery),
                 onClick = { galleryLauncher.launch("image/*") },
                 modifier = Modifier.weight(1f)
-            ) {
-                Icon(
-                    Icons.Default.Image,
-                    contentDescription = null,
-                    modifier = Modifier.size(18.dp)
-                )
-                Spacer(Modifier.width(8.dp))
-                Text(stringResource(R.string.wallet_gallery))
-            }
+            )
         }
 
-        Spacer(Modifier.height(16.dp))
+        Spacer(Modifier.height(24.dp))
 
         Button(
             onClick = onNext,
-            modifier = Modifier.fillMaxWidth(),
-            enabled = input.isNotBlank()
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(52.dp),
+            shape = fieldShape,
+            enabled = input.isNotBlank(),
+            colors = ButtonDefaults.buttonColors(
+                containerColor = accent,
+                contentColor = Color.White,
+                disabledContainerColor = fieldBg,
+                disabledContentColor = MaterialTheme.colorScheme.onSurfaceVariant
+            )
         ) {
-            Text(stringResource(R.string.wallet_next))
+            Text(stringResource(R.string.wallet_next), fontWeight = FontWeight.SemiBold)
         }
+    }
+}
+
+@Composable
+private fun SendInputAction(
+    icon: ImageVector,
+    label: String,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    TextButton(
+        onClick = onClick,
+        modifier = modifier,
+        colors = ButtonDefaults.textButtonColors(contentColor = WispThemeColors.zapColor)
+    ) {
+        Icon(icon, contentDescription = null, modifier = Modifier.size(18.dp))
+        Spacer(Modifier.width(6.dp))
+        Text(label, fontWeight = FontWeight.Medium, maxLines = 1)
     }
 }
 
@@ -2262,6 +2306,7 @@ private fun ReceiveAmountContent(
     onAmountChange: (String) -> Unit,
     onGenerate: (Long, String, Int) -> Unit,
     onLoadDepositAddress: () -> Unit,
+    onShowAddressQR: () -> Unit = {},
     modifier: Modifier = Modifier
 ) {
     val receiveCtx = LocalContext.current
@@ -2564,7 +2609,7 @@ private fun ReceiveAmountContent(
                     textAlign = TextAlign.Center
                 )
                 Spacer(Modifier.height(12.dp))
-                LightningAddressReceiveRow(address = lightningAddress)
+                LightningAddressReceiveRow(address = lightningAddress, onShowQR = onShowAddressQR)
             }
         }
 
@@ -2574,54 +2619,64 @@ private fun ReceiveAmountContent(
 
 // Lightning address displayed below the invoice form
 @Composable
-private fun LightningAddressReceiveRow(address: String) {
+private fun LightningAddressReceiveRow(
+    address: String,
+    onShowQR: () -> Unit
+) {
     val clipboardManager = LocalClipboardManager.current
-    val context = LocalContext.current
-    val actionShape = RoundedCornerShape(14.dp)
-    val actionBg = MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.4f)
-
-    Column(
-        modifier = Modifier
-            .fillMaxWidth()
-            .background(actionBg, actionShape)
-            .padding(horizontal = 16.dp, vertical = 12.dp)
-    ) {
-        Text(
-            address,
-            style = MaterialTheme.typography.bodyMedium,
-            color = MaterialTheme.colorScheme.onSurface,
-            textAlign = TextAlign.Center,
-            modifier = Modifier.fillMaxWidth()
-        )
-        Spacer(Modifier.height(10.dp))
+    Column {
+        Row(verticalAlignment = Alignment.CenterVertically) {
+            HorizontalDivider(modifier = Modifier.weight(1f))
+            Text(
+                stringResource(R.string.wallet_receive_via_address),
+                style = MaterialTheme.typography.labelMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                modifier = Modifier.padding(horizontal = 12.dp)
+            )
+            HorizontalDivider(modifier = Modifier.weight(1f))
+        }
+        Spacer(Modifier.height(16.dp))
         Row(
             verticalAlignment = Alignment.CenterVertically,
-            modifier = Modifier.fillMaxWidth()
+            modifier = Modifier
+                .fillMaxWidth()
+                .background(
+                    MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.4f),
+                    RoundedCornerShape(14.dp)
+                )
+                .padding(start = 16.dp, end = 6.dp, top = 6.dp, bottom = 6.dp)
         ) {
-            TextButton(
-                onClick = { clipboardManager.setText(AnnotatedString(address)) },
-                modifier = Modifier.weight(1f),
-                colors = ButtonDefaults.textButtonColors(contentColor = WispThemeColors.zapColor)
-            ) {
-                Icon(Icons.Default.ContentCopy, contentDescription = null, modifier = Modifier.size(16.dp))
-                Spacer(Modifier.width(4.dp))
-                Text(stringResource(R.string.wallet_copy_address), fontWeight = FontWeight.Medium, style = MaterialTheme.typography.labelMedium)
+            Icon(
+                Icons.Outlined.Bolt,
+                contentDescription = null,
+                tint = WispThemeColors.zapColor,
+                modifier = Modifier.size(18.dp)
+            )
+            Spacer(Modifier.width(10.dp))
+            Text(
+                address,
+                style = MaterialTheme.typography.bodyMedium,
+                fontWeight = FontWeight.Medium,
+                color = MaterialTheme.colorScheme.onSurface,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+                modifier = Modifier.weight(1f)
+            )
+            IconButton(onClick = onShowQR) {
+                Icon(
+                    Icons.Default.QrCode,
+                    contentDescription = stringResource(R.string.wallet_receive_address_tab),
+                    modifier = Modifier.size(20.dp),
+                    tint = MaterialTheme.colorScheme.onSurfaceVariant
+                )
             }
-            VerticalDivider(modifier = Modifier.height(20.dp))
-            TextButton(
-                onClick = {
-                    val intent = Intent(Intent.ACTION_SEND).apply {
-                        type = "text/plain"
-                        putExtra(Intent.EXTRA_TEXT, address)
-                    }
-                    context.startActivity(Intent.createChooser(intent, context.getString(R.string.wallet_share_address)))
-                },
-                modifier = Modifier.weight(1f),
-                colors = ButtonDefaults.textButtonColors(contentColor = WispThemeColors.zapColor)
-            ) {
-                Icon(Icons.Default.Share, contentDescription = null, modifier = Modifier.size(16.dp))
-                Spacer(Modifier.width(4.dp))
-                Text(stringResource(R.string.wallet_share), fontWeight = FontWeight.Medium, style = MaterialTheme.typography.labelMedium)
+            IconButton(onClick = { clipboardManager.setText(AnnotatedString(address)) }) {
+                Icon(
+                    Icons.Default.ContentCopy,
+                    contentDescription = stringResource(R.string.cd_copy_invoice),
+                    modifier = Modifier.size(18.dp),
+                    tint = MaterialTheme.colorScheme.onSurfaceVariant
+                )
             }
         }
     }
@@ -2775,10 +2830,7 @@ private fun OnchainSendAmountContent(
     ) {
         Spacer(Modifier.height(8.dp))
         Row(verticalAlignment = Alignment.CenterVertically) {
-            IconButton(onClick = onBack) {
-                Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = stringResource(R.string.btn_back))
-            }
-            Icon(Icons.Default.ArrowUpward, contentDescription = null, tint = accent, modifier = Modifier.size(20.dp))
+            Icon(Icons.AutoMirrored.Filled.Send, contentDescription = null, tint = accent, modifier = Modifier.size(20.dp))
             Spacer(Modifier.width(8.dp))
             Text(stringResource(R.string.wallet_onchain_send_title), style = MaterialTheme.typography.titleLarge, fontWeight = FontWeight.SemiBold)
         }
@@ -2885,7 +2937,7 @@ private fun OnchainSendAmountContent(
                 shape = fieldShape,
                 colors = ButtonDefaults.buttonColors(containerColor = accent, contentColor = Color.White)
             ) {
-                Icon(Icons.Default.ArrowUpward, contentDescription = null, modifier = Modifier.size(18.dp))
+                Icon(Icons.AutoMirrored.Filled.Send, contentDescription = null, modifier = Modifier.size(18.dp))
                 Spacer(Modifier.width(8.dp))
                 Text(stringResource(R.string.wallet_onchain_continue), style = MaterialTheme.typography.titleSmall, fontWeight = FontWeight.SemiBold)
             }
@@ -2975,10 +3027,7 @@ private fun OnchainSendConfirmContent(
     ) {
         Spacer(Modifier.height(8.dp))
         Row(modifier = Modifier.fillMaxWidth(), verticalAlignment = Alignment.CenterVertically) {
-            IconButton(onClick = onBack) {
-                Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = stringResource(R.string.btn_back))
-            }
-            Icon(Icons.Default.ArrowUpward, contentDescription = null, tint = accent, modifier = Modifier.size(20.dp))
+            Icon(Icons.AutoMirrored.Filled.Send, contentDescription = null, tint = accent, modifier = Modifier.size(20.dp))
             Spacer(Modifier.width(8.dp))
             Text(stringResource(R.string.wallet_onchain_send_title), style = MaterialTheme.typography.titleLarge, fontWeight = FontWeight.SemiBold)
         }
@@ -3050,7 +3099,7 @@ private fun OnchainSendConfirmContent(
                     shape = fieldShape,
                     colors = ButtonDefaults.buttonColors(containerColor = accent, contentColor = Color.White)
                 ) {
-                    Icon(Icons.Default.ArrowUpward, contentDescription = null, modifier = Modifier.size(18.dp))
+                    Icon(Icons.AutoMirrored.Filled.Send, contentDescription = null, modifier = Modifier.size(18.dp))
                     Spacer(Modifier.width(8.dp))
                     Text(stringResource(R.string.wallet_onchain_send_confirm), fontWeight = FontWeight.SemiBold)
                 }
@@ -3437,7 +3486,7 @@ private fun TransactionHistoryContent(
                     // both render. The list is deduped by (paymentHash, type)
                     // upstream, so these keys are unique.
                     items(transactions, key = { "${it.paymentHash}|${it.type}" }) { tx ->
-                        TransactionRow(tx, profileLookup, displayMode)
+                        TransactionRow(tx, profileLookup, displayMode, expandable = true)
                         HorizontalDivider(
                             modifier = Modifier.padding(horizontal = 16.dp),
                             color = MaterialTheme.colorScheme.outlineVariant
@@ -3474,20 +3523,25 @@ private fun TransactionHistoryContent(
 private fun TransactionRow(
     tx: WalletTransaction,
     profileLookup: (String) -> com.darkwisp.app.nostr.ProfileData?,
-    displayMode: WalletBalanceDisplayMode = WalletBalanceDisplayMode.SATS
+    displayMode: WalletBalanceDisplayMode = WalletBalanceDisplayMode.SATS,
+    expandable: Boolean = false
 ) {
     val isIncoming = tx.type == "incoming"
     val amountSats = tx.amountMsats / 1000
     val profile = tx.counterpartyPubkey?.let { profileLookup(it) }
     val ctx = LocalContext.current
+    val clipboardManager = LocalClipboardManager.current
     val fiatMode by FiatPreferences.get(ctx).fiatMode.collectAsState()
     val fiatCurrency by FiatPreferences.get(ctx).currency.collectAsState()
     val isHidden = displayMode == WalletBalanceDisplayMode.HIDDEN
     val isWalletFiat = displayMode == WalletBalanceDisplayMode.FIAT
+    var expanded by remember { mutableStateOf(false) }
 
+  Column(modifier = Modifier.fillMaxWidth()) {
     Row(
         modifier = Modifier
             .fillMaxWidth()
+            .then(if (expandable) Modifier.clickable { expanded = !expanded } else Modifier)
             .padding(horizontal = 16.dp, vertical = 12.dp),
         verticalAlignment = Alignment.CenterVertically
     ) {
@@ -3540,11 +3594,26 @@ private fun TransactionRow(
                 maxLines = 1,
                 overflow = TextOverflow.Ellipsis
             )
-            Text(
-                formatRelativeTime(tx.settledAt ?: tx.createdAt),
-                style = MaterialTheme.typography.bodySmall,
-                color = MaterialTheme.colorScheme.onSurfaceVariant
-            )
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                if (tx.pending) {
+                    Text(
+                        stringResource(R.string.wallet_tx_pending),
+                        style = MaterialTheme.typography.bodySmall,
+                        fontWeight = FontWeight.Medium,
+                        color = WispThemeColors.zapColor
+                    )
+                    Text(
+                        " · ",
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                    )
+                }
+                Text(
+                    formatRelativeTime(tx.settledAt ?: tx.createdAt),
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+            }
         }
 
         // Amount + fee. In HIDDEN mode every number is masked so a
@@ -3621,6 +3690,122 @@ private fun TransactionRow(
                     color = MaterialTheme.colorScheme.onSurfaceVariant
                 )
             }
+        }
+
+        if (expandable) {
+            Spacer(Modifier.width(4.dp))
+            Icon(
+                if (expanded) Icons.Default.KeyboardArrowUp else Icons.Default.KeyboardArrowDown,
+                contentDescription = null,
+                tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                modifier = Modifier.size(20.dp)
+            )
+        }
+    }
+
+    if (expandable) {
+        AnimatedVisibility(visible = expanded) {
+            TransactionDetailPanel(
+                tx = tx,
+                onCopy = { clipboardManager.setText(AnnotatedString(it)) }
+            )
+        }
+    }
+  }
+}
+
+@Composable
+private fun TransactionDetailPanel(
+    tx: WalletTransaction,
+    onCopy: (String) -> Unit
+) {
+    val context = LocalContext.current
+    val sats = tx.amountMsats / 1000
+    val feeSats = tx.feeMsats / 1000
+    val fullDate = remember(tx.settledAt, tx.createdAt) {
+        val secs = tx.settledAt ?: tx.createdAt
+        java.text.SimpleDateFormat("MMM d, yyyy · h:mm a", java.util.Locale.getDefault())
+            .format(java.util.Date(secs * 1000))
+    }
+    val note = tx.description?.takeIf {
+        it.isNotBlank() && it != "null" && !it.trimStart().startsWith("{")
+    }
+    val idLabel = if (tx.isOnchain) "Transaction ID" else "Payment hash"
+
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(start = 16.dp, end = 16.dp, bottom = 12.dp)
+            .background(
+                MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.4f),
+                RoundedCornerShape(12.dp)
+            )
+            .padding(14.dp),
+        verticalArrangement = Arrangement.spacedBy(10.dp)
+    ) {
+        TxDetailRow("Status", if (tx.pending) "Pending" else "Completed")
+        TxDetailRow("Type", if (tx.isOnchain) "On-chain" else "Lightning")
+        TxDetailRow("Amount", "%,d sats".format(sats))
+        if (tx.feeMsats > 0) TxDetailRow("Network fee", "%,d sats".format(feeSats))
+        TxDetailRow("Date", fullDate)
+        if (note != null) TxDetailRow("Note", note)
+        TxDetailRow(idLabel, tx.paymentHash, mono = true, onCopy = { onCopy(tx.paymentHash) })
+        if (tx.isOnchain) {
+            TextButton(
+                onClick = {
+                    context.startActivity(
+                        android.content.Intent(
+                            android.content.Intent.ACTION_VIEW,
+                            android.net.Uri.parse("https://mempool.space/tx/${tx.paymentHash}")
+                        )
+                    )
+                },
+                contentPadding = PaddingValues(0.dp),
+                colors = ButtonDefaults.textButtonColors(contentColor = WispThemeColors.zapColor)
+            ) {
+                Icon(Icons.Default.Share, contentDescription = null, modifier = Modifier.size(16.dp))
+                Spacer(Modifier.width(6.dp))
+                Text("View on mempool.space", style = MaterialTheme.typography.labelLarge)
+            }
+        }
+    }
+}
+
+@Composable
+private fun TxDetailRow(
+    label: String,
+    value: String,
+    mono: Boolean = false,
+    onCopy: (() -> Unit)? = null
+) {
+    Row(
+        modifier = Modifier.fillMaxWidth(),
+        verticalAlignment = Alignment.Top
+    ) {
+        Text(
+            label,
+            style = MaterialTheme.typography.labelMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            modifier = Modifier.width(110.dp)
+        )
+        Spacer(Modifier.width(12.dp))
+        Text(
+            value,
+            style = MaterialTheme.typography.bodySmall,
+            fontFamily = if (mono) FontFamily.Monospace else null,
+            color = MaterialTheme.colorScheme.onSurface,
+            modifier = Modifier.weight(1f)
+        )
+        if (onCopy != null) {
+            Spacer(Modifier.width(6.dp))
+            Icon(
+                Icons.Default.ContentCopy,
+                contentDescription = stringResource(R.string.action_copy),
+                tint = WispThemeColors.zapColor,
+                modifier = Modifier
+                    .size(18.dp)
+                    .clickable(onClick = onCopy)
+            )
         }
     }
 }

--- a/app/src/main/kotlin/com/darkwisp/app/ui/screen/WalletScreen.kt
+++ b/app/src/main/kotlin/com/darkwisp/app/ui/screen/WalletScreen.kt
@@ -84,6 +84,7 @@ import androidx.compose.material.icons.automirrored.filled.KeyboardArrowRight
 import androidx.compose.material.icons.filled.Image
 import androidx.compose.material.icons.filled.KeyboardArrowDown
 import androidx.compose.material.icons.filled.KeyboardArrowUp
+import androidx.compose.material.icons.filled.CurrencyBitcoin
 import androidx.compose.material.icons.filled.QrCode
 import androidx.compose.material.icons.outlined.Info
 import androidx.compose.material.icons.filled.Receipt
@@ -118,8 +119,12 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Scaffold
+import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
+import androidx.compose.foundation.gestures.detectVerticalDragGestures
+import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.material3.TopAppBar
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
@@ -146,6 +151,9 @@ import androidx.lifecycle.compose.LocalLifecycleOwner
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.AnnotatedString
+import androidx.compose.ui.text.buildAnnotatedString
+import androidx.compose.ui.text.SpanStyle
+import androidx.compose.ui.text.withStyle
 import androidx.compose.ui.viewinterop.AndroidView
 import androidx.core.content.ContextCompat
 import androidx.compose.ui.text.font.FontFamily
@@ -166,6 +174,7 @@ import com.darkwisp.app.BuildConfig
 import com.darkwisp.app.R
 import com.darkwisp.app.nostr.NipA3
 import com.darkwisp.app.repo.BalanceUnit
+import com.darkwisp.app.repo.OnchainFeeQuote
 import com.darkwisp.app.repo.WalletBalanceDisplayMode
 import com.darkwisp.app.repo.FiatPreferences
 import com.darkwisp.app.repo.WalletMode
@@ -207,6 +216,7 @@ fun WalletScreen(
     // app bar to match iOS — leaves more headroom for the centered logo
     // + title layout.
     val hideAppBar = currentPage is WalletPage.Home ||
+        currentPage is WalletPage.Transactions ||
         currentPage is WalletPage.ModeSelection ||
         currentPage is WalletPage.NwcSetup ||
         currentPage is WalletPage.SparkSetup ||
@@ -426,6 +436,7 @@ fun WalletScreen(
                     is WalletPage.SendInput -> SendInputContent(
                         input = viewModel.sendInput.collectAsState().value,
                         error = viewModel.sendError.collectAsState().value,
+                        walletMode = viewModel.walletMode.collectAsState().value,
                         onInputChange = { viewModel.updateSendInput(it) },
                         onNext = { viewModel.processInput() },
                         onScanQR = { viewModel.navigateTo(WalletPage.ScanQR) },
@@ -498,8 +509,13 @@ fun WalletScreen(
                         amount = viewModel.receiveAmount.collectAsState().value,
                         isLoading = viewModel.isLoading.collectAsState().value,
                         lightningAddress = viewModel.lightningAddress.collectAsState().value,
+                        walletMode = viewModel.walletMode.collectAsState().value,
+                        depositAddress = viewModel.depositAddress.collectAsState().value,
+                        depositAddressLoading = viewModel.depositAddressLoading.collectAsState().value,
+                        depositAddressError = viewModel.depositAddressError.collectAsState().value,
                         onAmountChange = { viewModel.setReceiveAmount(it) },
-                        onGenerate = { sats, note -> viewModel.generateInvoice(sats, note) },
+                        onGenerate = { sats, note, expirySecs -> viewModel.generateInvoice(sats, note, expirySecs) },
+                        onLoadDepositAddress = { viewModel.loadDepositAddress() },
                         modifier = Modifier.padding(padding)
                     )
                     is WalletPage.ReceiveInvoice -> {
@@ -520,17 +536,34 @@ fun WalletScreen(
                         )
                     }
                     is WalletPage.Transactions -> {
-                        // Observe profile refresh key so UI recomposes when new profiles arrive
+                        // Home stays visible behind the transactions bottom sheet.
                         val profileKey = viewModel.profileRefreshKey.collectAsState().value
-                        TransactionHistoryContent(
-                            transactions = viewModel.transactions.collectAsState().value,
-                            error = viewModel.transactionsError.collectAsState().value,
-                            isLoading = viewModel.isLoading.collectAsState().value,
-                            isLoadingMore = viewModel.isLoadingMore.collectAsState().value,
-                            hasMore = viewModel.hasMoreTransactions.collectAsState().value,
-                            onLoadMore = { viewModel.loadMoreTransactions() },
-                            profileLookup = { viewModel.getProfileData(it) },
-                            profileRefreshKey = profileKey,
+                        WalletHomeContent(
+                            balanceMsats = balanceMsats,
+                            walletMode = viewModel.walletMode.collectAsState().value,
+                            balanceUnit = viewModel.balanceUnit.collectAsState().value,
+                            showSettingsAlert = viewModel.walletMode.collectAsState().value == WalletMode.SPARK
+                                    && !viewModel.seedBackupAcked.collectAsState().value,
+                            seedBackupAcked = viewModel.seedBackupAcked.collectAsState().value,
+                            backupMissing = viewModel.backupMissing.collectAsState().value,
+                            onSend = { viewModel.navigateTo(WalletPage.SendInput) },
+                            onReceive = { viewModel.navigateTo(WalletPage.ReceiveAmount) },
+                            onTransactions = {},
+                            onRefresh = { viewModel.refreshBalance() },
+                            onSettings = { viewModel.navigateTo(WalletPage.Settings) },
+                            onBackupToRelay = {
+                                viewModel.resetBackupStatus()
+                                viewModel.navigateTo(WalletPage.BackupToRelay)
+                            },
+                            onViewSeed = { viewModel.showMnemonicBackup() },
+                            lightningAddress = viewModel.lightningAddress.collectAsState().value,
+                            onSetupAddress = {
+                                viewModel.resetAddressSetupState()
+                                viewModel.navigateTo(WalletPage.LightningAddressSetup)
+                            },
+                            recentTransactions = viewModel.transactions.collectAsState().value,
+                            profileLookup = remember(profileKey) { { viewModel.getProfileData(it) } },
+                            nwcNodeAlias = viewModel.nwcNodeAlias.collectAsState().value,
                             pubkey = viewModel.keyRepo.getPubkeyHex(),
                             modifier = Modifier.padding(padding)
                         )
@@ -613,6 +646,65 @@ fun WalletScreen(
                         },
                         modifier = Modifier.padding(padding)
                     )
+                    is WalletPage.OnchainSendAmount -> {
+                        val page = currentPage as WalletPage.OnchainSendAmount
+                        val sendAmount by viewModel.sendAmount.collectAsState()
+                        val feeLoading by viewModel.onchainSendLoading.collectAsState()
+                        val error by viewModel.sendError.collectAsState()
+                        val feeQuote by viewModel.onchainFeeQuote.collectAsState()
+                        OnchainSendAmountContent(
+                            address = page.address,
+                            amount = sendAmount,
+                            balanceSats = balanceMsats / 1000,
+                            isLoading = feeLoading,
+                            error = error,
+                            feeQuote = feeQuote,
+                            onAmountChange = {
+                                viewModel.setSendAmount(it)
+                                viewModel.clearOnchainQuote()
+                            },
+                            onUseAll = {
+                                viewModel.setSendAmount((balanceMsats / 1000).toString())
+                                viewModel.clearOnchainQuote()
+                            },
+                            onGetFeeQuote = {
+                                val sats = sendAmount.toLongOrNull() ?: return@OnchainSendAmountContent
+                                viewModel.prepareOnchainSend(page.address, sats)
+                            },
+                            onContinue = {
+                                val sats = sendAmount.toLongOrNull() ?: return@OnchainSendAmountContent
+                                viewModel.continueToOnchainConfirm(page.address, sats)
+                            },
+                            onBack = {
+                                viewModel.clearOnchainQuote()
+                                viewModel.navigateBack()
+                            },
+                            modifier = Modifier.padding(padding)
+                        )
+                    }
+                    is WalletPage.OnchainSendConfirm -> {
+                        val page = currentPage as WalletPage.OnchainSendConfirm
+                        val sending by viewModel.isLoading.collectAsState()
+                        OnchainSendConfirmContent(
+                            address = page.address,
+                            amountSats = page.amountSats,
+                            feeQuote = page.feeQuote,
+                            isLoading = sending,
+                            onConfirm = { viewModel.sendOnchain(page.prepareData) },
+                            onBack = { viewModel.navigateBack() },
+                            modifier = Modifier.padding(padding)
+                        )
+                    }
+                    is WalletPage.OnchainSendResult -> {
+                        val page = currentPage as WalletPage.OnchainSendResult
+                        OnchainSendResultContent(
+                            success = page.success,
+                            paymentId = page.paymentId,
+                            message = page.message,
+                            onDone = { viewModel.navigateHome() },
+                            modifier = Modifier.padding(padding)
+                        )
+                    }
                     else -> {
                         // ModeSelection, NwcSetup, SparkSetup — shouldn't appear while connected
                         val profileKey = viewModel.profileRefreshKey.collectAsState().value
@@ -647,6 +739,28 @@ fun WalletScreen(
                             nwcNodeAlias = viewModel.nwcNodeAlias.collectAsState().value,
                             pubkey = viewModel.keyRepo.getPubkeyHex(),
                             modifier = Modifier.padding(padding)
+                        )
+                    }
+                }
+
+                // Transactions full-screen bottom sheet — swipe down to dismiss
+                if (currentPage is WalletPage.Transactions) {
+                    val txSheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
+                    val txProfileKey = viewModel.profileRefreshKey.collectAsState().value
+                    ModalBottomSheet(
+                        onDismissRequest = { viewModel.navigateBack() },
+                        sheetState = txSheetState,
+                    ) {
+                        TransactionHistoryContent(
+                            transactions = viewModel.transactions.collectAsState().value,
+                            error = viewModel.transactionsError.collectAsState().value,
+                            isLoading = viewModel.isLoading.collectAsState().value,
+                            isLoadingMore = viewModel.isLoadingMore.collectAsState().value,
+                            hasMore = viewModel.hasMoreTransactions.collectAsState().value,
+                            onLoadMore = { viewModel.loadMoreTransactions() },
+                            profileLookup = { viewModel.getProfileData(it) },
+                            profileRefreshKey = txProfileKey,
+                            pubkey = viewModel.keyRepo.getPubkeyHex(),
                         )
                     }
                 }
@@ -1510,7 +1624,24 @@ private fun WalletHomeContent(
 
         // ── Recent transactions inline footer ──────────────────────
         if (recentTransactions.isNotEmpty()) {
-            Column(modifier = Modifier.fillMaxWidth()) {
+            Column(
+                modifier = Modifier.fillMaxWidth()
+                    .pointerInput(onTransactions) {
+                        var totalDrag = 0f
+                        detectVerticalDragGestures(
+                            onDragStart = { totalDrag = 0f },
+                            onDragEnd = { totalDrag = 0f },
+                            onDragCancel = { totalDrag = 0f }
+                        ) { change, delta ->
+                            totalDrag += delta
+                            if (totalDrag < -40f) {
+                                totalDrag = 0f
+                                change.consume()
+                                onTransactions()
+                            }
+                        }
+                    }
+            ) {
                 Row(
                     modifier = Modifier
                         .fillMaxWidth()
@@ -1602,6 +1733,7 @@ private fun WalletActionButton(
 private fun SendInputContent(
     input: String,
     error: String?,
+    walletMode: WalletMode = WalletMode.NONE,
     onInputChange: (String) -> Unit,
     onNext: () -> Unit,
     onScanQR: () -> Unit,
@@ -1667,7 +1799,14 @@ private fun SendInputContent(
             value = input,
             onValueChange = onInputChange,
             label = { Text(stringResource(R.string.wallet_lightning_address_invoice)) },
-            placeholder = { Text(stringResource(R.string.placeholder_user_domain)) },
+            placeholder = {
+                Text(
+                    if (walletMode == WalletMode.SPARK)
+                        stringResource(R.string.placeholder_send_spark)
+                    else
+                        stringResource(R.string.placeholder_user_domain)
+                )
+            },
             modifier = Modifier.fillMaxWidth(),
             singleLine = false,
             maxLines = 4,
@@ -2104,7 +2243,11 @@ private fun SendResultContent(
 
 // --- Receive amount ---
 
-private enum class ReceiveTab { INVOICE, ADDRESS }
+private enum class ReceiveTab { LIGHTNING, BITCOIN }
+
+private enum class InvoiceExpiry(val seconds: Int) {
+    ONE_HOUR(3600), ONE_DAY(86400), CUSTOM(0)
+}
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -2112,8 +2255,13 @@ private fun ReceiveAmountContent(
     amount: String,
     isLoading: Boolean,
     lightningAddress: String?,
+    walletMode: WalletMode,
+    depositAddress: String?,
+    depositAddressLoading: Boolean,
+    depositAddressError: String?,
     onAmountChange: (String) -> Unit,
-    onGenerate: (Long, String) -> Unit,
+    onGenerate: (Long, String, Int) -> Unit,
+    onLoadDepositAddress: () -> Unit,
     modifier: Modifier = Modifier
 ) {
     val receiveCtx = LocalContext.current
@@ -2128,11 +2276,20 @@ private fun ReceiveAmountContent(
         ((fiatValue / btcPrice) * 100_000_000.0).toLong()
     } else null
     val satAmount: Long? = if (fiatMode) fiatSats else amount.toLongOrNull()
-    val canCreate = (satAmount ?: 0L) > 0L && !isLoading
 
     var description by remember { mutableStateOf("") }
-    var selectedTab by remember { mutableStateOf(ReceiveTab.INVOICE) }
-    val hasLightningAddress = !lightningAddress.isNullOrBlank()
+    var selectedExpiry by remember { mutableStateOf(InvoiceExpiry.ONE_HOUR) }
+    var customHours by remember { mutableStateOf("") }
+    val expirySecs = when (selectedExpiry) {
+        InvoiceExpiry.ONE_HOUR -> 3600
+        InvoiceExpiry.ONE_DAY -> 86400
+        InvoiceExpiry.CUSTOM -> (customHours.toIntOrNull() ?: 0) * 3600
+    }
+    val canCreate = (satAmount ?: 0L) > 0L && !isLoading &&
+        (selectedExpiry != InvoiceExpiry.CUSTOM || expirySecs > 0)
+
+    val isSpark = walletMode == WalletMode.SPARK
+    var selectedTab by remember { mutableStateOf(ReceiveTab.LIGHTNING) }
 
     val fieldShape = RoundedCornerShape(14.dp)
     val fieldBg = MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.4f)
@@ -2156,24 +2313,35 @@ private fun ReceiveAmountContent(
 
         Spacer(Modifier.height(20.dp))
 
-        if (hasLightningAddress) {
+        // Show tab row only for Spark wallets (which support on-chain)
+        if (isSpark) {
             SingleChoiceSegmentedButtonRow(modifier = Modifier.fillMaxWidth()) {
                 SegmentedButton(
-                    selected = selectedTab == ReceiveTab.INVOICE,
-                    onClick = { selectedTab = ReceiveTab.INVOICE },
-                    shape = SegmentedButtonDefaults.itemShape(index = 0, count = 2)
-                ) { Text(stringResource(R.string.wallet_receive_invoice_tab)) }
+                    selected = selectedTab == ReceiveTab.LIGHTNING,
+                    onClick = { selectedTab = ReceiveTab.LIGHTNING },
+                    shape = SegmentedButtonDefaults.itemShape(index = 0, count = 2),
+                    icon = { Icon(Icons.Outlined.Bolt, contentDescription = null, modifier = Modifier.size(16.dp)) }
+                ) { Text(stringResource(R.string.wallet_receive_lightning_tab)) }
                 SegmentedButton(
-                    selected = selectedTab == ReceiveTab.ADDRESS,
-                    onClick = { selectedTab = ReceiveTab.ADDRESS },
-                    shape = SegmentedButtonDefaults.itemShape(index = 1, count = 2)
-                ) { Text(stringResource(R.string.wallet_receive_address_tab)) }
+                    selected = selectedTab == ReceiveTab.BITCOIN,
+                    onClick = {
+                        selectedTab = ReceiveTab.BITCOIN
+                        onLoadDepositAddress()
+                    },
+                    shape = SegmentedButtonDefaults.itemShape(index = 1, count = 2),
+                    icon = { Icon(Icons.Default.CurrencyBitcoin, contentDescription = null, modifier = Modifier.size(16.dp)) }
+                ) { Text(stringResource(R.string.wallet_receive_bitcoin_tab)) }
             }
             Spacer(Modifier.height(20.dp))
         }
 
-        if (selectedTab == ReceiveTab.ADDRESS && hasLightningAddress) {
-            ReceiveAddressBlock(address = lightningAddress!!)
+        if (selectedTab == ReceiveTab.BITCOIN && isSpark) {
+            ReceiveBitcoinBlock(
+                address = depositAddress,
+                isLoading = depositAddressLoading,
+                error = depositAddressError,
+                onRetry = onLoadDepositAddress
+            )
         } else {
             // AMOUNT field
             Text(
@@ -2201,7 +2369,6 @@ private fun ReceiveAmountContent(
                     value = amount,
                     onValueChange = { input ->
                         val filtered = if (fiatMode) {
-                            // Allow digits + a single decimal point
                             val sb = StringBuilder()
                             var seenDot = false
                             for (c in input) {
@@ -2290,6 +2457,51 @@ private fun ReceiveAmountContent(
                 )
             }
 
+            Spacer(Modifier.height(20.dp))
+
+            // EXPIRES selector
+            Text(
+                stringResource(R.string.wallet_receive_expires_label),
+                style = MaterialTheme.typography.labelMedium,
+                fontWeight = FontWeight.SemiBold,
+                letterSpacing = 0.5.sp,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+            Spacer(Modifier.height(8.dp))
+            Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                listOf(
+                    InvoiceExpiry.ONE_HOUR to stringResource(R.string.wallet_receive_expires_1h),
+                    InvoiceExpiry.ONE_DAY to stringResource(R.string.wallet_receive_expires_24h),
+                    InvoiceExpiry.CUSTOM to stringResource(R.string.wallet_receive_expires_custom)
+                ).forEachIndexed { _, (expiry, label) ->
+                    val isSelected = selectedExpiry == expiry
+                    OutlinedButton(
+                        onClick = { selectedExpiry = expiry },
+                        modifier = Modifier.weight(1f),
+                        colors = ButtonDefaults.outlinedButtonColors(
+                            containerColor = if (isSelected) MaterialTheme.colorScheme.primary.copy(alpha = 0.12f) else Color.Transparent,
+                            contentColor = if (isSelected) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.onSurfaceVariant
+                        ),
+                        border = BorderStroke(
+                            1.dp,
+                            if (isSelected) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.outline
+                        ),
+                        contentPadding = PaddingValues(horizontal = 8.dp, vertical = 6.dp)
+                    ) { Text(label, style = MaterialTheme.typography.labelMedium) }
+                }
+            }
+            if (selectedExpiry == InvoiceExpiry.CUSTOM) {
+                Spacer(Modifier.height(8.dp))
+                OutlinedTextField(
+                    value = customHours,
+                    onValueChange = { customHours = it.filter { c -> c.isDigit() } },
+                    label = { Text(stringResource(R.string.wallet_receive_expires_hours)) },
+                    singleLine = true,
+                    keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
+                    modifier = Modifier.fillMaxWidth()
+                )
+            }
+
             Spacer(Modifier.height(24.dp))
 
             if (isLoading) {
@@ -2317,7 +2529,7 @@ private fun ReceiveAmountContent(
                 Button(
                     onClick = {
                         val sats = satAmount ?: return@Button
-                        onGenerate(sats, description)
+                        onGenerate(sats, description, expirySecs)
                     },
                     enabled = canCreate,
                     modifier = Modifier
@@ -2338,6 +2550,371 @@ private fun ReceiveAmountContent(
                     )
                 }
             }
+
+            // Lightning address — shown below invoice form as "or receive via" row
+            if (!lightningAddress.isNullOrBlank()) {
+                Spacer(Modifier.height(24.dp))
+                HorizontalDivider(color = MaterialTheme.colorScheme.outline.copy(alpha = 0.3f))
+                Spacer(Modifier.height(16.dp))
+                Text(
+                    stringResource(R.string.wallet_receive_via_address),
+                    style = MaterialTheme.typography.labelMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    modifier = Modifier.fillMaxWidth(),
+                    textAlign = TextAlign.Center
+                )
+                Spacer(Modifier.height(12.dp))
+                LightningAddressReceiveRow(address = lightningAddress)
+            }
+        }
+
+        Spacer(Modifier.height(24.dp))
+    }
+}
+
+// Lightning address displayed below the invoice form
+@Composable
+private fun LightningAddressReceiveRow(address: String) {
+    val clipboardManager = LocalClipboardManager.current
+    val context = LocalContext.current
+    val actionShape = RoundedCornerShape(14.dp)
+    val actionBg = MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.4f)
+
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .background(actionBg, actionShape)
+            .padding(horizontal = 16.dp, vertical = 12.dp)
+    ) {
+        Text(
+            address,
+            style = MaterialTheme.typography.bodyMedium,
+            color = MaterialTheme.colorScheme.onSurface,
+            textAlign = TextAlign.Center,
+            modifier = Modifier.fillMaxWidth()
+        )
+        Spacer(Modifier.height(10.dp))
+        Row(
+            verticalAlignment = Alignment.CenterVertically,
+            modifier = Modifier.fillMaxWidth()
+        ) {
+            TextButton(
+                onClick = { clipboardManager.setText(AnnotatedString(address)) },
+                modifier = Modifier.weight(1f),
+                colors = ButtonDefaults.textButtonColors(contentColor = WispThemeColors.zapColor)
+            ) {
+                Icon(Icons.Default.ContentCopy, contentDescription = null, modifier = Modifier.size(16.dp))
+                Spacer(Modifier.width(4.dp))
+                Text(stringResource(R.string.wallet_copy_address), fontWeight = FontWeight.Medium, style = MaterialTheme.typography.labelMedium)
+            }
+            VerticalDivider(modifier = Modifier.height(20.dp))
+            TextButton(
+                onClick = {
+                    val intent = Intent(Intent.ACTION_SEND).apply {
+                        type = "text/plain"
+                        putExtra(Intent.EXTRA_TEXT, address)
+                    }
+                    context.startActivity(Intent.createChooser(intent, context.getString(R.string.wallet_share_address)))
+                },
+                modifier = Modifier.weight(1f),
+                colors = ButtonDefaults.textButtonColors(contentColor = WispThemeColors.zapColor)
+            ) {
+                Icon(Icons.Default.Share, contentDescription = null, modifier = Modifier.size(16.dp))
+                Spacer(Modifier.width(4.dp))
+                Text(stringResource(R.string.wallet_share), fontWeight = FontWeight.Medium, style = MaterialTheme.typography.labelMedium)
+            }
+        }
+    }
+}
+
+// Bitcoin on-chain deposit address block (Spark only)
+@Composable
+private fun ReceiveBitcoinBlock(
+    address: String?,
+    isLoading: Boolean,
+    error: String?,
+    onRetry: () -> Unit
+) {
+    val clipboardManager = LocalClipboardManager.current
+    val context = LocalContext.current
+    val cardShape = RoundedCornerShape(16.dp)
+    val cardBg = MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.35f)
+    val actionShape = RoundedCornerShape(14.dp)
+    val actionBg = MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.4f)
+
+    when {
+        isLoading -> {
+            Box(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .background(cardBg, cardShape)
+                    .padding(40.dp),
+                contentAlignment = Alignment.Center
+            ) {
+                CircularProgressIndicator(strokeWidth = 2.dp, modifier = Modifier.size(32.dp))
+            }
+        }
+        error != null -> {
+            Column(
+                horizontalAlignment = Alignment.CenterHorizontally,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .background(cardBg, cardShape)
+                    .padding(24.dp)
+            ) {
+                Text(error, style = MaterialTheme.typography.bodyMedium, color = MaterialTheme.colorScheme.error, textAlign = TextAlign.Center)
+                Spacer(Modifier.height(16.dp))
+                OutlinedButton(onClick = onRetry) { Text(stringResource(R.string.retry)) }
+            }
+        }
+        address != null -> {
+            val qrBitmap = remember(address) {
+                val writer = QRCodeWriter()
+                val matrix = writer.encode("bitcoin:$address", BarcodeFormat.QR_CODE, 512, 512)
+                val bitmap = Bitmap.createBitmap(matrix.width, matrix.height, Bitmap.Config.RGB_565)
+                for (x in 0 until matrix.width) {
+                    for (y in 0 until matrix.height) {
+                        bitmap.setPixel(x, y, if (matrix.get(x, y)) android.graphics.Color.BLACK else android.graphics.Color.WHITE)
+                    }
+                }
+                bitmap
+            }
+            Column(horizontalAlignment = Alignment.CenterHorizontally) {
+                Column(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .background(cardBg, cardShape)
+                        .padding(20.dp),
+                    horizontalAlignment = Alignment.CenterHorizontally
+                ) {
+                    Image(
+                        bitmap = qrBitmap.asImageBitmap(),
+                        contentDescription = stringResource(R.string.cd_bitcoin_address_qr),
+                        modifier = Modifier
+                            .size(260.dp)
+                            .background(Color.White, RoundedCornerShape(12.dp))
+                            .padding(8.dp)
+                    )
+                    Spacer(Modifier.height(12.dp))
+                    Text(
+                        address,
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        textAlign = TextAlign.Center,
+                        fontFamily = androidx.compose.ui.text.font.FontFamily.Monospace
+                    )
+                }
+                Spacer(Modifier.height(16.dp))
+                Row(
+                    verticalAlignment = Alignment.CenterVertically,
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .background(actionBg, actionShape)
+                ) {
+                    TextButton(
+                        onClick = { clipboardManager.setText(AnnotatedString(address)) },
+                        modifier = Modifier.weight(1f),
+                        colors = ButtonDefaults.textButtonColors(contentColor = WispThemeColors.zapColor)
+                    ) {
+                        Icon(Icons.Default.ContentCopy, contentDescription = null, modifier = Modifier.size(18.dp))
+                        Spacer(Modifier.width(6.dp))
+                        Text(stringResource(R.string.wallet_copy_address), fontWeight = FontWeight.Medium)
+                    }
+                    VerticalDivider(modifier = Modifier.height(24.dp))
+                    TextButton(
+                        onClick = {
+                            val intent = Intent(Intent.ACTION_SEND).apply {
+                                type = "text/plain"
+                                putExtra(Intent.EXTRA_TEXT, address)
+                            }
+                            context.startActivity(Intent.createChooser(intent, context.getString(R.string.wallet_share_address)))
+                        },
+                        modifier = Modifier.weight(1f),
+                        colors = ButtonDefaults.textButtonColors(contentColor = WispThemeColors.zapColor)
+                    ) {
+                        Icon(Icons.Default.Share, contentDescription = null, modifier = Modifier.size(18.dp))
+                        Spacer(Modifier.width(6.dp))
+                        Text(stringResource(R.string.wallet_share), fontWeight = FontWeight.Medium)
+                    }
+                }
+            }
+        }
+        else -> {
+            // Initial state — trigger load
+            LaunchedEffect(Unit) { onRetry() }
+        }
+    }
+}
+
+// On-chain send: amount entry (with inline fee quote)
+@Composable
+private fun OnchainSendAmountContent(
+    address: String,
+    amount: String,
+    balanceSats: Long,
+    isLoading: Boolean,
+    error: String?,
+    feeQuote: OnchainFeeQuote?,
+    onAmountChange: (String) -> Unit,
+    onUseAll: () -> Unit,
+    onGetFeeQuote: () -> Unit,
+    onContinue: () -> Unit,
+    onBack: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    val amountSats = amount.toLongOrNull() ?: 0L
+    val fieldShape = RoundedCornerShape(14.dp)
+    val fieldBg = MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.4f)
+    val accent = WispThemeColors.zapColor
+
+    Column(
+        modifier = modifier
+            .fillMaxSize()
+            .padding(horizontal = 20.dp)
+            .verticalScroll(rememberScrollState())
+    ) {
+        Spacer(Modifier.height(8.dp))
+        Row(verticalAlignment = Alignment.CenterVertically) {
+            IconButton(onClick = onBack) {
+                Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = stringResource(R.string.btn_back))
+            }
+            Icon(Icons.Default.ArrowUpward, contentDescription = null, tint = accent, modifier = Modifier.size(20.dp))
+            Spacer(Modifier.width(8.dp))
+            Text(stringResource(R.string.wallet_onchain_send_title), style = MaterialTheme.typography.titleLarge, fontWeight = FontWeight.SemiBold)
+        }
+
+        Spacer(Modifier.height(20.dp))
+
+        // Recipient address (read-only)
+        Box(
+            modifier = Modifier
+                .fillMaxWidth()
+                .background(fieldBg, fieldShape)
+                .padding(16.dp)
+        ) {
+            Text(
+                address,
+                style = MaterialTheme.typography.bodyMedium,
+                fontFamily = androidx.compose.ui.text.font.FontFamily.Monospace,
+                color = MaterialTheme.colorScheme.onSurface
+            )
+        }
+        Spacer(Modifier.height(10.dp))
+        Row(verticalAlignment = Alignment.CenterVertically) {
+            Icon(Icons.Default.CurrencyBitcoin, contentDescription = null, tint = accent, modifier = Modifier.size(16.dp))
+            Spacer(Modifier.width(6.dp))
+            Text(
+                stringResource(R.string.wallet_onchain_bitcoin_detected),
+                style = MaterialTheme.typography.bodySmall,
+                color = accent
+            )
+        }
+
+        Spacer(Modifier.height(20.dp))
+
+        // Amount label + Use All
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.SpaceBetween,
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Text(
+                stringResource(R.string.wallet_onchain_amount_sats),
+                style = MaterialTheme.typography.labelMedium,
+                fontWeight = FontWeight.SemiBold,
+                letterSpacing = 0.5.sp,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+            Text(
+                stringResource(R.string.wallet_onchain_use_all, balanceSats),
+                style = MaterialTheme.typography.labelMedium,
+                fontWeight = FontWeight.SemiBold,
+                color = accent,
+                modifier = Modifier.clickable(onClick = onUseAll)
+            )
+        }
+        Spacer(Modifier.height(8.dp))
+        Box(
+            modifier = Modifier
+                .fillMaxWidth()
+                .background(fieldBg, fieldShape)
+                .padding(horizontal = 16.dp, vertical = 16.dp)
+        ) {
+            val amountStyle = MaterialTheme.typography.titleLarge.copy(color = MaterialTheme.colorScheme.onSurface)
+            BasicTextField(
+                value = amount,
+                onValueChange = { onAmountChange(it.filter { c -> c.isDigit() }) },
+                textStyle = amountStyle,
+                singleLine = true,
+                keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
+                cursorBrush = androidx.compose.ui.graphics.SolidColor(MaterialTheme.colorScheme.primary),
+                modifier = Modifier.fillMaxWidth(),
+                decorationBox = { inner ->
+                    if (amount.isEmpty()) Text("0", style = amountStyle.copy(color = MaterialTheme.colorScheme.onSurfaceVariant))
+                    inner()
+                }
+            )
+        }
+
+        if (error != null) {
+            Spacer(Modifier.height(12.dp))
+            Text(error, color = MaterialTheme.colorScheme.error, style = MaterialTheme.typography.bodySmall)
+        }
+
+        Spacer(Modifier.height(20.dp))
+
+        if (feeQuote != null) {
+            val feeSats = feeQuote.mediumFeeSats
+            val totalSats = amountSats + feeSats
+            Column(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .background(fieldBg, fieldShape)
+                    .padding(16.dp),
+                verticalArrangement = Arrangement.spacedBy(10.dp)
+            ) {
+                OnchainAmountRow(stringResource(R.string.wallet_onchain_amount), "%,d sats".format(amountSats))
+                OnchainAmountRow(stringResource(R.string.wallet_onchain_fee), "%,d sats".format(feeSats))
+                HorizontalDivider()
+                OnchainAmountRow(stringResource(R.string.wallet_onchain_total), "%,d sats".format(totalSats), emphasize = true)
+            }
+            Spacer(Modifier.height(16.dp))
+            Button(
+                onClick = onContinue,
+                modifier = Modifier.fillMaxWidth().height(52.dp),
+                shape = fieldShape,
+                colors = ButtonDefaults.buttonColors(containerColor = accent, contentColor = Color.White)
+            ) {
+                Icon(Icons.Default.ArrowUpward, contentDescription = null, modifier = Modifier.size(18.dp))
+                Spacer(Modifier.width(8.dp))
+                Text(stringResource(R.string.wallet_onchain_continue), style = MaterialTheme.typography.titleSmall, fontWeight = FontWeight.SemiBold)
+            }
+        } else if (isLoading) {
+            Box(
+                modifier = Modifier.fillMaxWidth().background(fieldBg, fieldShape).padding(vertical = 14.dp),
+                contentAlignment = Alignment.Center
+            ) {
+                Row(verticalAlignment = Alignment.CenterVertically) {
+                    CircularProgressIndicator(strokeWidth = 2.dp, modifier = Modifier.size(18.dp))
+                    Spacer(Modifier.width(10.dp))
+                    Text(stringResource(R.string.wallet_onchain_fetching_fee), style = MaterialTheme.typography.bodyMedium, color = MaterialTheme.colorScheme.onSurfaceVariant)
+                }
+            }
+        } else {
+            Button(
+                onClick = onGetFeeQuote,
+                enabled = amountSats > 0L,
+                modifier = Modifier.fillMaxWidth().height(52.dp),
+                shape = fieldShape,
+                colors = ButtonDefaults.buttonColors(
+                    containerColor = accent,
+                    contentColor = Color.White,
+                    disabledContainerColor = fieldBg,
+                    disabledContentColor = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+            ) {
+                Text(stringResource(R.string.wallet_onchain_get_fee_quote), style = MaterialTheme.typography.titleSmall, fontWeight = FontWeight.SemiBold)
+            }
         }
 
         Spacer(Modifier.height(24.dp))
@@ -2345,85 +2922,192 @@ private fun ReceiveAmountContent(
 }
 
 @Composable
-private fun ReceiveAddressBlock(address: String) {
-    val clipboardManager = LocalClipboardManager.current
-    val context = LocalContext.current
+private fun OnchainAmountRow(label: String, value: String, emphasize: Boolean = false) {
+    Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.SpaceBetween) {
+        Text(
+            label,
+            style = if (emphasize) MaterialTheme.typography.titleSmall else MaterialTheme.typography.bodyMedium,
+            fontWeight = if (emphasize) FontWeight.SemiBold else FontWeight.Normal,
+            color = if (emphasize) MaterialTheme.colorScheme.onSurface else MaterialTheme.colorScheme.onSurfaceVariant
+        )
+        Text(
+            value,
+            style = if (emphasize) MaterialTheme.typography.titleSmall else MaterialTheme.typography.bodyMedium,
+            fontWeight = if (emphasize) FontWeight.SemiBold else FontWeight.Normal,
+            color = if (emphasize) WispThemeColors.zapColor else MaterialTheme.colorScheme.onSurface
+        )
+    }
+}
 
-    val qrBitmap = remember(address) {
-        val writer = QRCodeWriter()
-        val matrix = writer.encode(address, BarcodeFormat.QR_CODE, 512, 512)
-        val bitmap = Bitmap.createBitmap(matrix.width, matrix.height, Bitmap.Config.RGB_565)
-        for (x in 0 until matrix.width) {
-            for (y in 0 until matrix.height) {
-                bitmap.setPixel(x, y, if (matrix.get(x, y)) android.graphics.Color.BLACK else android.graphics.Color.WHITE)
+// On-chain send: confirm (chunked address, big amount hero, irreversibility warning)
+@Composable
+private fun OnchainSendConfirmContent(
+    address: String,
+    amountSats: Long,
+    feeQuote: OnchainFeeQuote,
+    isLoading: Boolean,
+    onConfirm: () -> Unit,
+    onBack: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    val feeSats = feeQuote.mediumFeeSats
+    val accent = WispThemeColors.zapColor
+    val fieldShape = RoundedCornerShape(14.dp)
+    val fieldBg = MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.4f)
+
+    val chunked = remember(address) {
+        buildAnnotatedString {
+            address.chunked(4).forEachIndexed { i, group ->
+                withStyle(SpanStyle(color = if (i % 2 == 0) androidx.compose.ui.graphics.Color(0xFFE6E6E6) else accent)) {
+                    append(group)
+                }
+                append(" ")
             }
         }
-        bitmap
     }
 
-    val cardShape = RoundedCornerShape(16.dp)
-    val cardBg = MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.35f)
-    val actionShape = RoundedCornerShape(14.dp)
-    val actionBg = MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.4f)
+    Column(
+        modifier = modifier
+            .fillMaxSize()
+            .padding(horizontal = 20.dp)
+            .verticalScroll(rememberScrollState()),
+        horizontalAlignment = Alignment.CenterHorizontally
+    ) {
+        Spacer(Modifier.height(8.dp))
+        Row(modifier = Modifier.fillMaxWidth(), verticalAlignment = Alignment.CenterVertically) {
+            IconButton(onClick = onBack) {
+                Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = stringResource(R.string.btn_back))
+            }
+            Icon(Icons.Default.ArrowUpward, contentDescription = null, tint = accent, modifier = Modifier.size(20.dp))
+            Spacer(Modifier.width(8.dp))
+            Text(stringResource(R.string.wallet_onchain_send_title), style = MaterialTheme.typography.titleLarge, fontWeight = FontWeight.SemiBold)
+        }
 
-    Column(horizontalAlignment = Alignment.CenterHorizontally) {
+        Spacer(Modifier.height(32.dp))
+
+        Text(
+            "%,d sats".format(amountSats),
+            style = MaterialTheme.typography.headlineLarge,
+            fontWeight = FontWeight.Bold,
+            color = accent
+        )
+        Spacer(Modifier.height(4.dp))
+        Text(
+            stringResource(R.string.wallet_onchain_plus_fee, feeSats),
+            style = MaterialTheme.typography.bodyMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant
+        )
+
+        Spacer(Modifier.height(28.dp))
+
         Column(
             modifier = Modifier
                 .fillMaxWidth()
-                .background(cardBg, cardShape)
+                .background(fieldBg, fieldShape)
                 .padding(20.dp),
             horizontalAlignment = Alignment.CenterHorizontally
         ) {
-            Image(
-                bitmap = qrBitmap.asImageBitmap(),
-                contentDescription = stringResource(R.string.cd_invoice_qr_code),
-                modifier = Modifier
-                    .size(260.dp)
-                    .background(Color.White, RoundedCornerShape(12.dp))
-                    .padding(8.dp)
-            )
-            Spacer(Modifier.height(12.dp))
             Text(
-                address,
-                style = MaterialTheme.typography.bodyMedium,
-                color = MaterialTheme.colorScheme.onSurfaceVariant,
-                textAlign = TextAlign.Center
+                stringResource(R.string.wallet_onchain_sending_to),
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+            Spacer(Modifier.height(10.dp))
+            Text(
+                chunked,
+                style = MaterialTheme.typography.bodyLarge,
+                fontFamily = androidx.compose.ui.text.font.FontFamily.Monospace,
+                textAlign = TextAlign.Center,
+                lineHeight = 28.sp
             )
         }
 
         Spacer(Modifier.height(20.dp))
 
-        Row(
-            verticalAlignment = Alignment.CenterVertically,
-            modifier = Modifier
-                .fillMaxWidth()
-                .background(actionBg, actionShape)
-        ) {
-            TextButton(
-                onClick = { clipboardManager.setText(AnnotatedString(address)) },
-                modifier = Modifier.weight(1f),
-                colors = ButtonDefaults.textButtonColors(contentColor = WispThemeColors.zapColor)
-            ) {
-                Icon(Icons.Default.ContentCopy, contentDescription = null, modifier = Modifier.size(18.dp))
-                Spacer(Modifier.width(6.dp))
-                Text("Copy address", fontWeight = FontWeight.Medium)
+        Text(
+            stringResource(R.string.wallet_onchain_irreversible_warning),
+            style = MaterialTheme.typography.bodySmall,
+            color = accent,
+            textAlign = TextAlign.Center
+        )
+
+        Spacer(Modifier.height(24.dp))
+
+        if (isLoading) {
+            CircularProgressIndicator()
+        } else {
+            Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.spacedBy(12.dp)) {
+                OutlinedButton(
+                    onClick = onBack,
+                    modifier = Modifier.weight(1f).height(52.dp),
+                    shape = fieldShape
+                ) {
+                    Text(stringResource(R.string.btn_back))
+                }
+                Button(
+                    onClick = onConfirm,
+                    modifier = Modifier.weight(1f).height(52.dp),
+                    shape = fieldShape,
+                    colors = ButtonDefaults.buttonColors(containerColor = accent, contentColor = Color.White)
+                ) {
+                    Icon(Icons.Default.ArrowUpward, contentDescription = null, modifier = Modifier.size(18.dp))
+                    Spacer(Modifier.width(8.dp))
+                    Text(stringResource(R.string.wallet_onchain_send_confirm), fontWeight = FontWeight.SemiBold)
+                }
             }
-            VerticalDivider(modifier = Modifier.height(24.dp))
-            TextButton(
-                onClick = {
-                    val intent = Intent(Intent.ACTION_SEND).apply {
-                        type = "text/plain"
-                        putExtra(Intent.EXTRA_TEXT, address)
-                    }
-                    context.startActivity(Intent.createChooser(intent, "Share Lightning Address"))
-                },
-                modifier = Modifier.weight(1f),
-                colors = ButtonDefaults.textButtonColors(contentColor = WispThemeColors.zapColor)
-            ) {
-                Icon(Icons.Default.Share, contentDescription = null, modifier = Modifier.size(18.dp))
-                Spacer(Modifier.width(6.dp))
-                Text("Share", fontWeight = FontWeight.Medium)
+        }
+
+        Spacer(Modifier.height(24.dp))
+    }
+}
+
+// On-chain send: result
+@Composable
+private fun OnchainSendResultContent(
+    success: Boolean,
+    paymentId: String?,
+    message: String,
+    onDone: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    val context = LocalContext.current
+
+    Column(
+        modifier = modifier.fillMaxSize().padding(horizontal = 16.dp),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.Center
+    ) {
+        Icon(
+            if (success) Icons.Default.Check else Icons.Default.Close,
+            contentDescription = null,
+            modifier = Modifier.size(72.dp),
+            tint = if (success) WispThemeColors.zapColor else MaterialTheme.colorScheme.error
+        )
+        Spacer(Modifier.height(16.dp))
+        Text(
+            stringResource(if (success) R.string.wallet_onchain_payment_sent else R.string.wallet_onchain_payment_failed),
+            style = MaterialTheme.typography.headlineMedium,
+            color = MaterialTheme.colorScheme.onSurface
+        )
+        Spacer(Modifier.height(8.dp))
+        Text(
+            message,
+            style = MaterialTheme.typography.bodyMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            textAlign = TextAlign.Center
+        )
+        if (success && paymentId != null) {
+            Spacer(Modifier.height(16.dp))
+            TextButton(onClick = {
+                val intent = Intent(Intent.ACTION_VIEW, android.net.Uri.parse("https://mempool.space/tx/$paymentId"))
+                context.startActivity(intent)
+            }) {
+                Text(stringResource(R.string.wallet_onchain_view_mempool))
             }
+        }
+        Spacer(Modifier.height(24.dp))
+        FilledTonalButton(onClick = onDone, modifier = Modifier.fillMaxWidth()) {
+            Text(stringResource(R.string.btn_done))
         }
     }
 }

--- a/app/src/main/kotlin/com/darkwisp/app/ui/screen/WalletScreen.kt
+++ b/app/src/main/kotlin/com/darkwisp/app/ui/screen/WalletScreen.kt
@@ -2599,16 +2599,6 @@ private fun ReceiveAmountContent(
             // Lightning address — shown below invoice form as "or receive via" row
             if (!lightningAddress.isNullOrBlank()) {
                 Spacer(Modifier.height(24.dp))
-                HorizontalDivider(color = MaterialTheme.colorScheme.outline.copy(alpha = 0.3f))
-                Spacer(Modifier.height(16.dp))
-                Text(
-                    stringResource(R.string.wallet_receive_via_address),
-                    style = MaterialTheme.typography.labelMedium,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant,
-                    modifier = Modifier.fillMaxWidth(),
-                    textAlign = TextAlign.Center
-                )
-                Spacer(Modifier.height(12.dp))
                 LightningAddressReceiveRow(address = lightningAddress, onShowQR = onShowAddressQR)
             }
         }

--- a/app/src/main/kotlin/com/darkwisp/app/viewmodel/WalletViewModel.kt
+++ b/app/src/main/kotlin/com/darkwisp/app/viewmodel/WalletViewModel.kt
@@ -30,6 +30,7 @@ import com.darkwisp.app.repo.NwcRepository
 import com.darkwisp.app.repo.SparkRepository
 import com.darkwisp.app.repo.WalletMode
 import com.darkwisp.app.repo.WalletModeRepository
+import com.darkwisp.app.repo.OnchainFeeQuote
 import com.darkwisp.app.repo.WalletProvider
 import android.util.Log
 import com.darkwisp.app.repo.WalletTransaction
@@ -125,6 +126,14 @@ sealed class WalletPage {
     data class SendResult(val success: Boolean, val message: String) : WalletPage()
     object ReceiveAmount : WalletPage()
     data class ReceiveInvoice(val invoice: String, val amountSats: Long) : WalletPage()
+    data class OnchainSendAmount(val address: String) : WalletPage()
+    data class OnchainSendConfirm(
+        val address: String,
+        val amountSats: Long,
+        val feeQuote: OnchainFeeQuote,
+        val prepareData: Any
+    ) : WalletPage()
+    data class OnchainSendResult(val success: Boolean, val paymentId: String?, val message: String) : WalletPage()
     data class ReceiveSuccess(val amountSats: Long) : WalletPage()
     object Transactions : WalletPage()
     object Settings : WalletPage()
@@ -195,6 +204,25 @@ class WalletViewModel(
     // Receive flow
     private val _receiveAmount = MutableStateFlow("")
     val receiveAmount: StateFlow<String> = _receiveAmount
+
+    // On-chain deposit address (Spark only)
+    private val _depositAddress = MutableStateFlow<String?>(null)
+    val depositAddress: StateFlow<String?> = _depositAddress
+
+    private val _depositAddressLoading = MutableStateFlow(false)
+    val depositAddressLoading: StateFlow<Boolean> = _depositAddressLoading
+
+    private val _depositAddressError = MutableStateFlow<String?>(null)
+    val depositAddressError: StateFlow<String?> = _depositAddressError
+
+    // On-chain send (Spark only)
+    private val _onchainFeeQuote = MutableStateFlow<OnchainFeeQuote?>(null)
+    val onchainFeeQuote: StateFlow<OnchainFeeQuote?> = _onchainFeeQuote
+
+    private var _onchainPrepareData: Any? = null
+
+    private val _onchainSendLoading = MutableStateFlow(false)
+    val onchainSendLoading: StateFlow<Boolean> = _onchainSendLoading
 
     // Transactions
     private val _transactions = MutableStateFlow<List<WalletTransaction>>(emptyList())
@@ -318,6 +346,11 @@ class WalletViewModel(
         // would otherwise stay at the prior wallet's acknowledged value
         // until the next refreshState() call.
         _seedBackupAcked.value = false
+        _depositAddress.value = null
+        _depositAddressError.value = null
+        _depositAddressLoading.value = false
+        _onchainFeeQuote.value = null
+        _onchainPrepareData = null
     }
 
     /**
@@ -544,6 +577,8 @@ class WalletViewModel(
         _deleteConfirmText.value = ""
         _lightningAddressError.value = null
         _addressAvailable.value = null
+        _onchainFeeQuote.value = null
+        _onchainPrepareData = null
     }
 
     val isOnHome: Boolean get() = pageStack.size <= 1
@@ -1248,6 +1283,10 @@ class WalletViewModel(
         _sendError.value = null
     }
 
+    fun setSendAmount(value: String) {
+        _sendAmount.value = value
+    }
+
     fun updateSendAmount(digit: Char) {
         val current = _sendAmount.value
         if (current.length < 10) {
@@ -1262,8 +1301,18 @@ class WalletViewModel(
         }
     }
 
+    private fun isBtcAddress(s: String): Boolean {
+        val lower = s.lowercase()
+        if (lower.startsWith("bc1") && s.length >= 14) return true
+        if ((s.startsWith("1") || s.startsWith("3")) && s.length in 26..35 &&
+            s.all { it.isLetterOrDigit() && it != '0' && it != 'O' && it != 'I' && it != 'l' }) return true
+        return false
+    }
+
     fun processInput(input: String = _sendInput.value) {
-        val trimmed = input.trim().removePrefix("lightning:")
+        val trimmed = input.trim()
+            .removePrefix("lightning:").removePrefix("LIGHTNING:")
+            .let { it.removePrefix("bitcoin:").removePrefix("BITCOIN:") }
         _sendError.value = null
 
         when {
@@ -1283,6 +1332,10 @@ class WalletViewModel(
                     _sendAmount.value = ""
                     navigateTo(WalletPage.SendAmount(noffer.raw))
                 }
+            }
+            _walletMode.value == WalletMode.SPARK && isBtcAddress(trimmed) -> {
+                clearOnchainQuote()
+                navigateTo(WalletPage.OnchainSendAmount(trimmed))
             }
             trimmed.lowercase().startsWith("lnbc") -> {
                 val decoded = Bolt11.decode(trimmed)
@@ -1306,7 +1359,10 @@ class WalletViewModel(
                 navigateTo(WalletPage.SendAmount(trimmed))
             }
             else -> {
-                _sendError.value = "Enter a lightning address (user@domain), BOLT11 invoice, or CLINK offer"
+                _sendError.value = if (_walletMode.value == WalletMode.SPARK)
+                    "Enter a lightning address, BOLT11 invoice, CLINK offer, or Bitcoin address"
+                else
+                    "Enter a lightning address (user@domain), BOLT11 invoice, or CLINK offer"
             }
         }
     }
@@ -1482,10 +1538,10 @@ class WalletViewModel(
         _receiveAmount.value = value
     }
 
-    fun generateInvoice(amountSats: Long, description: String = "") {
+    fun generateInvoice(amountSats: Long, description: String = "", expirySecs: Int = 3600) {
         _isLoading.value = true
         viewModelScope.launch {
-            val result = activeProvider.makeInvoice(amountSats * 1000, description)
+            val result = activeProvider.makeInvoice(amountSats * 1000, description, expirySecs)
             result.fold(
                 onSuccess = { invoice ->
                     navigateTo(WalletPage.ReceiveInvoice(invoice, amountSats))
@@ -1493,6 +1549,74 @@ class WalletViewModel(
                 },
                 onFailure = { e ->
                     _sendError.value = e.message ?: "Failed to create invoice"
+                }
+            )
+            _isLoading.value = false
+        }
+    }
+
+    // --- On-chain receive (Spark only) ---
+
+    fun loadDepositAddress(force: Boolean = false) {
+        if (!force && _depositAddress.value != null) return
+        _depositAddressLoading.value = true
+        _depositAddressError.value = null
+        viewModelScope.launch {
+            sparkRepo.getDepositAddress().fold(
+                onSuccess = { address -> _depositAddress.value = address },
+                onFailure = { e -> _depositAddressError.value = e.message ?: "Failed to load address" }
+            )
+            _depositAddressLoading.value = false
+        }
+    }
+
+    // --- On-chain send (Spark only) ---
+
+    fun clearOnchainQuote() {
+        _onchainFeeQuote.value = null
+        _onchainPrepareData = null
+    }
+
+    fun prepareOnchainSend(address: String, amountSats: Long) {
+        clearOnchainQuote()
+        _onchainSendLoading.value = true
+        _sendError.value = null
+        viewModelScope.launch {
+            sparkRepo.prepareOnchainSend(address, amountSats).fold(
+                onSuccess = { (quote, prepareData) ->
+                    _onchainFeeQuote.value = quote
+                    _onchainPrepareData = prepareData
+                },
+                onFailure = { e -> _sendError.value = e.message ?: "Failed to estimate fee" }
+            )
+            _onchainSendLoading.value = false
+        }
+    }
+
+    fun continueToOnchainConfirm(address: String, amountSats: Long) {
+        val quote = _onchainFeeQuote.value ?: return
+        val prepareData = _onchainPrepareData ?: return
+        navigateTo(WalletPage.OnchainSendConfirm(address, amountSats, quote, prepareData))
+    }
+
+    fun sendOnchain(prepareData: Any) {
+        if (_isLoading.value) return
+        _isLoading.value = true
+        viewModelScope.launch {
+            sparkRepo.sendOnchain(prepareData).fold(
+                onSuccess = { paymentId ->
+                    pageStack.removeAt(pageStack.lastIndex)
+                    val resultPage = WalletPage.OnchainSendResult(true, paymentId, "Bitcoin sent!")
+                    pageStack.add(resultPage)
+                    _currentPage.value = resultPage
+                    clearOnchainQuote()
+                    refreshBalance()
+                },
+                onFailure = { e ->
+                    pageStack.removeAt(pageStack.lastIndex)
+                    val resultPage = WalletPage.OnchainSendResult(false, null, e.message ?: "Send failed")
+                    pageStack.add(resultPage)
+                    _currentPage.value = resultPage
                 }
             )
             _isLoading.value = false

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -776,6 +776,46 @@
     <string name="wallet_receive_note_label">NOTE (OPTIONAL)</string>
     <string name="wallet_receive_note_placeholder">For coffee, etc.</string>
     <string name="wallet_receive_create_invoice">Create invoice</string>
+    <!-- Updated tab labels for Spark on-chain receive -->
+    <string name="wallet_receive_lightning_tab">Lightning</string>
+    <string name="wallet_receive_bitcoin_tab">Bitcoin</string>
+    <!-- Invoice expiry selector -->
+    <string name="wallet_receive_expires_label">EXPIRES</string>
+    <string name="wallet_receive_expires_1h">1 hour</string>
+    <string name="wallet_receive_expires_24h">24 hours</string>
+    <string name="wallet_receive_expires_custom">Custom</string>
+    <string name="wallet_receive_expires_hours">Hours until expiry</string>
+    <!-- Lightning address receive row -->
+    <string name="wallet_receive_via_address">or receive to your Lightning address</string>
+    <string name="wallet_copy_address">Copy address</string>
+    <string name="wallet_share_address">Share address</string>
+    <string name="wallet_share">Share</string>
+    <!-- Bitcoin on-chain deposit address -->
+    <string name="cd_bitcoin_address_qr">Bitcoin address QR code</string>
+    <!-- On-chain send flow -->
+    <string name="wallet_onchain_send_title">Send Payment</string>
+    <string name="wallet_onchain_bitcoin_detected">Bitcoin address detected – on-chain payment</string>
+    <string name="wallet_onchain_amount_sats">Amount (sats)</string>
+    <string name="wallet_onchain_use_all" formatted="false">Use All (%,d sats)</string>
+    <string name="wallet_onchain_fetching_fee">Estimating fee…</string>
+    <string name="wallet_onchain_get_fee_quote">Get Fee Quote</string>
+    <string name="wallet_onchain_amount">Amount</string>
+    <string name="wallet_onchain_fee">Network Fee</string>
+    <string name="wallet_onchain_total">Total</string>
+    <string name="wallet_onchain_continue">Continue</string>
+    <string name="wallet_onchain_plus_fee" formatted="false">+ %,d sats fee</string>
+    <string name="wallet_onchain_sending_to">Sending to:</string>
+    <string name="wallet_onchain_irreversible_warning">Bitcoin transactions cannot be reversed. Please verify the address is correct.</string>
+    <string name="wallet_onchain_send_confirm">Confirm Send</string>
+    <string name="wallet_onchain_payment_sent">Sent</string>
+    <string name="wallet_onchain_payment_failed">Send Failed</string>
+    <string name="wallet_onchain_view_mempool">View on mempool.space</string>
+    <!-- Spark send placeholder (accepts Lightning + Bitcoin addresses) -->
+    <string name="placeholder_send_spark">Lightning invoice or Bitcoin address</string>
+    <!-- Generic actions -->
+    <string name="retry">Retry</string>
+    <string name="cancel">Cancel</string>
+    <string name="done">Done</string>
     <string name="wallet_backup_missing_title">Wallet backup not found</string>
     <string name="wallet_backup_missing_body">Your wallet recovery phrase is not backed up to any relay. If you lose this device, you could lose your funds.</string>
     <string name="wallet_backup_now">Backup Now</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -812,6 +812,7 @@
     <string name="wallet_onchain_view_mempool">View on mempool.space</string>
     <!-- Spark send placeholder (accepts Lightning + Bitcoin addresses) -->
     <string name="placeholder_send_spark">Lightning invoice or Bitcoin address</string>
+    <string name="wallet_send_input_hint_onchain">Lightning or Bitcoin address, invoice, or CLINK offer</string>
     <!-- Generic actions -->
     <string name="retry">Retry</string>
     <string name="cancel">Cancel</string>
@@ -901,6 +902,8 @@
     <string name="section_invite_codes">Invite codes</string>
     <string name="action_generate_invite">Generate invite code</string>
     <string name="label_latest_invite_code">Latest invite code</string>
+    <string name="action_copy">Copy</string>
+    <string name="wallet_tx_pending">Pending</string>
     <string name="action_copy_code">Copy code</string>
     <string name="action_copy_invite_link">Copy invite link</string>
     <string name="title_assign_role">Assign role</string>


### PR DESCRIPTION
## Summary

- **On-chain receive** (Spark only): Bitcoin deposit address via Spark SDK with QR code, copy, and share; shown under the Lightning tab as a segmented tab switcher
- **On-chain send** (Spark only): Bitcoin address auto-detection in Send input → amount entry with fee quote → confirmation screen with chunked alternating-color address and irreversibility warning; mempool.space deep-link on completion
- **Receive screen redesign**: segmented Lightning / Bitcoin tabs (Spark), expiry selector (1h · 24h · Custom), note field, fiat toggle parity; lightning address row redesigned as compact bolt icon + address + QR icon + copy icon
- **iOS-style Send input**: tall dark card with top-aligned placeholder (mentions CLINK for both Spark and NWC), Scan QR · Paste · Gallery action row, accent Next button
- **On-chain send icons**: ArrowUpward replaced with AutoMirrored Send (paper airplane) icon on both amount and confirm screens
- **Transaction history bottom sheet**: swipe-up sheet overlays the home dashboard instead of replacing it; 40 px upward drag or "View all" tap opens it, swipe down or scrim tap dismisses
- **Expandable transaction detail drawer**: tap any row in the history sheet to expand Status, Type, Amount, Network fee, Date, Note, and Payment hash with copy icon; on-chain transactions get a mempool.space deep-link

## Test plan

- [ ] Spark: Send input shows "Lightning or Bitcoin address, invoice, or CLINK offer" placeholder
- [ ] NWC: Send input shows "Lightning address, invoice, or CLINK offer" placeholder
- [ ] Paste, Scan QR, and Gallery all populate the send field; nsec strings are blocked
- [ ] Spark: entering a `bc1…` address routes to on-chain send flow
- [ ] On-chain amount screen: fee quote loads, Use All fills balance, Continue advances
- [ ] On-chain confirm screen: paper airplane icon, chunked address, irreversibility warning
- [ ] On-chain result: mempool.space link appears on success
- [ ] Receive: Lightning / Bitcoin tab switcher shown for Spark; NWC shows Lightning only
- [ ] Lightning address row shows QR icon → navigates to address QR page
- [ ] Expiry selector (1h · 24h · Custom) generates invoices with correct expiry
- [ ] Transaction sheet: swipe up on recent tx footer → sheet opens over home dashboard
- [ ] Transaction sheet: swipe down or tap scrim → dismisses
- [ ] Tap any transaction row → detail drawer expands with correct fields
- [ ] Payment hash copy icon works; on-chain row shows mempool.space link