### PR TITLE
feat: render kind 30817 (custom NIPs / NUDs) like articles

### DIFF
--- a/app/src/main/kotlin/com/darkwisp/app/Navigation.kt
+++ b/app/src/main/kotlin/com/darkwisp/app/Navigation.kt
@@ -191,7 +191,8 @@ fun NostrUriData.toRoute(): String? = when (this) {
     is NostrUriData.ProfileRef -> "profile/$pubkey"
     is NostrUriData.NoteRef -> "thread/$eventId"
     is NostrUriData.AddressRef ->
-        if (kind == 30023 && author != null) "article/$kind/$author/$dTag" else null
+        if ((kind == 30023 || kind == com.darkwisp.app.nostr.CustomNip.KIND) && author != null)
+            "article/$kind/$author/$dTag" else null
 }
 
 @Composable
@@ -2423,6 +2424,7 @@ fun WispNavHost(
                 articleViewModel.loadArticle(kind, author, dTag, feedViewModel.eventRepo)
                 val articleEvent = feedViewModel.eventRepo.findAddressableEvent(kind, author, dTag)
                 articleViewModel.loadComments(
+                    kind = kind,
                     author = author,
                     dTag = dTag,
                     articleEventId = articleEvent?.id,

--- a/app/src/main/kotlin/com/darkwisp/app/nostr/CustomNip.kt
+++ b/app/src/main/kotlin/com/darkwisp/app/nostr/CustomNip.kt
@@ -1,0 +1,21 @@
+package com.darkwisp.app.nostr
+
+/**
+ * Custom NIP (kind 30817) — a "NUD" (Nostr Unofficial Document): a community-authored NIP.
+ * Structurally identical to a NIP-23 long-form article (addressable by `kind:pubkey:d`,
+ * markdown body, `title`/`published_at`/`summary` tags), plus zero or more `k` tags naming
+ * the event kinds the document defines. We render it with the existing article machinery; this
+ * object just holds the kind constant and the `k`-tag parsing for the defined-kind chips.
+ */
+object CustomNip {
+    const val KIND = 30817
+
+    /** A kind this NUD defines, from a `["k", "<number>", "<name>"]` tag (name optional). */
+    data class DefinedKind(val num: String, val name: String)
+
+    /** Parse the `k` tags into the kinds this document defines, in tag order. */
+    fun parseDefinedKinds(event: NostrEvent): List<DefinedKind> =
+        event.tags
+            .filter { it.size >= 2 && it[0] == "k" && it[1].isNotBlank() }
+            .map { DefinedKind(num = it[1], name = it.getOrNull(2)?.trim().orEmpty()) }
+}

--- a/app/src/main/kotlin/com/darkwisp/app/ui/component/RichContent.kt
+++ b/app/src/main/kotlin/com/darkwisp/app/ui/component/RichContent.kt
@@ -1054,9 +1054,10 @@ fun RichContent(
                                     )
                                 }
                             }
-                            kind == 30023 -> {
+                            kind == 30023 || kind == com.darkwisp.app.nostr.CustomNip.KIND -> {
                                 if (eventRepo != null && segment.author != null) {
                                     ArticleCard(
+                                        kind = kind,
                                         dTag = segment.dTag,
                                         author = segment.author,
                                         relayHints = segment.relays,
@@ -1501,6 +1502,7 @@ private fun UnsupportedKindBadge(kind: Int?, style: TextStyle) {
 
 @Composable
 private fun ArticleCard(
+    kind: Int,
     dTag: String,
     author: String,
     relayHints: List<String>,
@@ -1509,14 +1511,14 @@ private fun ArticleCard(
     onProfileClick: ((String) -> Unit)?
 ) {
     val version by eventRepo.quotedEventVersion.collectAsState()
-    val event = remember(author, dTag, version) {
-        eventRepo.findAddressableEvent(30023, author, dTag)
+    val event = remember(kind, author, dTag, version) {
+        eventRepo.findAddressableEvent(kind, author, dTag)
     }
     val profile = remember(author, version) { eventRepo.getProfileData(author) }
 
-    LaunchedEffect(author, dTag) {
-        if (eventRepo.findAddressableEvent(30023, author, dTag) == null) {
-            eventRepo.requestAddressableEvent(30023, author, dTag, relayHints)
+    LaunchedEffect(kind, author, dTag) {
+        if (eventRepo.findAddressableEvent(kind, author, dTag) == null) {
+            eventRepo.requestAddressableEvent(kind, author, dTag, relayHints)
         }
     }
 
@@ -1533,7 +1535,7 @@ private fun ArticleCard(
             .fillMaxWidth()
             .padding(vertical = 6.dp)
             .then(
-                if (onArticleClick != null) Modifier.clickable { onArticleClick(30023, author, dTag) }
+                if (onArticleClick != null) Modifier.clickable { onArticleClick(kind, author, dTag) }
                 else Modifier
             )
     ) {
@@ -1577,14 +1579,14 @@ private fun ArticleCard(
                             modifier = Modifier.padding(end = 8.dp)
                         ) {
                             Text(
-                                text = "ARTICLE",
+                                text = if (kind == com.darkwisp.app.nostr.CustomNip.KIND) "NIP" else "ARTICLE",
                                 style = MaterialTheme.typography.labelSmall,
                                 color = MaterialTheme.colorScheme.onPrimaryContainer,
                                 modifier = Modifier.padding(horizontal = 6.dp, vertical = 2.dp)
                             )
                         }
                         Text(
-                            text = title ?: "Untitled Article",
+                            text = title ?: if (kind == com.darkwisp.app.nostr.CustomNip.KIND) "Untitled NIP" else "Untitled Article",
                             style = MaterialTheme.typography.titleSmall,
                             color = MaterialTheme.colorScheme.onSurface,
                             maxLines = 2,

--- a/app/src/main/kotlin/com/darkwisp/app/ui/screen/ArticleScreen.kt
+++ b/app/src/main/kotlin/com/darkwisp/app/ui/screen/ArticleScreen.kt
@@ -27,6 +27,7 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
+import androidx.compose.material3.AssistChip
 import androidx.compose.material3.SuggestionChip
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
@@ -56,6 +57,7 @@ import androidx.compose.ui.unit.dp
 import coil3.compose.AsyncImage
 import com.darkwisp.app.repo.EventRepository
 import com.darkwisp.app.ui.component.ProfilePicture
+import com.darkwisp.app.nostr.CustomNip
 import com.darkwisp.app.nostr.Nip30
 import com.darkwisp.app.nostr.NostrEvent
 import com.darkwisp.app.ui.component.ActionBar
@@ -96,6 +98,7 @@ fun ArticleScreen(
     val coverImage by viewModel.coverImage.collectAsState()
     val publishedAt by viewModel.publishedAt.collectAsState()
     val hashtags by viewModel.hashtags.collectAsState()
+    val definedKinds by viewModel.definedKinds.collectAsState()
     val comments by viewModel.comments.collectAsState()
     val isCommentsLoading by viewModel.isCommentsLoading.collectAsState()
 
@@ -125,7 +128,7 @@ fun ArticleScreen(
             TopAppBar(
                 title = {
                     Text(
-                        text = title ?: "Article",
+                        text = title ?: if (article?.kind == CustomNip.KIND) "NIP" else "Article",
                         maxLines = 1,
                         overflow = TextOverflow.Ellipsis
                     )
@@ -214,6 +217,22 @@ fun ArticleScreen(
                                                 color = MaterialTheme.colorScheme.onSurfaceVariant
                                             )
                                         }
+                                    }
+                                }
+                            }
+
+                            if (definedKinds.isNotEmpty()) {
+                                Spacer(Modifier.height(12.dp))
+                                FlowRow {
+                                    definedKinds.forEach { dk ->
+                                        val label = if (dk.name.isNotBlank()) "kind ${dk.num} · ${dk.name}"
+                                                    else "kind ${dk.num}"
+                                        AssistChip(
+                                            onClick = {},
+                                            enabled = false,
+                                            label = { Text(label) },
+                                            modifier = Modifier.padding(end = 6.dp)
+                                        )
                                     }
                                 }
                             }

--- a/app/src/main/kotlin/com/darkwisp/app/viewmodel/ArticleViewModel.kt
+++ b/app/src/main/kotlin/com/darkwisp/app/viewmodel/ArticleViewModel.kt
@@ -3,6 +3,7 @@ package com.darkwisp.app.viewmodel
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.darkwisp.app.nostr.ClientMessage
+import com.darkwisp.app.nostr.CustomNip
 import com.darkwisp.app.nostr.Filter
 import com.darkwisp.app.nostr.Nip10
 import com.darkwisp.app.nostr.Nip57
@@ -38,6 +39,10 @@ class ArticleViewModel : ViewModel() {
 
     private val _hashtags = MutableStateFlow<List<String>>(emptyList())
     val hashtags: StateFlow<List<String>> = _hashtags
+
+    // Custom NIP (kind 30817) defined-kind chips, from `k` tags. Empty for ordinary articles.
+    private val _definedKinds = MutableStateFlow<List<CustomNip.DefinedKind>>(emptyList())
+    val definedKinds: StateFlow<List<CustomNip.DefinedKind>> = _definedKinds
 
     // Comments
     private val _comments = MutableStateFlow<List<Pair<NostrEvent, Int>>>(emptyList())
@@ -89,6 +94,7 @@ class ArticleViewModel : ViewModel() {
     }
 
     fun loadComments(
+        kind: Int,
         author: String,
         dTag: String,
         articleEventId: String?,
@@ -107,7 +113,7 @@ class ArticleViewModel : ViewModel() {
         this.relayHintStoreRef = relayHintStore
         _isCommentsLoading.value = true
 
-        val coordinate = "30023:$author:$dTag"
+        val coordinate = "$kind:$author:$dTag"
         val commentSubId = "article-comments"
         activeSubIds.add(commentSubId)
 
@@ -365,6 +371,8 @@ class ArticleViewModel : ViewModel() {
         _coverImage.value = event.tags.firstOrNull { it.size >= 2 && it[0] == "image" }?.get(1)
         _publishedAt.value = event.tags.firstOrNull { it.size >= 2 && it[0] == "published_at" }?.get(1)?.toLongOrNull()
         _hashtags.value = event.tags.filter { it.size >= 2 && it[0] == "t" }.map { it[1] }
+        _definedKinds.value =
+            if (event.kind == CustomNip.KIND) CustomNip.parseDefinedKinds(event) else emptyList()
         _isLoading.value = false
     }
 


### PR DESCRIPTION
Community-authored NIPs (kind 30817) are structurally NIP-23 long-form articles, so render them through the existing article machinery: inline naddr embed card, full reader, and comments keyed by the kind:pubkey:d coordinate.

- nostr/CustomNip.kt: KIND constant + k-tag (defined-kinds) parsing
- Navigation: route 30817 naddr into the article reader; pass kind to comments
- ArticleViewModel: kind-parameterized comment/engagement coordinate (was hardcoded 30023); expose defined-kinds for the reader chips
- ArticleScreen: defined-kind chips; NIP label/fallback for 30817
- RichContent: embed dispatch + ArticleCard kind-aware (fetch/lookup/click, NIP kicker instead of ARTICLE)