### PR TITLE
feat(wallet): Receive redesign, tx history sheet, on-chain tx display

### DIFF
--- a/app/src/main/kotlin/com/darkwisp/app/nostr/Nip47.kt
+++ b/app/src/main/kotlin/com/darkwisp/app/nostr/Nip47.kt
@@ -49,7 +49,7 @@ object Nip47 {
         object GetBalance : NwcRequest()
         object GetInfo : NwcRequest()
         data class PayInvoice(val invoice: String) : NwcRequest()
-        data class MakeInvoice(val amountMsats: Long, val description: String) : NwcRequest()
+        data class MakeInvoice(val amountMsats: Long, val description: String, val expiry: Int? = null) : NwcRequest()
         data class ListTransactions(val limit: Int = 50, val offset: Int = 0) : NwcRequest()
     }
 
@@ -172,6 +172,7 @@ object Nip47 {
                 put("params", buildJsonObject {
                     put("amount", request.amountMsats)
                     put("description", request.description)
+                    request.expiry?.let { put("expiry", it) }
                 })
             }
             is NwcRequest.ListTransactions -> buildJsonObject {

--- a/app/src/main/kotlin/com/darkwisp/app/repo/NwcRepository.kt
+++ b/app/src/main/kotlin/com/darkwisp/app/repo/NwcRepository.kt
@@ -356,15 +356,6 @@ class NwcRepository(private val context: Context, private val relayPool: RelayPo
         return result.map { (it as Nip47.NwcResponse.MakeInvoiceResult).invoice }
     }
 
-    override suspend fun getDepositAddress(): Result<String> =
-        Result.failure(UnsupportedOperationException("NWC does not support on-chain receive"))
-
-    override suspend fun prepareOnchainSend(address: String, amountSats: Long): Result<Pair<OnchainFeeQuote, Any>> =
-        Result.failure(UnsupportedOperationException("NWC does not support on-chain send"))
-
-    override suspend fun sendOnchain(prepareData: Any, speed: String): Result<String> =
-        Result.failure(UnsupportedOperationException("NWC does not support on-chain send"))
-
     suspend fun listNwcTransactions(limit: Int = 50, offset: Int = 0): Result<List<Nip47.Transaction>> {
         val result = sendRequest(Nip47.NwcRequest.ListTransactions(limit = limit, offset = offset))
         return result.map { (it as Nip47.NwcResponse.ListTransactionsResult).transactions }

--- a/app/src/main/kotlin/com/darkwisp/app/repo/NwcRepository.kt
+++ b/app/src/main/kotlin/com/darkwisp/app/repo/NwcRepository.kt
@@ -58,6 +58,9 @@ class NwcRepository(private val context: Context, private val relayPool: RelayPo
     private val _paymentReceived = MutableSharedFlow<Long>(extraBufferCapacity = 8)
     override val paymentReceived: SharedFlow<Long> = _paymentReceived
 
+    private val _transactionsChanged = MutableSharedFlow<Unit>(extraBufferCapacity = 8)
+    override val transactionsChanged: SharedFlow<Unit> = _transactionsChanged
+
     private fun emitStatus(msg: String) {
         Log.d(TAG, msg)
         _statusLog.tryEmit(msg)
@@ -348,10 +351,19 @@ class NwcRepository(private val context: Context, private val relayPool: RelayPo
         return result.map { (it as Nip47.NwcResponse.PayInvoiceResult).preimage }
     }
 
-    override suspend fun makeInvoice(amountMsats: Long, description: String): Result<String> {
-        val result = sendRequest(Nip47.NwcRequest.MakeInvoice(amountMsats, description))
+    override suspend fun makeInvoice(amountMsats: Long, description: String, expirySecs: Int): Result<String> {
+        val result = sendRequest(Nip47.NwcRequest.MakeInvoice(amountMsats, description, expirySecs))
         return result.map { (it as Nip47.NwcResponse.MakeInvoiceResult).invoice }
     }
+
+    override suspend fun getDepositAddress(): Result<String> =
+        Result.failure(UnsupportedOperationException("NWC does not support on-chain receive"))
+
+    override suspend fun prepareOnchainSend(address: String, amountSats: Long): Result<Pair<OnchainFeeQuote, Any>> =
+        Result.failure(UnsupportedOperationException("NWC does not support on-chain send"))
+
+    override suspend fun sendOnchain(prepareData: Any, speed: String): Result<String> =
+        Result.failure(UnsupportedOperationException("NWC does not support on-chain send"))
 
     suspend fun listNwcTransactions(limit: Int = 50, offset: Int = 0): Result<List<Nip47.Transaction>> {
         val result = sendRequest(Nip47.NwcRequest.ListTransactions(limit = limit, offset = offset))

--- a/app/src/main/kotlin/com/darkwisp/app/repo/SparkRepository.kt
+++ b/app/src/main/kotlin/com/darkwisp/app/repo/SparkRepository.kt
@@ -5,10 +5,13 @@ import android.util.Log
 import androidx.security.crypto.EncryptedSharedPreferences
 import androidx.security.crypto.MasterKey
 import breez_sdk_spark.CheckLightningAddressRequest
+import breez_sdk_spark.ClaimDepositRequest
 import breez_sdk_spark.ConnectRequest
+import breez_sdk_spark.DepositInfo
 import breez_sdk_spark.EventListener
 import breez_sdk_spark.GetInfoRequest
 import breez_sdk_spark.ListPaymentsRequest
+import breez_sdk_spark.MaxFee
 import breez_sdk_spark.Network
 import breez_sdk_spark.PaymentDetails
 import breez_sdk_spark.PaymentType
@@ -284,6 +287,9 @@ class SparkRepository(
                                 refreshBalanceInternal()
                                 _transactionsChanged.tryEmit(Unit)
                             }
+                            is SdkEvent.UnclaimedDeposits -> {
+                                claimDeposits(e.unclaimedDeposits)
+                            }
                             else -> {}
                         }
                     }
@@ -294,6 +300,7 @@ class SparkRepository(
                 emitStatus("Connected to Spark")
 
                 refreshBalanceInternal()
+                claimPendingDeposits()
             } catch (e: Exception) {
                 emitStatus("Connection failed: ${e.message}")
                 Log.e(TAG, "Spark connect failed", e)
@@ -468,6 +475,54 @@ class SparkRepository(
         }
     }
 
+    // --- On-chain deposit claiming ---
+
+    /**
+     * On-chain deposits sit unclaimed (and show as "Pending" in history) until
+     * explicitly claimed once they have enough confirmations. The SDK emits
+     * [SdkEvent.UnclaimedDeposits] when deposits become claimable; claim them
+     * automatically so they settle without user action.
+     */
+    private suspend fun claimDeposits(deposits: List<DepositInfo>) {
+        val instance = sdk ?: return
+        var claimedAny = false
+        for (deposit in deposits) {
+            try {
+                instance.claimDeposit(
+                    ClaimDepositRequest(
+                        txid = deposit.txid,
+                        vout = deposit.vout,
+                        maxFee = MaxFee.NetworkRecommended(leewaySatPerVbyte = 5UL)
+                    )
+                )
+                claimedAny = true
+                emitStatus("Claimed on-chain deposit")
+            } catch (e: Exception) {
+                emitStatus("Failed to claim deposit: ${e.message}")
+                Log.e(TAG, "claimDeposit failed for ${deposit.txid}", e)
+            }
+        }
+        if (claimedAny) {
+            refreshBalanceInternal()
+            _transactionsChanged.tryEmit(Unit)
+        }
+    }
+
+    /** Claim any deposits that became claimable while the app was closed. */
+    suspend fun claimPendingDeposits() {
+        withContext(Dispatchers.IO) {
+            try {
+                val instance = sdk ?: return@withContext
+                val response = instance.listUnclaimedDeposits(breez_sdk_spark.ListUnclaimedDepositsRequest)
+                if (response.deposits.isNotEmpty()) {
+                    claimDeposits(response.deposits)
+                }
+            } catch (e: Exception) {
+                Log.d(TAG, "listUnclaimedDeposits failed: ${e.message}")
+            }
+        }
+    }
+
     // --- Transactions ---
 
     override suspend fun listTransactions(limit: Int, offset: Int): Result<List<WalletTransaction>> =
@@ -512,7 +567,13 @@ class SparkRepository(
                         feeMsats = payment.fees.toLong() * 1000,
                         createdAt = payment.timestamp.toLong(),
                         settledAt = payment.timestamp.toLong(),
-                        pending = payment.status == breez_sdk_spark.PaymentStatus.PENDING,
+                        // On-chain payments made outside this app instance (another
+                        // wallet on the same seed) aren't tracked by this SDK session,
+                        // so PaymentStatus can stay stuck at PENDING long after the
+                        // underlying transaction is confirmed. Since dark-wisp doesn't
+                        // initiate on-chain send/receive itself, don't trust that flag
+                        // for on-chain rows — the mempool.space link lets users verify.
+                        pending = !onchain && payment.status == breez_sdk_spark.PaymentStatus.PENDING,
                         isOnchain = onchain
                     )
                 }

--- a/app/src/main/kotlin/com/darkwisp/app/repo/SparkRepository.kt
+++ b/app/src/main/kotlin/com/darkwisp/app/repo/SparkRepository.kt
@@ -10,7 +10,6 @@ import breez_sdk_spark.EventListener
 import breez_sdk_spark.GetInfoRequest
 import breez_sdk_spark.ListPaymentsRequest
 import breez_sdk_spark.Network
-import breez_sdk_spark.OnchainConfirmationSpeed
 import breez_sdk_spark.PaymentDetails
 import breez_sdk_spark.PaymentType
 import breez_sdk_spark.PrepareSendPaymentRequest
@@ -455,57 +454,6 @@ class SparkRepository(
             }
         }
 
-    override suspend fun getDepositAddress(): Result<String> = withContext(Dispatchers.IO) {
-        try {
-            val instance = sdk ?: return@withContext Result.failure(Exception("Not connected"))
-            val response = instance.receivePayment(ReceivePaymentRequest(ReceivePaymentMethod.BitcoinAddress))
-            Result.success(response.paymentRequest)
-        } catch (e: Exception) {
-            Result.failure(e)
-        }
-    }
-
-    override suspend fun prepareOnchainSend(address: String, amountSats: Long): Result<Pair<OnchainFeeQuote, Any>> =
-        withContext(Dispatchers.IO) {
-            try {
-                val instance = sdk ?: return@withContext Result.failure(Exception("Not connected"))
-                val prepareReq = PrepareSendPaymentRequest(
-                    paymentRequest = address,
-                    amount = java.math.BigInteger.valueOf(amountSats)
-                )
-                val prepareResponse = instance.prepareSendPayment(prepareReq)
-                val method = prepareResponse.paymentMethod as? SendPaymentMethod.BitcoinAddress
-                    ?: return@withContext Result.failure(Exception("Not a Bitcoin address payment"))
-                val feeQuote = method.feeQuote
-                val quote = OnchainFeeQuote(
-                    fastFeeSats = (feeQuote.speedFast.userFeeSat + feeQuote.speedFast.l1BroadcastFeeSat).toLong(),
-                    mediumFeeSats = (feeQuote.speedMedium.userFeeSat + feeQuote.speedMedium.l1BroadcastFeeSat).toLong(),
-                    slowFeeSats = (feeQuote.speedSlow.userFeeSat + feeQuote.speedSlow.l1BroadcastFeeSat).toLong()
-                )
-                Result.success(Pair(quote, prepareResponse as Any))
-            } catch (e: Exception) {
-                Result.failure(e)
-            }
-        }
-
-    override suspend fun sendOnchain(prepareData: Any, speed: String): Result<String> = withContext(Dispatchers.IO) {
-        try {
-            val instance = sdk ?: return@withContext Result.failure(Exception("Not connected"))
-            val prepareResponse = prepareData as breez_sdk_spark.PrepareSendPaymentResponse
-            val confirmationSpeed = when (speed) {
-                "FAST" -> OnchainConfirmationSpeed.FAST
-                "SLOW" -> OnchainConfirmationSpeed.SLOW
-                else -> OnchainConfirmationSpeed.MEDIUM
-            }
-            val options = SendPaymentOptions.BitcoinAddress(confirmationSpeed = confirmationSpeed)
-            val sendResponse = instance.sendPayment(SendPaymentRequest(prepareResponse, options))
-            emitStatus("Bitcoin sent")
-            Result.success(sendResponse.payment.id)
-        } catch (e: Exception) {
-            emitStatus("Bitcoin send failed: ${e.message}")
-            Result.failure(e)
-        }
-    }
 
     // --- Sync polling ---
 

--- a/app/src/main/kotlin/com/darkwisp/app/repo/SparkRepository.kt
+++ b/app/src/main/kotlin/com/darkwisp/app/repo/SparkRepository.kt
@@ -10,6 +10,7 @@ import breez_sdk_spark.EventListener
 import breez_sdk_spark.GetInfoRequest
 import breez_sdk_spark.ListPaymentsRequest
 import breez_sdk_spark.Network
+import breez_sdk_spark.OnchainConfirmationSpeed
 import breez_sdk_spark.PaymentDetails
 import breez_sdk_spark.PaymentType
 import breez_sdk_spark.PrepareSendPaymentRequest
@@ -100,6 +101,9 @@ class SparkRepository(
 
     private val _paymentReceived = MutableSharedFlow<Long>(extraBufferCapacity = 8)
     override val paymentReceived: SharedFlow<Long> = _paymentReceived
+
+    private val _transactionsChanged = MutableSharedFlow<Unit>(extraBufferCapacity = 8)
+    override val transactionsChanged: SharedFlow<Unit> = _transactionsChanged
 
     // Identity pubkey from the SDK's GetInfoResponse — exposed for the
     // Wallet Info expandable in settings. Populated on first balance fetch
@@ -267,15 +271,19 @@ class SparkRepository(
                             is SdkEvent.PaymentSucceeded -> {
                                 emitStatus("Payment succeeded")
                                 refreshBalanceInternal()
+                                _transactionsChanged.tryEmit(Unit)
                                 if (e.payment.paymentType == PaymentType.RECEIVE) {
                                     _paymentReceived.tryEmit(e.payment.amount.toLong() * 1000)
                                 }
                             }
                             is SdkEvent.PaymentFailed -> {
                                 emitStatus("Payment failed")
+                                _transactionsChanged.tryEmit(Unit)
                             }
                             is SdkEvent.PaymentPending -> {
                                 emitStatus("Payment pending")
+                                refreshBalanceInternal()
+                                _transactionsChanged.tryEmit(Unit)
                             }
                             else -> {}
                         }
@@ -425,7 +433,7 @@ class SparkRepository(
 
     // --- Receive ---
 
-    override suspend fun makeInvoice(amountMsats: Long, description: String): Result<String> =
+    override suspend fun makeInvoice(amountMsats: Long, description: String, expirySecs: Int): Result<String> =
         withContext(Dispatchers.IO) {
             try {
                 val instance = sdk ?: return@withContext Result.failure(Exception("Not connected"))
@@ -435,7 +443,7 @@ class SparkRepository(
                 val method = ReceivePaymentMethod.Bolt11Invoice(
                     description = description.ifEmpty { "Wisp wallet" },
                     amountSats = amountSats,
-                    expirySecs = 3600u,
+                    expirySecs = expirySecs.toUInt(),
                     paymentHash = null
                 )
                 val response = instance.receivePayment(ReceivePaymentRequest(method))
@@ -446,6 +454,58 @@ class SparkRepository(
                 Result.failure(e)
             }
         }
+
+    override suspend fun getDepositAddress(): Result<String> = withContext(Dispatchers.IO) {
+        try {
+            val instance = sdk ?: return@withContext Result.failure(Exception("Not connected"))
+            val response = instance.receivePayment(ReceivePaymentRequest(ReceivePaymentMethod.BitcoinAddress))
+            Result.success(response.paymentRequest)
+        } catch (e: Exception) {
+            Result.failure(e)
+        }
+    }
+
+    override suspend fun prepareOnchainSend(address: String, amountSats: Long): Result<Pair<OnchainFeeQuote, Any>> =
+        withContext(Dispatchers.IO) {
+            try {
+                val instance = sdk ?: return@withContext Result.failure(Exception("Not connected"))
+                val prepareReq = PrepareSendPaymentRequest(
+                    paymentRequest = address,
+                    amount = java.math.BigInteger.valueOf(amountSats)
+                )
+                val prepareResponse = instance.prepareSendPayment(prepareReq)
+                val method = prepareResponse.paymentMethod as? SendPaymentMethod.BitcoinAddress
+                    ?: return@withContext Result.failure(Exception("Not a Bitcoin address payment"))
+                val feeQuote = method.feeQuote
+                val quote = OnchainFeeQuote(
+                    fastFeeSats = (feeQuote.speedFast.userFeeSat + feeQuote.speedFast.l1BroadcastFeeSat).toLong(),
+                    mediumFeeSats = (feeQuote.speedMedium.userFeeSat + feeQuote.speedMedium.l1BroadcastFeeSat).toLong(),
+                    slowFeeSats = (feeQuote.speedSlow.userFeeSat + feeQuote.speedSlow.l1BroadcastFeeSat).toLong()
+                )
+                Result.success(Pair(quote, prepareResponse as Any))
+            } catch (e: Exception) {
+                Result.failure(e)
+            }
+        }
+
+    override suspend fun sendOnchain(prepareData: Any, speed: String): Result<String> = withContext(Dispatchers.IO) {
+        try {
+            val instance = sdk ?: return@withContext Result.failure(Exception("Not connected"))
+            val prepareResponse = prepareData as breez_sdk_spark.PrepareSendPaymentResponse
+            val confirmationSpeed = when (speed) {
+                "FAST" -> OnchainConfirmationSpeed.FAST
+                "SLOW" -> OnchainConfirmationSpeed.SLOW
+                else -> OnchainConfirmationSpeed.MEDIUM
+            }
+            val options = SendPaymentOptions.BitcoinAddress(confirmationSpeed = confirmationSpeed)
+            val sendResponse = instance.sendPayment(SendPaymentRequest(prepareResponse, options))
+            emitStatus("Bitcoin sent")
+            Result.success(sendResponse.payment.id)
+        } catch (e: Exception) {
+            emitStatus("Bitcoin send failed: ${e.message}")
+            Result.failure(e)
+        }
+    }
 
     // --- Sync polling ---
 

--- a/app/src/main/kotlin/com/darkwisp/app/repo/SparkRepository.kt
+++ b/app/src/main/kotlin/com/darkwisp/app/repo/SparkRepository.kt
@@ -533,17 +533,25 @@ class SparkRepository(
                 ))
                 val transactions = response.payments.map { payment ->
                     val lightningDetails = payment.details as? PaymentDetails.Lightning
+                    val depositDetails = payment.details as? PaymentDetails.Deposit
+                    val withdrawDetails = payment.details as? PaymentDetails.Withdraw
+                    val onchain = depositDetails != null || withdrawDetails != null
 
-                    // Prefer bolt11-decoded hash (matches ZapSender records), fall back to HTLC hash, then payment ID
-                    val decoded = lightningDetails?.invoice?.let {
-                        com.darkwisp.app.nostr.Bolt11.decode(it)
+                    val paymentHash = when {
+                        onchain -> depositDetails?.txId ?: withdrawDetails?.txId ?: payment.id
+                        else -> {
+                            // Prefer bolt11-decoded hash (matches ZapSender records), fall back to HTLC hash, then payment ID
+                            val decoded = lightningDetails?.invoice?.let {
+                                com.darkwisp.app.nostr.Bolt11.decode(it)
+                            }
+                            val htlcHash = lightningDetails?.htlcDetails?.paymentHash?.lowercase()
+                            decoded?.paymentHash ?: htlcHash ?: payment.id
+                        }
                     }
-                    val htlcHash = lightningDetails?.htlcDetails?.paymentHash?.lowercase()
-                    val paymentHash = decoded?.paymentHash ?: htlcHash ?: payment.id
                     // Prefer Spark's description, fall back to bolt11 description
                     // (bolt11 tag 13 may contain the kind 9734 zap request JSON)
                     val description = lightningDetails?.description
-                        ?: decoded?.description
+                        ?: lightningDetails?.invoice?.let { com.darkwisp.app.nostr.Bolt11.decode(it)?.description }
 
                     WalletTransaction(
                         type = when (payment.paymentType) {
@@ -555,7 +563,9 @@ class SparkRepository(
                         amountMsats = payment.amount.toLong() * 1000,
                         feeMsats = payment.fees.toLong() * 1000,
                         createdAt = payment.timestamp.toLong(),
-                        settledAt = payment.timestamp.toLong()
+                        settledAt = payment.timestamp.toLong(),
+                        pending = payment.status == breez_sdk_spark.PaymentStatus.PENDING,
+                        isOnchain = onchain
                     )
                 }
                 Result.success(transactions)

--- a/app/src/main/kotlin/com/darkwisp/app/repo/WalletProvider.kt
+++ b/app/src/main/kotlin/com/darkwisp/app/repo/WalletProvider.kt
@@ -3,6 +3,12 @@ package com.darkwisp.app.repo
 import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.StateFlow
 
+data class OnchainFeeQuote(
+    val fastFeeSats: Long,
+    val mediumFeeSats: Long,
+    val slowFeeSats: Long
+)
+
 interface WalletProvider {
     val balance: StateFlow<Long?>
     val isConnected: StateFlow<Boolean>
@@ -11,13 +17,25 @@ interface WalletProvider {
     /** Emits the amount in msats whenever an incoming payment is received. */
     val paymentReceived: SharedFlow<Long>
 
+    /** Emits Unit whenever the transaction list should be refreshed. */
+    val transactionsChanged: SharedFlow<Unit>
+
     fun hasConnection(): Boolean
     fun connect()
     fun disconnect()
     suspend fun fetchBalance(): Result<Long>
     suspend fun payInvoice(bolt11: String): Result<String>
-    suspend fun makeInvoice(amountMsats: Long, description: String): Result<String>
+    suspend fun makeInvoice(amountMsats: Long, description: String, expirySecs: Int = 3600): Result<String>
     suspend fun listTransactions(limit: Int = 50, offset: Int = 0): Result<List<WalletTransaction>>
+
+    /** Spark only — returns an on-chain deposit address. NWC returns failure. */
+    suspend fun getDepositAddress(): Result<String>
+
+    /** Spark only — prepares an on-chain send and returns fee quote + opaque prepare data. */
+    suspend fun prepareOnchainSend(address: String, amountSats: Long): Result<Pair<OnchainFeeQuote, Any>>
+
+    /** Spark only — broadcasts a prepared on-chain send. */
+    suspend fun sendOnchain(prepareData: Any, speed: String = "MEDIUM"): Result<String>
 }
 
 data class WalletTransaction(

--- a/app/src/main/kotlin/com/darkwisp/app/repo/WalletProvider.kt
+++ b/app/src/main/kotlin/com/darkwisp/app/repo/WalletProvider.kt
@@ -3,12 +3,6 @@ package com.darkwisp.app.repo
 import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.StateFlow
 
-data class OnchainFeeQuote(
-    val fastFeeSats: Long,
-    val mediumFeeSats: Long,
-    val slowFeeSats: Long
-)
-
 interface WalletProvider {
     val balance: StateFlow<Long?>
     val isConnected: StateFlow<Boolean>
@@ -27,15 +21,6 @@ interface WalletProvider {
     suspend fun payInvoice(bolt11: String): Result<String>
     suspend fun makeInvoice(amountMsats: Long, description: String, expirySecs: Int = 3600): Result<String>
     suspend fun listTransactions(limit: Int = 50, offset: Int = 0): Result<List<WalletTransaction>>
-
-    /** Spark only — returns an on-chain deposit address. NWC returns failure. */
-    suspend fun getDepositAddress(): Result<String>
-
-    /** Spark only — prepares an on-chain send and returns fee quote + opaque prepare data. */
-    suspend fun prepareOnchainSend(address: String, amountSats: Long): Result<Pair<OnchainFeeQuote, Any>>
-
-    /** Spark only — broadcasts a prepared on-chain send. */
-    suspend fun sendOnchain(prepareData: Any, speed: String = "MEDIUM"): Result<String>
 }
 
 data class WalletTransaction(

--- a/app/src/main/kotlin/com/darkwisp/app/repo/WalletProvider.kt
+++ b/app/src/main/kotlin/com/darkwisp/app/repo/WalletProvider.kt
@@ -47,5 +47,7 @@ data class WalletTransaction(
     val createdAt: Long,
     val settledAt: Long?,
     /** Pubkey of the counterparty (recipient for outgoing, sender for incoming zaps). */
-    val counterpartyPubkey: String? = null
+    val counterpartyPubkey: String? = null,
+    val pending: Boolean = false,
+    val isOnchain: Boolean = false
 )

--- a/app/src/main/kotlin/com/darkwisp/app/ui/screen/WalletScreen.kt
+++ b/app/src/main/kotlin/com/darkwisp/app/ui/screen/WalletScreen.kt
@@ -71,6 +71,7 @@ import androidx.compose.material.icons.outlined.Visibility
 import androidx.compose.material.icons.outlined.VpnKey
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.automirrored.filled.KeyboardArrowRight
+import androidx.compose.material.icons.automirrored.filled.Send
 import androidx.compose.material3.Surface
 import androidx.compose.material.icons.filled.ArrowDownward
 import androidx.compose.material.icons.filled.ArrowUpward
@@ -516,6 +517,7 @@ fun WalletScreen(
                         onAmountChange = { viewModel.setReceiveAmount(it) },
                         onGenerate = { sats, note, expirySecs -> viewModel.generateInvoice(sats, note, expirySecs) },
                         onLoadDepositAddress = { viewModel.loadDepositAddress() },
+                        onShowAddressQR = { viewModel.navigateTo(WalletPage.LightningAddressQR) },
                         modifier = Modifier.padding(padding)
                     )
                     is WalletPage.ReceiveInvoice -> {
@@ -1778,46 +1780,60 @@ private fun SendInputContent(
         }
     }
 
+    val accent = WispThemeColors.zapColor
+    val fieldShape = RoundedCornerShape(14.dp)
+    val fieldBg = MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.4f)
+    val hint = if (walletMode == WalletMode.SPARK) {
+        stringResource(R.string.wallet_send_input_hint_onchain)
+    } else {
+        stringResource(R.string.wallet_lightning_address_invoice)
+    }
+
     Column(
         modifier = modifier
             .fillMaxSize()
-            .padding(horizontal = 16.dp)
-            .verticalScroll(rememberScrollState()),
-        horizontalAlignment = Alignment.CenterHorizontally
+            .padding(horizontal = 20.dp)
+            .verticalScroll(rememberScrollState())
     ) {
-        Spacer(Modifier.height(32.dp))
+        Spacer(Modifier.height(8.dp))
 
         Text(
             stringResource(R.string.wallet_send),
-            style = MaterialTheme.typography.headlineMedium,
-            color = MaterialTheme.colorScheme.onSurface
+            style = MaterialTheme.typography.titleLarge,
+            fontWeight = FontWeight.SemiBold,
+            color = MaterialTheme.colorScheme.onSurface,
+            textAlign = TextAlign.Center,
+            modifier = Modifier.fillMaxWidth()
         )
 
-        Spacer(Modifier.height(24.dp))
+        Spacer(Modifier.height(20.dp))
 
-        OutlinedTextField(
-            value = input,
-            onValueChange = onInputChange,
-            label = { Text(stringResource(R.string.wallet_lightning_address_invoice)) },
-            placeholder = {
-                Text(
-                    if (walletMode == WalletMode.SPARK)
-                        stringResource(R.string.placeholder_send_spark)
-                    else
-                        stringResource(R.string.placeholder_user_domain)
-                )
-            },
-            modifier = Modifier.fillMaxWidth(),
-            singleLine = false,
-            maxLines = 4,
-            trailingIcon = {
-                IconButton(onClick = {
-                    clipboardManager.getText()?.text?.let { onInputChange(it) }
-                }) {
-                    Icon(Icons.Default.ContentPaste, contentDescription = stringResource(R.string.wallet_paste))
+        Box(
+            modifier = Modifier
+                .fillMaxWidth()
+                .heightIn(min = 120.dp)
+                .background(fieldBg, fieldShape)
+                .padding(16.dp)
+        ) {
+            val entryStyle = MaterialTheme.typography.bodyLarge.copy(
+                color = MaterialTheme.colorScheme.onSurface
+            )
+            BasicTextField(
+                value = input,
+                onValueChange = { new ->
+                    if (!com.darkwisp.app.ui.component.NsecPasteGuard.blockIfNsec(input, new)) onInputChange(new)
+                },
+                textStyle = entryStyle,
+                cursorBrush = androidx.compose.ui.graphics.SolidColor(accent),
+                modifier = Modifier.fillMaxWidth(),
+                decorationBox = { inner ->
+                    if (input.isEmpty()) {
+                        Text(hint, style = entryStyle.copy(color = MaterialTheme.colorScheme.onSurfaceVariant))
+                    }
+                    inner()
                 }
-            }
-        )
+            )
+        }
 
         if (error != null) {
             Spacer(Modifier.height(8.dp))
@@ -1828,48 +1844,76 @@ private fun SendInputContent(
             )
         }
 
-        Spacer(Modifier.height(24.dp))
+        Spacer(Modifier.height(16.dp))
 
-        // Scan QR / Import from Gallery buttons
         Row(
-            modifier = Modifier.fillMaxWidth(),
-            horizontalArrangement = Arrangement.spacedBy(12.dp)
+            verticalAlignment = Alignment.CenterVertically,
+            modifier = Modifier
+                .fillMaxWidth()
+                .background(fieldBg, fieldShape)
         ) {
-            OutlinedButton(
+            SendInputAction(
+                icon = Icons.Default.QrCode,
+                label = stringResource(R.string.wallet_scan_qr),
                 onClick = onScanQR,
                 modifier = Modifier.weight(1f)
-            ) {
-                Icon(
-                    Icons.Default.QrCode,
-                    contentDescription = null,
-                    modifier = Modifier.size(18.dp)
-                )
-                Spacer(Modifier.width(8.dp))
-                Text(stringResource(R.string.wallet_scan_qr))
-            }
-            OutlinedButton(
+            )
+            VerticalDivider(modifier = Modifier.height(24.dp))
+            SendInputAction(
+                icon = Icons.Default.ContentPaste,
+                label = stringResource(R.string.wallet_paste),
+                onClick = {
+                    clipboardManager.getText()?.text?.let { new ->
+                        if (!com.darkwisp.app.ui.component.NsecPasteGuard.blockIfNsec(input, new)) onInputChange(new)
+                    }
+                },
+                modifier = Modifier.weight(1f)
+            )
+            VerticalDivider(modifier = Modifier.height(24.dp))
+            SendInputAction(
+                icon = Icons.Default.Image,
+                label = stringResource(R.string.wallet_gallery),
                 onClick = { galleryLauncher.launch("image/*") },
                 modifier = Modifier.weight(1f)
-            ) {
-                Icon(
-                    Icons.Default.Image,
-                    contentDescription = null,
-                    modifier = Modifier.size(18.dp)
-                )
-                Spacer(Modifier.width(8.dp))
-                Text(stringResource(R.string.wallet_gallery))
-            }
+            )
         }
 
-        Spacer(Modifier.height(16.dp))
+        Spacer(Modifier.height(24.dp))
 
         Button(
             onClick = onNext,
-            modifier = Modifier.fillMaxWidth(),
-            enabled = input.isNotBlank()
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(52.dp),
+            shape = fieldShape,
+            enabled = input.isNotBlank(),
+            colors = ButtonDefaults.buttonColors(
+                containerColor = accent,
+                contentColor = Color.White,
+                disabledContainerColor = fieldBg,
+                disabledContentColor = MaterialTheme.colorScheme.onSurfaceVariant
+            )
         ) {
-            Text(stringResource(R.string.wallet_next))
+            Text(stringResource(R.string.wallet_next), fontWeight = FontWeight.SemiBold)
         }
+    }
+}
+
+@Composable
+private fun SendInputAction(
+    icon: ImageVector,
+    label: String,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    TextButton(
+        onClick = onClick,
+        modifier = modifier,
+        colors = ButtonDefaults.textButtonColors(contentColor = WispThemeColors.zapColor)
+    ) {
+        Icon(icon, contentDescription = null, modifier = Modifier.size(18.dp))
+        Spacer(Modifier.width(6.dp))
+        Text(label, fontWeight = FontWeight.Medium, maxLines = 1)
     }
 }
 
@@ -2262,6 +2306,7 @@ private fun ReceiveAmountContent(
     onAmountChange: (String) -> Unit,
     onGenerate: (Long, String, Int) -> Unit,
     onLoadDepositAddress: () -> Unit,
+    onShowAddressQR: () -> Unit = {},
     modifier: Modifier = Modifier
 ) {
     val receiveCtx = LocalContext.current
@@ -2564,7 +2609,7 @@ private fun ReceiveAmountContent(
                     textAlign = TextAlign.Center
                 )
                 Spacer(Modifier.height(12.dp))
-                LightningAddressReceiveRow(address = lightningAddress)
+                LightningAddressReceiveRow(address = lightningAddress, onShowQR = onShowAddressQR)
             }
         }
 
@@ -2574,54 +2619,64 @@ private fun ReceiveAmountContent(
 
 // Lightning address displayed below the invoice form
 @Composable
-private fun LightningAddressReceiveRow(address: String) {
+private fun LightningAddressReceiveRow(
+    address: String,
+    onShowQR: () -> Unit
+) {
     val clipboardManager = LocalClipboardManager.current
-    val context = LocalContext.current
-    val actionShape = RoundedCornerShape(14.dp)
-    val actionBg = MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.4f)
-
-    Column(
-        modifier = Modifier
-            .fillMaxWidth()
-            .background(actionBg, actionShape)
-            .padding(horizontal = 16.dp, vertical = 12.dp)
-    ) {
-        Text(
-            address,
-            style = MaterialTheme.typography.bodyMedium,
-            color = MaterialTheme.colorScheme.onSurface,
-            textAlign = TextAlign.Center,
-            modifier = Modifier.fillMaxWidth()
-        )
-        Spacer(Modifier.height(10.dp))
+    Column {
+        Row(verticalAlignment = Alignment.CenterVertically) {
+            HorizontalDivider(modifier = Modifier.weight(1f))
+            Text(
+                stringResource(R.string.wallet_receive_via_address),
+                style = MaterialTheme.typography.labelMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                modifier = Modifier.padding(horizontal = 12.dp)
+            )
+            HorizontalDivider(modifier = Modifier.weight(1f))
+        }
+        Spacer(Modifier.height(16.dp))
         Row(
             verticalAlignment = Alignment.CenterVertically,
-            modifier = Modifier.fillMaxWidth()
+            modifier = Modifier
+                .fillMaxWidth()
+                .background(
+                    MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.4f),
+                    RoundedCornerShape(14.dp)
+                )
+                .padding(start = 16.dp, end = 6.dp, top = 6.dp, bottom = 6.dp)
         ) {
-            TextButton(
-                onClick = { clipboardManager.setText(AnnotatedString(address)) },
-                modifier = Modifier.weight(1f),
-                colors = ButtonDefaults.textButtonColors(contentColor = WispThemeColors.zapColor)
-            ) {
-                Icon(Icons.Default.ContentCopy, contentDescription = null, modifier = Modifier.size(16.dp))
-                Spacer(Modifier.width(4.dp))
-                Text(stringResource(R.string.wallet_copy_address), fontWeight = FontWeight.Medium, style = MaterialTheme.typography.labelMedium)
+            Icon(
+                Icons.Outlined.Bolt,
+                contentDescription = null,
+                tint = WispThemeColors.zapColor,
+                modifier = Modifier.size(18.dp)
+            )
+            Spacer(Modifier.width(10.dp))
+            Text(
+                address,
+                style = MaterialTheme.typography.bodyMedium,
+                fontWeight = FontWeight.Medium,
+                color = MaterialTheme.colorScheme.onSurface,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+                modifier = Modifier.weight(1f)
+            )
+            IconButton(onClick = onShowQR) {
+                Icon(
+                    Icons.Default.QrCode,
+                    contentDescription = stringResource(R.string.wallet_receive_address_tab),
+                    modifier = Modifier.size(20.dp),
+                    tint = MaterialTheme.colorScheme.onSurfaceVariant
+                )
             }
-            VerticalDivider(modifier = Modifier.height(20.dp))
-            TextButton(
-                onClick = {
-                    val intent = Intent(Intent.ACTION_SEND).apply {
-                        type = "text/plain"
-                        putExtra(Intent.EXTRA_TEXT, address)
-                    }
-                    context.startActivity(Intent.createChooser(intent, context.getString(R.string.wallet_share_address)))
-                },
-                modifier = Modifier.weight(1f),
-                colors = ButtonDefaults.textButtonColors(contentColor = WispThemeColors.zapColor)
-            ) {
-                Icon(Icons.Default.Share, contentDescription = null, modifier = Modifier.size(16.dp))
-                Spacer(Modifier.width(4.dp))
-                Text(stringResource(R.string.wallet_share), fontWeight = FontWeight.Medium, style = MaterialTheme.typography.labelMedium)
+            IconButton(onClick = { clipboardManager.setText(AnnotatedString(address)) }) {
+                Icon(
+                    Icons.Default.ContentCopy,
+                    contentDescription = stringResource(R.string.cd_copy_invoice),
+                    modifier = Modifier.size(18.dp),
+                    tint = MaterialTheme.colorScheme.onSurfaceVariant
+                )
             }
         }
     }
@@ -2775,10 +2830,7 @@ private fun OnchainSendAmountContent(
     ) {
         Spacer(Modifier.height(8.dp))
         Row(verticalAlignment = Alignment.CenterVertically) {
-            IconButton(onClick = onBack) {
-                Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = stringResource(R.string.btn_back))
-            }
-            Icon(Icons.Default.ArrowUpward, contentDescription = null, tint = accent, modifier = Modifier.size(20.dp))
+            Icon(Icons.AutoMirrored.Filled.Send, contentDescription = null, tint = accent, modifier = Modifier.size(20.dp))
             Spacer(Modifier.width(8.dp))
             Text(stringResource(R.string.wallet_onchain_send_title), style = MaterialTheme.typography.titleLarge, fontWeight = FontWeight.SemiBold)
         }
@@ -2885,7 +2937,7 @@ private fun OnchainSendAmountContent(
                 shape = fieldShape,
                 colors = ButtonDefaults.buttonColors(containerColor = accent, contentColor = Color.White)
             ) {
-                Icon(Icons.Default.ArrowUpward, contentDescription = null, modifier = Modifier.size(18.dp))
+                Icon(Icons.AutoMirrored.Filled.Send, contentDescription = null, modifier = Modifier.size(18.dp))
                 Spacer(Modifier.width(8.dp))
                 Text(stringResource(R.string.wallet_onchain_continue), style = MaterialTheme.typography.titleSmall, fontWeight = FontWeight.SemiBold)
             }
@@ -2975,10 +3027,7 @@ private fun OnchainSendConfirmContent(
     ) {
         Spacer(Modifier.height(8.dp))
         Row(modifier = Modifier.fillMaxWidth(), verticalAlignment = Alignment.CenterVertically) {
-            IconButton(onClick = onBack) {
-                Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = stringResource(R.string.btn_back))
-            }
-            Icon(Icons.Default.ArrowUpward, contentDescription = null, tint = accent, modifier = Modifier.size(20.dp))
+            Icon(Icons.AutoMirrored.Filled.Send, contentDescription = null, tint = accent, modifier = Modifier.size(20.dp))
             Spacer(Modifier.width(8.dp))
             Text(stringResource(R.string.wallet_onchain_send_title), style = MaterialTheme.typography.titleLarge, fontWeight = FontWeight.SemiBold)
         }
@@ -3050,7 +3099,7 @@ private fun OnchainSendConfirmContent(
                     shape = fieldShape,
                     colors = ButtonDefaults.buttonColors(containerColor = accent, contentColor = Color.White)
                 ) {
-                    Icon(Icons.Default.ArrowUpward, contentDescription = null, modifier = Modifier.size(18.dp))
+                    Icon(Icons.AutoMirrored.Filled.Send, contentDescription = null, modifier = Modifier.size(18.dp))
                     Spacer(Modifier.width(8.dp))
                     Text(stringResource(R.string.wallet_onchain_send_confirm), fontWeight = FontWeight.SemiBold)
                 }
@@ -3437,7 +3486,7 @@ private fun TransactionHistoryContent(
                     // both render. The list is deduped by (paymentHash, type)
                     // upstream, so these keys are unique.
                     items(transactions, key = { "${it.paymentHash}|${it.type}" }) { tx ->
-                        TransactionRow(tx, profileLookup, displayMode)
+                        TransactionRow(tx, profileLookup, displayMode, expandable = true)
                         HorizontalDivider(
                             modifier = Modifier.padding(horizontal = 16.dp),
                             color = MaterialTheme.colorScheme.outlineVariant
@@ -3474,20 +3523,25 @@ private fun TransactionHistoryContent(
 private fun TransactionRow(
     tx: WalletTransaction,
     profileLookup: (String) -> com.darkwisp.app.nostr.ProfileData?,
-    displayMode: WalletBalanceDisplayMode = WalletBalanceDisplayMode.SATS
+    displayMode: WalletBalanceDisplayMode = WalletBalanceDisplayMode.SATS,
+    expandable: Boolean = false
 ) {
     val isIncoming = tx.type == "incoming"
     val amountSats = tx.amountMsats / 1000
     val profile = tx.counterpartyPubkey?.let { profileLookup(it) }
     val ctx = LocalContext.current
+    val clipboardManager = LocalClipboardManager.current
     val fiatMode by FiatPreferences.get(ctx).fiatMode.collectAsState()
     val fiatCurrency by FiatPreferences.get(ctx).currency.collectAsState()
     val isHidden = displayMode == WalletBalanceDisplayMode.HIDDEN
     val isWalletFiat = displayMode == WalletBalanceDisplayMode.FIAT
+    var expanded by remember { mutableStateOf(false) }
 
+  Column(modifier = Modifier.fillMaxWidth()) {
     Row(
         modifier = Modifier
             .fillMaxWidth()
+            .then(if (expandable) Modifier.clickable { expanded = !expanded } else Modifier)
             .padding(horizontal = 16.dp, vertical = 12.dp),
         verticalAlignment = Alignment.CenterVertically
     ) {
@@ -3540,11 +3594,26 @@ private fun TransactionRow(
                 maxLines = 1,
                 overflow = TextOverflow.Ellipsis
             )
-            Text(
-                formatRelativeTime(tx.settledAt ?: tx.createdAt),
-                style = MaterialTheme.typography.bodySmall,
-                color = MaterialTheme.colorScheme.onSurfaceVariant
-            )
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                if (tx.pending) {
+                    Text(
+                        stringResource(R.string.wallet_tx_pending),
+                        style = MaterialTheme.typography.bodySmall,
+                        fontWeight = FontWeight.Medium,
+                        color = WispThemeColors.zapColor
+                    )
+                    Text(
+                        " · ",
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                    )
+                }
+                Text(
+                    formatRelativeTime(tx.settledAt ?: tx.createdAt),
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+            }
         }
 
         // Amount + fee. In HIDDEN mode every number is masked so a
@@ -3621,6 +3690,122 @@ private fun TransactionRow(
                     color = MaterialTheme.colorScheme.onSurfaceVariant
                 )
             }
+        }
+
+        if (expandable) {
+            Spacer(Modifier.width(4.dp))
+            Icon(
+                if (expanded) Icons.Default.KeyboardArrowUp else Icons.Default.KeyboardArrowDown,
+                contentDescription = null,
+                tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                modifier = Modifier.size(20.dp)
+            )
+        }
+    }
+
+    if (expandable) {
+        AnimatedVisibility(visible = expanded) {
+            TransactionDetailPanel(
+                tx = tx,
+                onCopy = { clipboardManager.setText(AnnotatedString(it)) }
+            )
+        }
+    }
+  }
+}
+
+@Composable
+private fun TransactionDetailPanel(
+    tx: WalletTransaction,
+    onCopy: (String) -> Unit
+) {
+    val context = LocalContext.current
+    val sats = tx.amountMsats / 1000
+    val feeSats = tx.feeMsats / 1000
+    val fullDate = remember(tx.settledAt, tx.createdAt) {
+        val secs = tx.settledAt ?: tx.createdAt
+        java.text.SimpleDateFormat("MMM d, yyyy · h:mm a", java.util.Locale.getDefault())
+            .format(java.util.Date(secs * 1000))
+    }
+    val note = tx.description?.takeIf {
+        it.isNotBlank() && it != "null" && !it.trimStart().startsWith("{")
+    }
+    val idLabel = if (tx.isOnchain) "Transaction ID" else "Payment hash"
+
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(start = 16.dp, end = 16.dp, bottom = 12.dp)
+            .background(
+                MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.4f),
+                RoundedCornerShape(12.dp)
+            )
+            .padding(14.dp),
+        verticalArrangement = Arrangement.spacedBy(10.dp)
+    ) {
+        TxDetailRow("Status", if (tx.pending) "Pending" else "Completed")
+        TxDetailRow("Type", if (tx.isOnchain) "On-chain" else "Lightning")
+        TxDetailRow("Amount", "%,d sats".format(sats))
+        if (tx.feeMsats > 0) TxDetailRow("Network fee", "%,d sats".format(feeSats))
+        TxDetailRow("Date", fullDate)
+        if (note != null) TxDetailRow("Note", note)
+        TxDetailRow(idLabel, tx.paymentHash, mono = true, onCopy = { onCopy(tx.paymentHash) })
+        if (tx.isOnchain) {
+            TextButton(
+                onClick = {
+                    context.startActivity(
+                        android.content.Intent(
+                            android.content.Intent.ACTION_VIEW,
+                            android.net.Uri.parse("https://mempool.space/tx/${tx.paymentHash}")
+                        )
+                    )
+                },
+                contentPadding = PaddingValues(0.dp),
+                colors = ButtonDefaults.textButtonColors(contentColor = WispThemeColors.zapColor)
+            ) {
+                Icon(Icons.Default.Share, contentDescription = null, modifier = Modifier.size(16.dp))
+                Spacer(Modifier.width(6.dp))
+                Text("View on mempool.space", style = MaterialTheme.typography.labelLarge)
+            }
+        }
+    }
+}
+
+@Composable
+private fun TxDetailRow(
+    label: String,
+    value: String,
+    mono: Boolean = false,
+    onCopy: (() -> Unit)? = null
+) {
+    Row(
+        modifier = Modifier.fillMaxWidth(),
+        verticalAlignment = Alignment.Top
+    ) {
+        Text(
+            label,
+            style = MaterialTheme.typography.labelMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            modifier = Modifier.width(110.dp)
+        )
+        Spacer(Modifier.width(12.dp))
+        Text(
+            value,
+            style = MaterialTheme.typography.bodySmall,
+            fontFamily = if (mono) FontFamily.Monospace else null,
+            color = MaterialTheme.colorScheme.onSurface,
+            modifier = Modifier.weight(1f)
+        )
+        if (onCopy != null) {
+            Spacer(Modifier.width(6.dp))
+            Icon(
+                Icons.Default.ContentCopy,
+                contentDescription = stringResource(R.string.action_copy),
+                tint = WispThemeColors.zapColor,
+                modifier = Modifier
+                    .size(18.dp)
+                    .clickable(onClick = onCopy)
+            )
         }
     }
 }

--- a/app/src/main/kotlin/com/darkwisp/app/ui/screen/WalletScreen.kt
+++ b/app/src/main/kotlin/com/darkwisp/app/ui/screen/WalletScreen.kt
@@ -85,7 +85,6 @@ import androidx.compose.material.icons.automirrored.filled.KeyboardArrowRight
 import androidx.compose.material.icons.filled.Image
 import androidx.compose.material.icons.filled.KeyboardArrowDown
 import androidx.compose.material.icons.filled.KeyboardArrowUp
-import androidx.compose.material.icons.filled.CurrencyBitcoin
 import androidx.compose.material.icons.filled.QrCode
 import androidx.compose.material.icons.outlined.Info
 import androidx.compose.material.icons.filled.Receipt
@@ -103,9 +102,6 @@ import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.FilledTonalButton
 import androidx.compose.material3.HorizontalDivider
-import androidx.compose.material3.SegmentedButton
-import androidx.compose.material3.SegmentedButtonDefaults
-import androidx.compose.material3.SingleChoiceSegmentedButtonRow
 import androidx.compose.material3.TextFieldDefaults
 import androidx.compose.foundation.text.BasicTextField
 import androidx.compose.foundation.text.KeyboardOptions
@@ -175,7 +171,6 @@ import com.darkwisp.app.BuildConfig
 import com.darkwisp.app.R
 import com.darkwisp.app.nostr.NipA3
 import com.darkwisp.app.repo.BalanceUnit
-import com.darkwisp.app.repo.OnchainFeeQuote
 import com.darkwisp.app.repo.WalletBalanceDisplayMode
 import com.darkwisp.app.repo.FiatPreferences
 import com.darkwisp.app.repo.WalletMode
@@ -510,13 +505,8 @@ fun WalletScreen(
                         amount = viewModel.receiveAmount.collectAsState().value,
                         isLoading = viewModel.isLoading.collectAsState().value,
                         lightningAddress = viewModel.lightningAddress.collectAsState().value,
-                        walletMode = viewModel.walletMode.collectAsState().value,
-                        depositAddress = viewModel.depositAddress.collectAsState().value,
-                        depositAddressLoading = viewModel.depositAddressLoading.collectAsState().value,
-                        depositAddressError = viewModel.depositAddressError.collectAsState().value,
                         onAmountChange = { viewModel.setReceiveAmount(it) },
                         onGenerate = { sats, note, expirySecs -> viewModel.generateInvoice(sats, note, expirySecs) },
-                        onLoadDepositAddress = { viewModel.loadDepositAddress() },
                         onShowAddressQR = { viewModel.navigateTo(WalletPage.LightningAddressQR) },
                         modifier = Modifier.padding(padding)
                     )
@@ -648,65 +638,6 @@ fun WalletScreen(
                         },
                         modifier = Modifier.padding(padding)
                     )
-                    is WalletPage.OnchainSendAmount -> {
-                        val page = currentPage as WalletPage.OnchainSendAmount
-                        val sendAmount by viewModel.sendAmount.collectAsState()
-                        val feeLoading by viewModel.onchainSendLoading.collectAsState()
-                        val error by viewModel.sendError.collectAsState()
-                        val feeQuote by viewModel.onchainFeeQuote.collectAsState()
-                        OnchainSendAmountContent(
-                            address = page.address,
-                            amount = sendAmount,
-                            balanceSats = balanceMsats / 1000,
-                            isLoading = feeLoading,
-                            error = error,
-                            feeQuote = feeQuote,
-                            onAmountChange = {
-                                viewModel.setSendAmount(it)
-                                viewModel.clearOnchainQuote()
-                            },
-                            onUseAll = {
-                                viewModel.setSendAmount((balanceMsats / 1000).toString())
-                                viewModel.clearOnchainQuote()
-                            },
-                            onGetFeeQuote = {
-                                val sats = sendAmount.toLongOrNull() ?: return@OnchainSendAmountContent
-                                viewModel.prepareOnchainSend(page.address, sats)
-                            },
-                            onContinue = {
-                                val sats = sendAmount.toLongOrNull() ?: return@OnchainSendAmountContent
-                                viewModel.continueToOnchainConfirm(page.address, sats)
-                            },
-                            onBack = {
-                                viewModel.clearOnchainQuote()
-                                viewModel.navigateBack()
-                            },
-                            modifier = Modifier.padding(padding)
-                        )
-                    }
-                    is WalletPage.OnchainSendConfirm -> {
-                        val page = currentPage as WalletPage.OnchainSendConfirm
-                        val sending by viewModel.isLoading.collectAsState()
-                        OnchainSendConfirmContent(
-                            address = page.address,
-                            amountSats = page.amountSats,
-                            feeQuote = page.feeQuote,
-                            isLoading = sending,
-                            onConfirm = { viewModel.sendOnchain(page.prepareData) },
-                            onBack = { viewModel.navigateBack() },
-                            modifier = Modifier.padding(padding)
-                        )
-                    }
-                    is WalletPage.OnchainSendResult -> {
-                        val page = currentPage as WalletPage.OnchainSendResult
-                        OnchainSendResultContent(
-                            success = page.success,
-                            paymentId = page.paymentId,
-                            message = page.message,
-                            onDone = { viewModel.navigateHome() },
-                            modifier = Modifier.padding(padding)
-                        )
-                    }
                     else -> {
                         // ModeSelection, NwcSetup, SparkSetup — shouldn't appear while connected
                         val profileKey = viewModel.profileRefreshKey.collectAsState().value
@@ -2287,8 +2218,6 @@ private fun SendResultContent(
 
 // --- Receive amount ---
 
-private enum class ReceiveTab { LIGHTNING, BITCOIN }
-
 private enum class InvoiceExpiry(val seconds: Int) {
     ONE_HOUR(3600), ONE_DAY(86400), CUSTOM(0)
 }
@@ -2299,13 +2228,8 @@ private fun ReceiveAmountContent(
     amount: String,
     isLoading: Boolean,
     lightningAddress: String?,
-    walletMode: WalletMode,
-    depositAddress: String?,
-    depositAddressLoading: Boolean,
-    depositAddressError: String?,
     onAmountChange: (String) -> Unit,
     onGenerate: (Long, String, Int) -> Unit,
-    onLoadDepositAddress: () -> Unit,
     onShowAddressQR: () -> Unit = {},
     modifier: Modifier = Modifier
 ) {
@@ -2333,9 +2257,6 @@ private fun ReceiveAmountContent(
     val canCreate = (satAmount ?: 0L) > 0L && !isLoading &&
         (selectedExpiry != InvoiceExpiry.CUSTOM || expirySecs > 0)
 
-    val isSpark = walletMode == WalletMode.SPARK
-    var selectedTab by remember { mutableStateOf(ReceiveTab.LIGHTNING) }
-
     val fieldShape = RoundedCornerShape(14.dp)
     val fieldBg = MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.4f)
 
@@ -2358,249 +2279,218 @@ private fun ReceiveAmountContent(
 
         Spacer(Modifier.height(20.dp))
 
-        // Show tab row only for Spark wallets (which support on-chain)
-        if (isSpark) {
-            SingleChoiceSegmentedButtonRow(modifier = Modifier.fillMaxWidth()) {
-                SegmentedButton(
-                    selected = selectedTab == ReceiveTab.LIGHTNING,
-                    onClick = { selectedTab = ReceiveTab.LIGHTNING },
-                    shape = SegmentedButtonDefaults.itemShape(index = 0, count = 2),
-                    icon = { Icon(Icons.Outlined.Bolt, contentDescription = null, modifier = Modifier.size(16.dp)) }
-                ) { Text(stringResource(R.string.wallet_receive_lightning_tab)) }
-                SegmentedButton(
-                    selected = selectedTab == ReceiveTab.BITCOIN,
-                    onClick = {
-                        selectedTab = ReceiveTab.BITCOIN
-                        onLoadDepositAddress()
-                    },
-                    shape = SegmentedButtonDefaults.itemShape(index = 1, count = 2),
-                    icon = { Icon(Icons.Default.CurrencyBitcoin, contentDescription = null, modifier = Modifier.size(16.dp)) }
-                ) { Text(stringResource(R.string.wallet_receive_bitcoin_tab)) }
-            }
-            Spacer(Modifier.height(20.dp))
-        }
+        // AMOUNT field
+        Text(
+            stringResource(R.string.wallet_receive_amount_label),
+            style = MaterialTheme.typography.labelMedium,
+            fontWeight = FontWeight.SemiBold,
+            letterSpacing = 0.5.sp,
+            color = MaterialTheme.colorScheme.onSurfaceVariant
+        )
+        Spacer(Modifier.height(8.dp))
 
-        if (selectedTab == ReceiveTab.BITCOIN && isSpark) {
-            ReceiveBitcoinBlock(
-                address = depositAddress,
-                isLoading = depositAddressLoading,
-                error = depositAddressError,
-                onRetry = onLoadDepositAddress
-            )
-        } else {
-            // AMOUNT field
-            Text(
-                stringResource(R.string.wallet_receive_amount_label),
-                style = MaterialTheme.typography.labelMedium,
+        Row(
+            verticalAlignment = Alignment.CenterVertically,
+            modifier = Modifier
+                .fillMaxWidth()
+                .background(fieldBg, fieldShape)
+                .padding(horizontal = 16.dp, vertical = 16.dp)
+        ) {
+            val amountTextStyle = TextStyle(
+                fontSize = 32.sp,
                 fontWeight = FontWeight.SemiBold,
-                letterSpacing = 0.5.sp,
-                color = MaterialTheme.colorScheme.onSurfaceVariant
+                color = MaterialTheme.colorScheme.onSurface
             )
-            Spacer(Modifier.height(8.dp))
-
-            Row(
-                verticalAlignment = Alignment.CenterVertically,
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .background(fieldBg, fieldShape)
-                    .padding(horizontal = 16.dp, vertical = 16.dp)
-            ) {
-                val amountTextStyle = TextStyle(
-                    fontSize = 32.sp,
-                    fontWeight = FontWeight.SemiBold,
-                    color = MaterialTheme.colorScheme.onSurface
-                )
-                BasicTextField(
-                    value = amount,
-                    onValueChange = { input ->
-                        val filtered = if (fiatMode) {
-                            val sb = StringBuilder()
-                            var seenDot = false
-                            for (c in input) {
-                                if (c.isDigit()) sb.append(c)
-                                else if (c == '.' && !seenDot) { sb.append(c); seenDot = true }
-                            }
-                            sb.toString()
-                        } else {
-                            input.filter { it.isDigit() }
+            BasicTextField(
+                value = amount,
+                onValueChange = { input ->
+                    val filtered = if (fiatMode) {
+                        val sb = StringBuilder()
+                        var seenDot = false
+                        for (c in input) {
+                            if (c.isDigit()) sb.append(c)
+                            else if (c == '.' && !seenDot) { sb.append(c); seenDot = true }
                         }
-                        onAmountChange(filtered)
-                    },
-                    textStyle = amountTextStyle,
-                    singleLine = true,
-                    keyboardOptions = KeyboardOptions(
-                        keyboardType = if (fiatMode) KeyboardType.Decimal else KeyboardType.NumberPassword
-                    ),
-                    cursorBrush = androidx.compose.ui.graphics.SolidColor(MaterialTheme.colorScheme.primary),
-                    modifier = Modifier.weight(1f),
-                    decorationBox = { inner ->
-                        Box(contentAlignment = Alignment.CenterStart) {
-                            if (amount.isEmpty()) {
-                                Text(
-                                    "0",
-                                    style = amountTextStyle.copy(color = MaterialTheme.colorScheme.onSurfaceVariant)
-                                )
-                            }
-                            inner()
-                        }
+                        sb.toString()
+                    } else {
+                        input.filter { it.isDigit() }
                     }
-                )
-                Spacer(Modifier.width(8.dp))
-                Text(
-                    if (fiatMode) currency.code else stringResource(R.string.wallet_sats),
-                    style = MaterialTheme.typography.titleMedium,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant
-                )
-            }
-            if (fiatMode && fiatSats != null && fiatSats > 0L) {
-                Spacer(Modifier.height(6.dp))
-                Text(
-                    "≈ %,d sats".format(fiatSats),
-                    style = MaterialTheme.typography.bodySmall,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant,
-                    modifier = Modifier.padding(start = 4.dp)
-                )
-            }
-
-            Spacer(Modifier.height(20.dp))
-
-            // NOTE field
-            Text(
-                stringResource(R.string.wallet_receive_note_label),
-                style = MaterialTheme.typography.labelMedium,
-                fontWeight = FontWeight.SemiBold,
-                letterSpacing = 0.5.sp,
-                color = MaterialTheme.colorScheme.onSurfaceVariant
-            )
-            Spacer(Modifier.height(8.dp))
-
-            Box(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .background(fieldBg, fieldShape)
-                    .padding(horizontal = 16.dp, vertical = 14.dp)
-            ) {
-                val noteStyle = MaterialTheme.typography.bodyMedium.copy(
-                    color = MaterialTheme.colorScheme.onSurface
-                )
-                BasicTextField(
-                    value = description,
-                    onValueChange = { description = it },
-                    textStyle = noteStyle,
-                    singleLine = true,
-                    cursorBrush = androidx.compose.ui.graphics.SolidColor(MaterialTheme.colorScheme.primary),
-                    modifier = Modifier.fillMaxWidth(),
-                    decorationBox = { inner ->
-                        if (description.isEmpty()) {
+                    onAmountChange(filtered)
+                },
+                textStyle = amountTextStyle,
+                singleLine = true,
+                keyboardOptions = KeyboardOptions(
+                    keyboardType = if (fiatMode) KeyboardType.Decimal else KeyboardType.NumberPassword
+                ),
+                cursorBrush = androidx.compose.ui.graphics.SolidColor(MaterialTheme.colorScheme.primary),
+                modifier = Modifier.weight(1f),
+                decorationBox = { inner ->
+                    Box(contentAlignment = Alignment.CenterStart) {
+                        if (amount.isEmpty()) {
                             Text(
-                                stringResource(R.string.wallet_receive_note_placeholder),
-                                style = noteStyle.copy(color = MaterialTheme.colorScheme.onSurfaceVariant)
+                                "0",
+                                style = amountTextStyle.copy(color = MaterialTheme.colorScheme.onSurfaceVariant)
                             )
                         }
                         inner()
                     }
-                )
-            }
-
-            Spacer(Modifier.height(20.dp))
-
-            // EXPIRES selector
+                }
+            )
+            Spacer(Modifier.width(8.dp))
             Text(
-                stringResource(R.string.wallet_receive_expires_label),
-                style = MaterialTheme.typography.labelMedium,
-                fontWeight = FontWeight.SemiBold,
-                letterSpacing = 0.5.sp,
+                if (fiatMode) currency.code else stringResource(R.string.wallet_sats),
+                style = MaterialTheme.typography.titleMedium,
                 color = MaterialTheme.colorScheme.onSurfaceVariant
             )
-            Spacer(Modifier.height(8.dp))
-            Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
-                listOf(
-                    InvoiceExpiry.ONE_HOUR to stringResource(R.string.wallet_receive_expires_1h),
-                    InvoiceExpiry.ONE_DAY to stringResource(R.string.wallet_receive_expires_24h),
-                    InvoiceExpiry.CUSTOM to stringResource(R.string.wallet_receive_expires_custom)
-                ).forEachIndexed { _, (expiry, label) ->
-                    val isSelected = selectedExpiry == expiry
-                    OutlinedButton(
-                        onClick = { selectedExpiry = expiry },
-                        modifier = Modifier.weight(1f),
-                        colors = ButtonDefaults.outlinedButtonColors(
-                            containerColor = if (isSelected) MaterialTheme.colorScheme.primary.copy(alpha = 0.12f) else Color.Transparent,
-                            contentColor = if (isSelected) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.onSurfaceVariant
-                        ),
-                        border = BorderStroke(
-                            1.dp,
-                            if (isSelected) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.outline
-                        ),
-                        contentPadding = PaddingValues(horizontal = 8.dp, vertical = 6.dp)
-                    ) { Text(label, style = MaterialTheme.typography.labelMedium) }
-                }
-            }
-            if (selectedExpiry == InvoiceExpiry.CUSTOM) {
-                Spacer(Modifier.height(8.dp))
-                OutlinedTextField(
-                    value = customHours,
-                    onValueChange = { customHours = it.filter { c -> c.isDigit() } },
-                    label = { Text(stringResource(R.string.wallet_receive_expires_hours)) },
-                    singleLine = true,
-                    keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
-                    modifier = Modifier.fillMaxWidth()
-                )
-            }
+        }
+        if (fiatMode && fiatSats != null && fiatSats > 0L) {
+            Spacer(Modifier.height(6.dp))
+            Text(
+                "≈ %,d sats".format(fiatSats),
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                modifier = Modifier.padding(start = 4.dp)
+            )
+        }
 
-            Spacer(Modifier.height(24.dp))
+        Spacer(Modifier.height(20.dp))
 
-            if (isLoading) {
-                Box(
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .background(fieldBg, fieldShape)
-                        .padding(vertical = 14.dp),
-                    contentAlignment = Alignment.Center
-                ) {
-                    Row(verticalAlignment = Alignment.CenterVertically) {
-                        CircularProgressIndicator(
-                            strokeWidth = 2.dp,
-                            modifier = Modifier.size(18.dp)
-                        )
-                        Spacer(Modifier.width(10.dp))
+        // NOTE field
+        Text(
+            stringResource(R.string.wallet_receive_note_label),
+            style = MaterialTheme.typography.labelMedium,
+            fontWeight = FontWeight.SemiBold,
+            letterSpacing = 0.5.sp,
+            color = MaterialTheme.colorScheme.onSurfaceVariant
+        )
+        Spacer(Modifier.height(8.dp))
+
+        Box(
+            modifier = Modifier
+                .fillMaxWidth()
+                .background(fieldBg, fieldShape)
+                .padding(horizontal = 16.dp, vertical = 14.dp)
+        ) {
+            val noteStyle = MaterialTheme.typography.bodyMedium.copy(
+                color = MaterialTheme.colorScheme.onSurface
+            )
+            BasicTextField(
+                value = description,
+                onValueChange = { description = it },
+                textStyle = noteStyle,
+                singleLine = true,
+                cursorBrush = androidx.compose.ui.graphics.SolidColor(MaterialTheme.colorScheme.primary),
+                modifier = Modifier.fillMaxWidth(),
+                decorationBox = { inner ->
+                    if (description.isEmpty()) {
                         Text(
-                            stringResource(R.string.wallet_creating_invoice),
-                            style = MaterialTheme.typography.bodyMedium,
-                            color = MaterialTheme.colorScheme.onSurfaceVariant
+                            stringResource(R.string.wallet_receive_note_placeholder),
+                            style = noteStyle.copy(color = MaterialTheme.colorScheme.onSurfaceVariant)
                         )
                     }
+                    inner()
                 }
-            } else {
-                Button(
-                    onClick = {
-                        val sats = satAmount ?: return@Button
-                        onGenerate(sats, description, expirySecs)
-                    },
-                    enabled = canCreate,
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .height(52.dp),
-                    shape = fieldShape,
-                    colors = ButtonDefaults.buttonColors(
-                        containerColor = MaterialTheme.colorScheme.primary,
-                        contentColor = Color.White,
-                        disabledContainerColor = fieldBg,
-                        disabledContentColor = MaterialTheme.colorScheme.onSurfaceVariant
-                    )
-                ) {
-                    Text(
-                        stringResource(R.string.wallet_receive_create_invoice),
-                        style = MaterialTheme.typography.titleSmall,
-                        fontWeight = FontWeight.SemiBold
-                    )
-                }
-            }
+            )
+        }
 
-            // Lightning address — shown below invoice form as "or receive via" row
-            if (!lightningAddress.isNullOrBlank()) {
-                Spacer(Modifier.height(24.dp))
-                LightningAddressReceiveRow(address = lightningAddress, onShowQR = onShowAddressQR)
+        Spacer(Modifier.height(20.dp))
+
+        // EXPIRES selector
+        Text(
+            stringResource(R.string.wallet_receive_expires_label),
+            style = MaterialTheme.typography.labelMedium,
+            fontWeight = FontWeight.SemiBold,
+            letterSpacing = 0.5.sp,
+            color = MaterialTheme.colorScheme.onSurfaceVariant
+        )
+        Spacer(Modifier.height(8.dp))
+        Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+            listOf(
+                InvoiceExpiry.ONE_HOUR to stringResource(R.string.wallet_receive_expires_1h),
+                InvoiceExpiry.ONE_DAY to stringResource(R.string.wallet_receive_expires_24h),
+                InvoiceExpiry.CUSTOM to stringResource(R.string.wallet_receive_expires_custom)
+            ).forEachIndexed { _, (expiry, label) ->
+                val isSelected = selectedExpiry == expiry
+                OutlinedButton(
+                    onClick = { selectedExpiry = expiry },
+                    modifier = Modifier.weight(1f),
+                    colors = ButtonDefaults.outlinedButtonColors(
+                        containerColor = if (isSelected) MaterialTheme.colorScheme.primary.copy(alpha = 0.12f) else Color.Transparent,
+                        contentColor = if (isSelected) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.onSurfaceVariant
+                    ),
+                    border = BorderStroke(
+                        1.dp,
+                        if (isSelected) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.outline
+                    ),
+                    contentPadding = PaddingValues(horizontal = 8.dp, vertical = 6.dp)
+                ) { Text(label, style = MaterialTheme.typography.labelMedium) }
             }
+        }
+        if (selectedExpiry == InvoiceExpiry.CUSTOM) {
+            Spacer(Modifier.height(8.dp))
+            OutlinedTextField(
+                value = customHours,
+                onValueChange = { customHours = it.filter { c -> c.isDigit() } },
+                label = { Text(stringResource(R.string.wallet_receive_expires_hours)) },
+                singleLine = true,
+                keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
+                modifier = Modifier.fillMaxWidth()
+            )
+        }
+
+        Spacer(Modifier.height(24.dp))
+
+        if (isLoading) {
+            Box(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .background(fieldBg, fieldShape)
+                    .padding(vertical = 14.dp),
+                contentAlignment = Alignment.Center
+            ) {
+                Row(verticalAlignment = Alignment.CenterVertically) {
+                    CircularProgressIndicator(
+                        strokeWidth = 2.dp,
+                        modifier = Modifier.size(18.dp)
+                    )
+                    Spacer(Modifier.width(10.dp))
+                    Text(
+                        stringResource(R.string.wallet_creating_invoice),
+                        style = MaterialTheme.typography.bodyMedium,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                    )
+                }
+            }
+        } else {
+            Button(
+                onClick = {
+                    val sats = satAmount ?: return@Button
+                    onGenerate(sats, description, expirySecs)
+                },
+                enabled = canCreate,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .height(52.dp),
+                shape = fieldShape,
+                colors = ButtonDefaults.buttonColors(
+                    containerColor = MaterialTheme.colorScheme.primary,
+                    contentColor = Color.White,
+                    disabledContainerColor = fieldBg,
+                    disabledContentColor = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+            ) {
+                Text(
+                    stringResource(R.string.wallet_receive_create_invoice),
+                    style = MaterialTheme.typography.titleSmall,
+                    fontWeight = FontWeight.SemiBold
+                )
+            }
+        }
+
+        // Lightning address — shown below invoice form as "or receive via" row
+        if (!lightningAddress.isNullOrBlank()) {
+            Spacer(Modifier.height(24.dp))
+            LightningAddressReceiveRow(address = lightningAddress, onShowQR = onShowAddressQR)
         }
 
         Spacer(Modifier.height(24.dp))
@@ -2668,485 +2558,6 @@ private fun LightningAddressReceiveRow(
                     tint = MaterialTheme.colorScheme.onSurfaceVariant
                 )
             }
-        }
-    }
-}
-
-// Bitcoin on-chain deposit address block (Spark only)
-@Composable
-private fun ReceiveBitcoinBlock(
-    address: String?,
-    isLoading: Boolean,
-    error: String?,
-    onRetry: () -> Unit
-) {
-    val clipboardManager = LocalClipboardManager.current
-    val context = LocalContext.current
-    val cardShape = RoundedCornerShape(16.dp)
-    val cardBg = MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.35f)
-    val actionShape = RoundedCornerShape(14.dp)
-    val actionBg = MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.4f)
-
-    when {
-        isLoading -> {
-            Box(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .background(cardBg, cardShape)
-                    .padding(40.dp),
-                contentAlignment = Alignment.Center
-            ) {
-                CircularProgressIndicator(strokeWidth = 2.dp, modifier = Modifier.size(32.dp))
-            }
-        }
-        error != null -> {
-            Column(
-                horizontalAlignment = Alignment.CenterHorizontally,
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .background(cardBg, cardShape)
-                    .padding(24.dp)
-            ) {
-                Text(error, style = MaterialTheme.typography.bodyMedium, color = MaterialTheme.colorScheme.error, textAlign = TextAlign.Center)
-                Spacer(Modifier.height(16.dp))
-                OutlinedButton(onClick = onRetry) { Text(stringResource(R.string.retry)) }
-            }
-        }
-        address != null -> {
-            val qrBitmap = remember(address) {
-                val writer = QRCodeWriter()
-                val matrix = writer.encode("bitcoin:$address", BarcodeFormat.QR_CODE, 512, 512)
-                val bitmap = Bitmap.createBitmap(matrix.width, matrix.height, Bitmap.Config.RGB_565)
-                for (x in 0 until matrix.width) {
-                    for (y in 0 until matrix.height) {
-                        bitmap.setPixel(x, y, if (matrix.get(x, y)) android.graphics.Color.BLACK else android.graphics.Color.WHITE)
-                    }
-                }
-                bitmap
-            }
-            Column(horizontalAlignment = Alignment.CenterHorizontally) {
-                Column(
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .background(cardBg, cardShape)
-                        .padding(20.dp),
-                    horizontalAlignment = Alignment.CenterHorizontally
-                ) {
-                    Image(
-                        bitmap = qrBitmap.asImageBitmap(),
-                        contentDescription = stringResource(R.string.cd_bitcoin_address_qr),
-                        modifier = Modifier
-                            .size(260.dp)
-                            .background(Color.White, RoundedCornerShape(12.dp))
-                            .padding(8.dp)
-                    )
-                    Spacer(Modifier.height(12.dp))
-                    Text(
-                        address,
-                        style = MaterialTheme.typography.bodySmall,
-                        color = MaterialTheme.colorScheme.onSurfaceVariant,
-                        textAlign = TextAlign.Center,
-                        fontFamily = androidx.compose.ui.text.font.FontFamily.Monospace
-                    )
-                }
-                Spacer(Modifier.height(16.dp))
-                Row(
-                    verticalAlignment = Alignment.CenterVertically,
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .background(actionBg, actionShape)
-                ) {
-                    TextButton(
-                        onClick = { clipboardManager.setText(AnnotatedString(address)) },
-                        modifier = Modifier.weight(1f),
-                        colors = ButtonDefaults.textButtonColors(contentColor = WispThemeColors.zapColor)
-                    ) {
-                        Icon(Icons.Default.ContentCopy, contentDescription = null, modifier = Modifier.size(18.dp))
-                        Spacer(Modifier.width(6.dp))
-                        Text(stringResource(R.string.wallet_copy_address), fontWeight = FontWeight.Medium)
-                    }
-                    VerticalDivider(modifier = Modifier.height(24.dp))
-                    TextButton(
-                        onClick = {
-                            val intent = Intent(Intent.ACTION_SEND).apply {
-                                type = "text/plain"
-                                putExtra(Intent.EXTRA_TEXT, address)
-                            }
-                            context.startActivity(Intent.createChooser(intent, context.getString(R.string.wallet_share_address)))
-                        },
-                        modifier = Modifier.weight(1f),
-                        colors = ButtonDefaults.textButtonColors(contentColor = WispThemeColors.zapColor)
-                    ) {
-                        Icon(Icons.Default.Share, contentDescription = null, modifier = Modifier.size(18.dp))
-                        Spacer(Modifier.width(6.dp))
-                        Text(stringResource(R.string.wallet_share), fontWeight = FontWeight.Medium)
-                    }
-                }
-            }
-        }
-        else -> {
-            // Initial state — trigger load
-            LaunchedEffect(Unit) { onRetry() }
-        }
-    }
-}
-
-// On-chain send: amount entry (with inline fee quote)
-@Composable
-private fun OnchainSendAmountContent(
-    address: String,
-    amount: String,
-    balanceSats: Long,
-    isLoading: Boolean,
-    error: String?,
-    feeQuote: OnchainFeeQuote?,
-    onAmountChange: (String) -> Unit,
-    onUseAll: () -> Unit,
-    onGetFeeQuote: () -> Unit,
-    onContinue: () -> Unit,
-    onBack: () -> Unit,
-    modifier: Modifier = Modifier
-) {
-    val amountSats = amount.toLongOrNull() ?: 0L
-    val fieldShape = RoundedCornerShape(14.dp)
-    val fieldBg = MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.4f)
-    val accent = WispThemeColors.zapColor
-
-    Column(
-        modifier = modifier
-            .fillMaxSize()
-            .padding(horizontal = 20.dp)
-            .verticalScroll(rememberScrollState())
-    ) {
-        Spacer(Modifier.height(8.dp))
-        Row(verticalAlignment = Alignment.CenterVertically) {
-            Icon(Icons.AutoMirrored.Filled.Send, contentDescription = null, tint = accent, modifier = Modifier.size(20.dp))
-            Spacer(Modifier.width(8.dp))
-            Text(stringResource(R.string.wallet_onchain_send_title), style = MaterialTheme.typography.titleLarge, fontWeight = FontWeight.SemiBold)
-        }
-
-        Spacer(Modifier.height(20.dp))
-
-        // Recipient address (read-only)
-        Box(
-            modifier = Modifier
-                .fillMaxWidth()
-                .background(fieldBg, fieldShape)
-                .padding(16.dp)
-        ) {
-            Text(
-                address,
-                style = MaterialTheme.typography.bodyMedium,
-                fontFamily = androidx.compose.ui.text.font.FontFamily.Monospace,
-                color = MaterialTheme.colorScheme.onSurface
-            )
-        }
-        Spacer(Modifier.height(10.dp))
-        Row(verticalAlignment = Alignment.CenterVertically) {
-            Icon(Icons.Default.CurrencyBitcoin, contentDescription = null, tint = accent, modifier = Modifier.size(16.dp))
-            Spacer(Modifier.width(6.dp))
-            Text(
-                stringResource(R.string.wallet_onchain_bitcoin_detected),
-                style = MaterialTheme.typography.bodySmall,
-                color = accent
-            )
-        }
-
-        Spacer(Modifier.height(20.dp))
-
-        // Amount label + Use All
-        Row(
-            modifier = Modifier.fillMaxWidth(),
-            horizontalArrangement = Arrangement.SpaceBetween,
-            verticalAlignment = Alignment.CenterVertically
-        ) {
-            Text(
-                stringResource(R.string.wallet_onchain_amount_sats),
-                style = MaterialTheme.typography.labelMedium,
-                fontWeight = FontWeight.SemiBold,
-                letterSpacing = 0.5.sp,
-                color = MaterialTheme.colorScheme.onSurfaceVariant
-            )
-            Text(
-                stringResource(R.string.wallet_onchain_use_all, balanceSats),
-                style = MaterialTheme.typography.labelMedium,
-                fontWeight = FontWeight.SemiBold,
-                color = accent,
-                modifier = Modifier.clickable(onClick = onUseAll)
-            )
-        }
-        Spacer(Modifier.height(8.dp))
-        Box(
-            modifier = Modifier
-                .fillMaxWidth()
-                .background(fieldBg, fieldShape)
-                .padding(horizontal = 16.dp, vertical = 16.dp)
-        ) {
-            val amountStyle = MaterialTheme.typography.titleLarge.copy(color = MaterialTheme.colorScheme.onSurface)
-            BasicTextField(
-                value = amount,
-                onValueChange = { onAmountChange(it.filter { c -> c.isDigit() }) },
-                textStyle = amountStyle,
-                singleLine = true,
-                keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
-                cursorBrush = androidx.compose.ui.graphics.SolidColor(MaterialTheme.colorScheme.primary),
-                modifier = Modifier.fillMaxWidth(),
-                decorationBox = { inner ->
-                    if (amount.isEmpty()) Text("0", style = amountStyle.copy(color = MaterialTheme.colorScheme.onSurfaceVariant))
-                    inner()
-                }
-            )
-        }
-
-        if (error != null) {
-            Spacer(Modifier.height(12.dp))
-            Text(error, color = MaterialTheme.colorScheme.error, style = MaterialTheme.typography.bodySmall)
-        }
-
-        Spacer(Modifier.height(20.dp))
-
-        if (feeQuote != null) {
-            val feeSats = feeQuote.mediumFeeSats
-            val totalSats = amountSats + feeSats
-            Column(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .background(fieldBg, fieldShape)
-                    .padding(16.dp),
-                verticalArrangement = Arrangement.spacedBy(10.dp)
-            ) {
-                OnchainAmountRow(stringResource(R.string.wallet_onchain_amount), "%,d sats".format(amountSats))
-                OnchainAmountRow(stringResource(R.string.wallet_onchain_fee), "%,d sats".format(feeSats))
-                HorizontalDivider()
-                OnchainAmountRow(stringResource(R.string.wallet_onchain_total), "%,d sats".format(totalSats), emphasize = true)
-            }
-            Spacer(Modifier.height(16.dp))
-            Button(
-                onClick = onContinue,
-                modifier = Modifier.fillMaxWidth().height(52.dp),
-                shape = fieldShape,
-                colors = ButtonDefaults.buttonColors(containerColor = accent, contentColor = Color.White)
-            ) {
-                Icon(Icons.AutoMirrored.Filled.Send, contentDescription = null, modifier = Modifier.size(18.dp))
-                Spacer(Modifier.width(8.dp))
-                Text(stringResource(R.string.wallet_onchain_continue), style = MaterialTheme.typography.titleSmall, fontWeight = FontWeight.SemiBold)
-            }
-        } else if (isLoading) {
-            Box(
-                modifier = Modifier.fillMaxWidth().background(fieldBg, fieldShape).padding(vertical = 14.dp),
-                contentAlignment = Alignment.Center
-            ) {
-                Row(verticalAlignment = Alignment.CenterVertically) {
-                    CircularProgressIndicator(strokeWidth = 2.dp, modifier = Modifier.size(18.dp))
-                    Spacer(Modifier.width(10.dp))
-                    Text(stringResource(R.string.wallet_onchain_fetching_fee), style = MaterialTheme.typography.bodyMedium, color = MaterialTheme.colorScheme.onSurfaceVariant)
-                }
-            }
-        } else {
-            Button(
-                onClick = onGetFeeQuote,
-                enabled = amountSats > 0L,
-                modifier = Modifier.fillMaxWidth().height(52.dp),
-                shape = fieldShape,
-                colors = ButtonDefaults.buttonColors(
-                    containerColor = accent,
-                    contentColor = Color.White,
-                    disabledContainerColor = fieldBg,
-                    disabledContentColor = MaterialTheme.colorScheme.onSurfaceVariant
-                )
-            ) {
-                Text(stringResource(R.string.wallet_onchain_get_fee_quote), style = MaterialTheme.typography.titleSmall, fontWeight = FontWeight.SemiBold)
-            }
-        }
-
-        Spacer(Modifier.height(24.dp))
-    }
-}
-
-@Composable
-private fun OnchainAmountRow(label: String, value: String, emphasize: Boolean = false) {
-    Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.SpaceBetween) {
-        Text(
-            label,
-            style = if (emphasize) MaterialTheme.typography.titleSmall else MaterialTheme.typography.bodyMedium,
-            fontWeight = if (emphasize) FontWeight.SemiBold else FontWeight.Normal,
-            color = if (emphasize) MaterialTheme.colorScheme.onSurface else MaterialTheme.colorScheme.onSurfaceVariant
-        )
-        Text(
-            value,
-            style = if (emphasize) MaterialTheme.typography.titleSmall else MaterialTheme.typography.bodyMedium,
-            fontWeight = if (emphasize) FontWeight.SemiBold else FontWeight.Normal,
-            color = if (emphasize) WispThemeColors.zapColor else MaterialTheme.colorScheme.onSurface
-        )
-    }
-}
-
-// On-chain send: confirm (chunked address, big amount hero, irreversibility warning)
-@Composable
-private fun OnchainSendConfirmContent(
-    address: String,
-    amountSats: Long,
-    feeQuote: OnchainFeeQuote,
-    isLoading: Boolean,
-    onConfirm: () -> Unit,
-    onBack: () -> Unit,
-    modifier: Modifier = Modifier
-) {
-    val feeSats = feeQuote.mediumFeeSats
-    val accent = WispThemeColors.zapColor
-    val fieldShape = RoundedCornerShape(14.dp)
-    val fieldBg = MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.4f)
-
-    val chunked = remember(address) {
-        buildAnnotatedString {
-            address.chunked(4).forEachIndexed { i, group ->
-                withStyle(SpanStyle(color = if (i % 2 == 0) androidx.compose.ui.graphics.Color(0xFFE6E6E6) else accent)) {
-                    append(group)
-                }
-                append(" ")
-            }
-        }
-    }
-
-    Column(
-        modifier = modifier
-            .fillMaxSize()
-            .padding(horizontal = 20.dp)
-            .verticalScroll(rememberScrollState()),
-        horizontalAlignment = Alignment.CenterHorizontally
-    ) {
-        Spacer(Modifier.height(8.dp))
-        Row(modifier = Modifier.fillMaxWidth(), verticalAlignment = Alignment.CenterVertically) {
-            Icon(Icons.AutoMirrored.Filled.Send, contentDescription = null, tint = accent, modifier = Modifier.size(20.dp))
-            Spacer(Modifier.width(8.dp))
-            Text(stringResource(R.string.wallet_onchain_send_title), style = MaterialTheme.typography.titleLarge, fontWeight = FontWeight.SemiBold)
-        }
-
-        Spacer(Modifier.height(32.dp))
-
-        Text(
-            "%,d sats".format(amountSats),
-            style = MaterialTheme.typography.headlineLarge,
-            fontWeight = FontWeight.Bold,
-            color = accent
-        )
-        Spacer(Modifier.height(4.dp))
-        Text(
-            stringResource(R.string.wallet_onchain_plus_fee, feeSats),
-            style = MaterialTheme.typography.bodyMedium,
-            color = MaterialTheme.colorScheme.onSurfaceVariant
-        )
-
-        Spacer(Modifier.height(28.dp))
-
-        Column(
-            modifier = Modifier
-                .fillMaxWidth()
-                .background(fieldBg, fieldShape)
-                .padding(20.dp),
-            horizontalAlignment = Alignment.CenterHorizontally
-        ) {
-            Text(
-                stringResource(R.string.wallet_onchain_sending_to),
-                style = MaterialTheme.typography.bodySmall,
-                color = MaterialTheme.colorScheme.onSurfaceVariant
-            )
-            Spacer(Modifier.height(10.dp))
-            Text(
-                chunked,
-                style = MaterialTheme.typography.bodyLarge,
-                fontFamily = androidx.compose.ui.text.font.FontFamily.Monospace,
-                textAlign = TextAlign.Center,
-                lineHeight = 28.sp
-            )
-        }
-
-        Spacer(Modifier.height(20.dp))
-
-        Text(
-            stringResource(R.string.wallet_onchain_irreversible_warning),
-            style = MaterialTheme.typography.bodySmall,
-            color = accent,
-            textAlign = TextAlign.Center
-        )
-
-        Spacer(Modifier.height(24.dp))
-
-        if (isLoading) {
-            CircularProgressIndicator()
-        } else {
-            Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.spacedBy(12.dp)) {
-                OutlinedButton(
-                    onClick = onBack,
-                    modifier = Modifier.weight(1f).height(52.dp),
-                    shape = fieldShape
-                ) {
-                    Text(stringResource(R.string.btn_back))
-                }
-                Button(
-                    onClick = onConfirm,
-                    modifier = Modifier.weight(1f).height(52.dp),
-                    shape = fieldShape,
-                    colors = ButtonDefaults.buttonColors(containerColor = accent, contentColor = Color.White)
-                ) {
-                    Icon(Icons.AutoMirrored.Filled.Send, contentDescription = null, modifier = Modifier.size(18.dp))
-                    Spacer(Modifier.width(8.dp))
-                    Text(stringResource(R.string.wallet_onchain_send_confirm), fontWeight = FontWeight.SemiBold)
-                }
-            }
-        }
-
-        Spacer(Modifier.height(24.dp))
-    }
-}
-
-// On-chain send: result
-@Composable
-private fun OnchainSendResultContent(
-    success: Boolean,
-    paymentId: String?,
-    message: String,
-    onDone: () -> Unit,
-    modifier: Modifier = Modifier
-) {
-    val context = LocalContext.current
-
-    Column(
-        modifier = modifier.fillMaxSize().padding(horizontal = 16.dp),
-        horizontalAlignment = Alignment.CenterHorizontally,
-        verticalArrangement = Arrangement.Center
-    ) {
-        Icon(
-            if (success) Icons.Default.Check else Icons.Default.Close,
-            contentDescription = null,
-            modifier = Modifier.size(72.dp),
-            tint = if (success) WispThemeColors.zapColor else MaterialTheme.colorScheme.error
-        )
-        Spacer(Modifier.height(16.dp))
-        Text(
-            stringResource(if (success) R.string.wallet_onchain_payment_sent else R.string.wallet_onchain_payment_failed),
-            style = MaterialTheme.typography.headlineMedium,
-            color = MaterialTheme.colorScheme.onSurface
-        )
-        Spacer(Modifier.height(8.dp))
-        Text(
-            message,
-            style = MaterialTheme.typography.bodyMedium,
-            color = MaterialTheme.colorScheme.onSurfaceVariant,
-            textAlign = TextAlign.Center
-        )
-        if (success && paymentId != null) {
-            Spacer(Modifier.height(16.dp))
-            TextButton(onClick = {
-                val intent = Intent(Intent.ACTION_VIEW, android.net.Uri.parse("https://mempool.space/tx/$paymentId"))
-                context.startActivity(intent)
-            }) {
-                Text(stringResource(R.string.wallet_onchain_view_mempool))
-            }
-        }
-        Spacer(Modifier.height(24.dp))
-        FilledTonalButton(onClick = onDone, modifier = Modifier.fillMaxWidth()) {
-            Text(stringResource(R.string.btn_done))
         }
     }
 }

--- a/app/src/main/kotlin/com/darkwisp/app/ui/screen/WalletScreen.kt
+++ b/app/src/main/kotlin/com/darkwisp/app/ui/screen/WalletScreen.kt
@@ -807,8 +807,7 @@ fun WalletScreen(
                                 isLoading = viewModel.isLoading.collectAsState().value,
                                 lightningAddress = viewModel.lightningAddress.collectAsState().value,
                                 onAmountChange = { viewModel.setReceiveAmount(it) },
-                                onGenerate = { sats, note, expirySecs -> viewModel.generateInvoice(sats, note, expirySecs) },
-                                onShowAddressQR = { viewModel.navigateTo(WalletPage.LightningAddressQR) }
+                                onGenerate = { sats, note, expirySecs -> viewModel.generateInvoice(sats, note, expirySecs) }
                             )
                             is WalletPage.ReceiveInvoice -> ReceiveInvoiceContent(
                                 invoice = page.invoice,
@@ -2356,7 +2355,6 @@ private fun ReceiveAmountContent(
     lightningAddress: String?,
     onAmountChange: (String) -> Unit,
     onGenerate: (Long, String, Int) -> Unit,
-    onShowAddressQR: () -> Unit = {},
     modifier: Modifier = Modifier
 ) {
     val receiveCtx = LocalContext.current
@@ -2373,6 +2371,7 @@ private fun ReceiveAmountContent(
     val satAmount: Long? = if (fiatMode) fiatSats else amount.toLongOrNull()
 
     var description by remember { mutableStateOf("") }
+    var showAddressQR by remember { mutableStateOf(false) }
     var selectedExpiry by remember { mutableStateOf(InvoiceExpiry.ONE_HOUR) }
     var customHours by remember { mutableStateOf("") }
     val expirySecs = when (selectedExpiry) {
@@ -2385,12 +2384,27 @@ private fun ReceiveAmountContent(
 
     val fieldShape = RoundedCornerShape(14.dp)
     val fieldBg = MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.4f)
+    val scrollState = rememberScrollState()
+    var invoiceGenerating by remember { mutableStateOf(false) }
+
+    // The shared isLoading flag can flip true from unrelated wallet
+    // operations, so track invoice creation locally to avoid showing a
+    // spinner just because the sheet opened while isLoading happened to be true.
+    LaunchedEffect(isLoading) { if (!isLoading) invoiceGenerating = false }
+
+    // Scroll to the QR card once AnimatedVisibility has expanded and laid out.
+    LaunchedEffect(showAddressQR) {
+        if (showAddressQR) {
+            kotlinx.coroutines.delay(350)
+            scrollState.animateScrollTo(scrollState.maxValue)
+        }
+    }
 
     Column(
         modifier = modifier
             .fillMaxSize()
             .padding(horizontal = 20.dp)
-            .verticalScroll(rememberScrollState())
+            .verticalScroll(scrollState)
     ) {
         Spacer(Modifier.height(8.dp))
 
@@ -2566,7 +2580,7 @@ private fun ReceiveAmountContent(
 
         Spacer(Modifier.height(24.dp))
 
-        if (isLoading) {
+        if (invoiceGenerating) {
             Box(
                 modifier = Modifier
                     .fillMaxWidth()
@@ -2591,6 +2605,7 @@ private fun ReceiveAmountContent(
             Button(
                 onClick = {
                     val sats = satAmount ?: return@Button
+                    invoiceGenerating = true
                     onGenerate(sats, description, expirySecs)
                 },
                 enabled = canCreate,
@@ -2616,7 +2631,61 @@ private fun ReceiveAmountContent(
         // Lightning address — shown below invoice form as "or receive via" row
         if (!lightningAddress.isNullOrBlank()) {
             Spacer(Modifier.height(24.dp))
-            LightningAddressReceiveRow(address = lightningAddress, onShowQR = onShowAddressQR)
+            LightningAddressReceiveRow(
+                address = lightningAddress,
+                onShowQR = { showAddressQR = !showAddressQR }
+            )
+            AnimatedVisibility(visible = showAddressQR) {
+                val clipboardManager = LocalClipboardManager.current
+                val qrBitmap = remember(lightningAddress) {
+                    val writer = QRCodeWriter()
+                    val matrix = writer.encode(lightningAddress, BarcodeFormat.QR_CODE, 512, 512)
+                    val bmp = Bitmap.createBitmap(matrix.width, matrix.height, Bitmap.Config.RGB_565)
+                    for (x in 0 until matrix.width) {
+                        for (y in 0 until matrix.height) {
+                            bmp.setPixel(x, y, if (matrix.get(x, y)) android.graphics.Color.BLACK else android.graphics.Color.WHITE)
+                        }
+                    }
+                    bmp
+                }
+                Column(
+                    horizontalAlignment = Alignment.CenterHorizontally,
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(top = 16.dp)
+                        .background(
+                            MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.35f),
+                            RoundedCornerShape(16.dp)
+                        )
+                        .padding(20.dp)
+                ) {
+                    Image(
+                        bitmap = qrBitmap.asImageBitmap(),
+                        contentDescription = stringResource(R.string.cd_invoice_qr_code),
+                        modifier = Modifier
+                            .size(240.dp)
+                            .background(Color.White, RoundedCornerShape(12.dp))
+                            .padding(10.dp)
+                    )
+                    Spacer(Modifier.height(12.dp))
+                    Row(verticalAlignment = Alignment.CenterVertically) {
+                        Text(
+                            lightningAddress,
+                            style = MaterialTheme.typography.bodySmall,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                            modifier = Modifier.weight(1f)
+                        )
+                        IconButton(onClick = { clipboardManager.setText(AnnotatedString(lightningAddress)) }) {
+                            Icon(
+                                Icons.Default.ContentCopy,
+                                contentDescription = stringResource(R.string.wallet_copy_address),
+                                modifier = Modifier.size(18.dp),
+                                tint = MaterialTheme.colorScheme.onSurfaceVariant
+                            )
+                        }
+                    }
+                }
+            }
         }
 
         Spacer(Modifier.height(24.dp))

--- a/app/src/main/kotlin/com/darkwisp/app/ui/screen/WalletScreen.kt
+++ b/app/src/main/kotlin/com/darkwisp/app/ui/screen/WalletScreen.kt
@@ -84,6 +84,7 @@ import androidx.compose.material.icons.automirrored.filled.KeyboardArrowRight
 import androidx.compose.material.icons.filled.Image
 import androidx.compose.material.icons.filled.KeyboardArrowDown
 import androidx.compose.material.icons.filled.KeyboardArrowUp
+import androidx.compose.material.icons.filled.CurrencyBitcoin
 import androidx.compose.material.icons.filled.QrCode
 import androidx.compose.material.icons.outlined.Info
 import androidx.compose.material.icons.filled.Receipt
@@ -118,8 +119,12 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Scaffold
+import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
+import androidx.compose.foundation.gestures.detectVerticalDragGestures
+import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.material3.TopAppBar
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
@@ -146,6 +151,9 @@ import androidx.lifecycle.compose.LocalLifecycleOwner
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.AnnotatedString
+import androidx.compose.ui.text.buildAnnotatedString
+import androidx.compose.ui.text.SpanStyle
+import androidx.compose.ui.text.withStyle
 import androidx.compose.ui.viewinterop.AndroidView
 import androidx.core.content.ContextCompat
 import androidx.compose.ui.text.font.FontFamily
@@ -166,6 +174,7 @@ import com.darkwisp.app.BuildConfig
 import com.darkwisp.app.R
 import com.darkwisp.app.nostr.NipA3
 import com.darkwisp.app.repo.BalanceUnit
+import com.darkwisp.app.repo.OnchainFeeQuote
 import com.darkwisp.app.repo.WalletBalanceDisplayMode
 import com.darkwisp.app.repo.FiatPreferences
 import com.darkwisp.app.repo.WalletMode
@@ -207,6 +216,7 @@ fun WalletScreen(
     // app bar to match iOS — leaves more headroom for the centered logo
     // + title layout.
     val hideAppBar = currentPage is WalletPage.Home ||
+        currentPage is WalletPage.Transactions ||
         currentPage is WalletPage.ModeSelection ||
         currentPage is WalletPage.NwcSetup ||
         currentPage is WalletPage.SparkSetup ||
@@ -426,6 +436,7 @@ fun WalletScreen(
                     is WalletPage.SendInput -> SendInputContent(
                         input = viewModel.sendInput.collectAsState().value,
                         error = viewModel.sendError.collectAsState().value,
+                        walletMode = viewModel.walletMode.collectAsState().value,
                         onInputChange = { viewModel.updateSendInput(it) },
                         onNext = { viewModel.processInput() },
                         onScanQR = { viewModel.navigateTo(WalletPage.ScanQR) },
@@ -498,8 +509,13 @@ fun WalletScreen(
                         amount = viewModel.receiveAmount.collectAsState().value,
                         isLoading = viewModel.isLoading.collectAsState().value,
                         lightningAddress = viewModel.lightningAddress.collectAsState().value,
+                        walletMode = viewModel.walletMode.collectAsState().value,
+                        depositAddress = viewModel.depositAddress.collectAsState().value,
+                        depositAddressLoading = viewModel.depositAddressLoading.collectAsState().value,
+                        depositAddressError = viewModel.depositAddressError.collectAsState().value,
                         onAmountChange = { viewModel.setReceiveAmount(it) },
-                        onGenerate = { sats, note -> viewModel.generateInvoice(sats, note) },
+                        onGenerate = { sats, note, expirySecs -> viewModel.generateInvoice(sats, note, expirySecs) },
+                        onLoadDepositAddress = { viewModel.loadDepositAddress() },
                         modifier = Modifier.padding(padding)
                     )
                     is WalletPage.ReceiveInvoice -> {
@@ -520,17 +536,34 @@ fun WalletScreen(
                         )
                     }
                     is WalletPage.Transactions -> {
-                        // Observe profile refresh key so UI recomposes when new profiles arrive
+                        // Home stays visible behind the transactions bottom sheet.
                         val profileKey = viewModel.profileRefreshKey.collectAsState().value
-                        TransactionHistoryContent(
-                            transactions = viewModel.transactions.collectAsState().value,
-                            error = viewModel.transactionsError.collectAsState().value,
-                            isLoading = viewModel.isLoading.collectAsState().value,
-                            isLoadingMore = viewModel.isLoadingMore.collectAsState().value,
-                            hasMore = viewModel.hasMoreTransactions.collectAsState().value,
-                            onLoadMore = { viewModel.loadMoreTransactions() },
-                            profileLookup = { viewModel.getProfileData(it) },
-                            profileRefreshKey = profileKey,
+                        WalletHomeContent(
+                            balanceMsats = balanceMsats,
+                            walletMode = viewModel.walletMode.collectAsState().value,
+                            balanceUnit = viewModel.balanceUnit.collectAsState().value,
+                            showSettingsAlert = viewModel.walletMode.collectAsState().value == WalletMode.SPARK
+                                    && !viewModel.seedBackupAcked.collectAsState().value,
+                            seedBackupAcked = viewModel.seedBackupAcked.collectAsState().value,
+                            backupMissing = viewModel.backupMissing.collectAsState().value,
+                            onSend = { viewModel.navigateTo(WalletPage.SendInput) },
+                            onReceive = { viewModel.navigateTo(WalletPage.ReceiveAmount) },
+                            onTransactions = {},
+                            onRefresh = { viewModel.refreshBalance() },
+                            onSettings = { viewModel.navigateTo(WalletPage.Settings) },
+                            onBackupToRelay = {
+                                viewModel.resetBackupStatus()
+                                viewModel.navigateTo(WalletPage.BackupToRelay)
+                            },
+                            onViewSeed = { viewModel.showMnemonicBackup() },
+                            lightningAddress = viewModel.lightningAddress.collectAsState().value,
+                            onSetupAddress = {
+                                viewModel.resetAddressSetupState()
+                                viewModel.navigateTo(WalletPage.LightningAddressSetup)
+                            },
+                            recentTransactions = viewModel.transactions.collectAsState().value,
+                            profileLookup = remember(profileKey) { { viewModel.getProfileData(it) } },
+                            nwcNodeAlias = viewModel.nwcNodeAlias.collectAsState().value,
                             pubkey = viewModel.keyRepo.getPubkeyHex(),
                             modifier = Modifier.padding(padding)
                         )
@@ -613,6 +646,65 @@ fun WalletScreen(
                         },
                         modifier = Modifier.padding(padding)
                     )
+                    is WalletPage.OnchainSendAmount -> {
+                        val page = currentPage as WalletPage.OnchainSendAmount
+                        val sendAmount by viewModel.sendAmount.collectAsState()
+                        val feeLoading by viewModel.onchainSendLoading.collectAsState()
+                        val error by viewModel.sendError.collectAsState()
+                        val feeQuote by viewModel.onchainFeeQuote.collectAsState()
+                        OnchainSendAmountContent(
+                            address = page.address,
+                            amount = sendAmount,
+                            balanceSats = balanceMsats / 1000,
+                            isLoading = feeLoading,
+                            error = error,
+                            feeQuote = feeQuote,
+                            onAmountChange = {
+                                viewModel.setSendAmount(it)
+                                viewModel.clearOnchainQuote()
+                            },
+                            onUseAll = {
+                                viewModel.setSendAmount((balanceMsats / 1000).toString())
+                                viewModel.clearOnchainQuote()
+                            },
+                            onGetFeeQuote = {
+                                val sats = sendAmount.toLongOrNull() ?: return@OnchainSendAmountContent
+                                viewModel.prepareOnchainSend(page.address, sats)
+                            },
+                            onContinue = {
+                                val sats = sendAmount.toLongOrNull() ?: return@OnchainSendAmountContent
+                                viewModel.continueToOnchainConfirm(page.address, sats)
+                            },
+                            onBack = {
+                                viewModel.clearOnchainQuote()
+                                viewModel.navigateBack()
+                            },
+                            modifier = Modifier.padding(padding)
+                        )
+                    }
+                    is WalletPage.OnchainSendConfirm -> {
+                        val page = currentPage as WalletPage.OnchainSendConfirm
+                        val sending by viewModel.isLoading.collectAsState()
+                        OnchainSendConfirmContent(
+                            address = page.address,
+                            amountSats = page.amountSats,
+                            feeQuote = page.feeQuote,
+                            isLoading = sending,
+                            onConfirm = { viewModel.sendOnchain(page.prepareData) },
+                            onBack = { viewModel.navigateBack() },
+                            modifier = Modifier.padding(padding)
+                        )
+                    }
+                    is WalletPage.OnchainSendResult -> {
+                        val page = currentPage as WalletPage.OnchainSendResult
+                        OnchainSendResultContent(
+                            success = page.success,
+                            paymentId = page.paymentId,
+                            message = page.message,
+                            onDone = { viewModel.navigateHome() },
+                            modifier = Modifier.padding(padding)
+                        )
+                    }
                     else -> {
                         // ModeSelection, NwcSetup, SparkSetup — shouldn't appear while connected
                         val profileKey = viewModel.profileRefreshKey.collectAsState().value
@@ -647,6 +739,28 @@ fun WalletScreen(
                             nwcNodeAlias = viewModel.nwcNodeAlias.collectAsState().value,
                             pubkey = viewModel.keyRepo.getPubkeyHex(),
                             modifier = Modifier.padding(padding)
+                        )
+                    }
+                }
+
+                // Transactions full-screen bottom sheet — swipe down to dismiss
+                if (currentPage is WalletPage.Transactions) {
+                    val txSheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
+                    val txProfileKey = viewModel.profileRefreshKey.collectAsState().value
+                    ModalBottomSheet(
+                        onDismissRequest = { viewModel.navigateBack() },
+                        sheetState = txSheetState,
+                    ) {
+                        TransactionHistoryContent(
+                            transactions = viewModel.transactions.collectAsState().value,
+                            error = viewModel.transactionsError.collectAsState().value,
+                            isLoading = viewModel.isLoading.collectAsState().value,
+                            isLoadingMore = viewModel.isLoadingMore.collectAsState().value,
+                            hasMore = viewModel.hasMoreTransactions.collectAsState().value,
+                            onLoadMore = { viewModel.loadMoreTransactions() },
+                            profileLookup = { viewModel.getProfileData(it) },
+                            profileRefreshKey = txProfileKey,
+                            pubkey = viewModel.keyRepo.getPubkeyHex(),
                         )
                     }
                 }
@@ -1510,7 +1624,24 @@ private fun WalletHomeContent(
 
         // ── Recent transactions inline footer ──────────────────────
         if (recentTransactions.isNotEmpty()) {
-            Column(modifier = Modifier.fillMaxWidth()) {
+            Column(
+                modifier = Modifier.fillMaxWidth()
+                    .pointerInput(onTransactions) {
+                        var totalDrag = 0f
+                        detectVerticalDragGestures(
+                            onDragStart = { totalDrag = 0f },
+                            onDragEnd = { totalDrag = 0f },
+                            onDragCancel = { totalDrag = 0f }
+                        ) { change, delta ->
+                            totalDrag += delta
+                            if (totalDrag < -40f) {
+                                totalDrag = 0f
+                                change.consume()
+                                onTransactions()
+                            }
+                        }
+                    }
+            ) {
                 Row(
                     modifier = Modifier
                         .fillMaxWidth()
@@ -1602,6 +1733,7 @@ private fun WalletActionButton(
 private fun SendInputContent(
     input: String,
     error: String?,
+    walletMode: WalletMode = WalletMode.NONE,
     onInputChange: (String) -> Unit,
     onNext: () -> Unit,
     onScanQR: () -> Unit,
@@ -1667,7 +1799,14 @@ private fun SendInputContent(
             value = input,
             onValueChange = onInputChange,
             label = { Text(stringResource(R.string.wallet_lightning_address_invoice)) },
-            placeholder = { Text(stringResource(R.string.placeholder_user_domain)) },
+            placeholder = {
+                Text(
+                    if (walletMode == WalletMode.SPARK)
+                        stringResource(R.string.placeholder_send_spark)
+                    else
+                        stringResource(R.string.placeholder_user_domain)
+                )
+            },
             modifier = Modifier.fillMaxWidth(),
             singleLine = false,
             maxLines = 4,
@@ -2104,7 +2243,11 @@ private fun SendResultContent(
 
 // --- Receive amount ---
 
-private enum class ReceiveTab { INVOICE, ADDRESS }
+private enum class ReceiveTab { LIGHTNING, BITCOIN }
+
+private enum class InvoiceExpiry(val seconds: Int) {
+    ONE_HOUR(3600), ONE_DAY(86400), CUSTOM(0)
+}
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -2112,8 +2255,13 @@ private fun ReceiveAmountContent(
     amount: String,
     isLoading: Boolean,
     lightningAddress: String?,
+    walletMode: WalletMode,
+    depositAddress: String?,
+    depositAddressLoading: Boolean,
+    depositAddressError: String?,
     onAmountChange: (String) -> Unit,
-    onGenerate: (Long, String) -> Unit,
+    onGenerate: (Long, String, Int) -> Unit,
+    onLoadDepositAddress: () -> Unit,
     modifier: Modifier = Modifier
 ) {
     val receiveCtx = LocalContext.current
@@ -2128,11 +2276,20 @@ private fun ReceiveAmountContent(
         ((fiatValue / btcPrice) * 100_000_000.0).toLong()
     } else null
     val satAmount: Long? = if (fiatMode) fiatSats else amount.toLongOrNull()
-    val canCreate = (satAmount ?: 0L) > 0L && !isLoading
 
     var description by remember { mutableStateOf("") }
-    var selectedTab by remember { mutableStateOf(ReceiveTab.INVOICE) }
-    val hasLightningAddress = !lightningAddress.isNullOrBlank()
+    var selectedExpiry by remember { mutableStateOf(InvoiceExpiry.ONE_HOUR) }
+    var customHours by remember { mutableStateOf("") }
+    val expirySecs = when (selectedExpiry) {
+        InvoiceExpiry.ONE_HOUR -> 3600
+        InvoiceExpiry.ONE_DAY -> 86400
+        InvoiceExpiry.CUSTOM -> (customHours.toIntOrNull() ?: 0) * 3600
+    }
+    val canCreate = (satAmount ?: 0L) > 0L && !isLoading &&
+        (selectedExpiry != InvoiceExpiry.CUSTOM || expirySecs > 0)
+
+    val isSpark = walletMode == WalletMode.SPARK
+    var selectedTab by remember { mutableStateOf(ReceiveTab.LIGHTNING) }
 
     val fieldShape = RoundedCornerShape(14.dp)
     val fieldBg = MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.4f)
@@ -2156,24 +2313,35 @@ private fun ReceiveAmountContent(
 
         Spacer(Modifier.height(20.dp))
 
-        if (hasLightningAddress) {
+        // Show tab row only for Spark wallets (which support on-chain)
+        if (isSpark) {
             SingleChoiceSegmentedButtonRow(modifier = Modifier.fillMaxWidth()) {
                 SegmentedButton(
-                    selected = selectedTab == ReceiveTab.INVOICE,
-                    onClick = { selectedTab = ReceiveTab.INVOICE },
-                    shape = SegmentedButtonDefaults.itemShape(index = 0, count = 2)
-                ) { Text(stringResource(R.string.wallet_receive_invoice_tab)) }
+                    selected = selectedTab == ReceiveTab.LIGHTNING,
+                    onClick = { selectedTab = ReceiveTab.LIGHTNING },
+                    shape = SegmentedButtonDefaults.itemShape(index = 0, count = 2),
+                    icon = { Icon(Icons.Outlined.Bolt, contentDescription = null, modifier = Modifier.size(16.dp)) }
+                ) { Text(stringResource(R.string.wallet_receive_lightning_tab)) }
                 SegmentedButton(
-                    selected = selectedTab == ReceiveTab.ADDRESS,
-                    onClick = { selectedTab = ReceiveTab.ADDRESS },
-                    shape = SegmentedButtonDefaults.itemShape(index = 1, count = 2)
-                ) { Text(stringResource(R.string.wallet_receive_address_tab)) }
+                    selected = selectedTab == ReceiveTab.BITCOIN,
+                    onClick = {
+                        selectedTab = ReceiveTab.BITCOIN
+                        onLoadDepositAddress()
+                    },
+                    shape = SegmentedButtonDefaults.itemShape(index = 1, count = 2),
+                    icon = { Icon(Icons.Default.CurrencyBitcoin, contentDescription = null, modifier = Modifier.size(16.dp)) }
+                ) { Text(stringResource(R.string.wallet_receive_bitcoin_tab)) }
             }
             Spacer(Modifier.height(20.dp))
         }
 
-        if (selectedTab == ReceiveTab.ADDRESS && hasLightningAddress) {
-            ReceiveAddressBlock(address = lightningAddress!!)
+        if (selectedTab == ReceiveTab.BITCOIN && isSpark) {
+            ReceiveBitcoinBlock(
+                address = depositAddress,
+                isLoading = depositAddressLoading,
+                error = depositAddressError,
+                onRetry = onLoadDepositAddress
+            )
         } else {
             // AMOUNT field
             Text(
@@ -2201,7 +2369,6 @@ private fun ReceiveAmountContent(
                     value = amount,
                     onValueChange = { input ->
                         val filtered = if (fiatMode) {
-                            // Allow digits + a single decimal point
                             val sb = StringBuilder()
                             var seenDot = false
                             for (c in input) {
@@ -2290,6 +2457,51 @@ private fun ReceiveAmountContent(
                 )
             }
 
+            Spacer(Modifier.height(20.dp))
+
+            // EXPIRES selector
+            Text(
+                stringResource(R.string.wallet_receive_expires_label),
+                style = MaterialTheme.typography.labelMedium,
+                fontWeight = FontWeight.SemiBold,
+                letterSpacing = 0.5.sp,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+            Spacer(Modifier.height(8.dp))
+            Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                listOf(
+                    InvoiceExpiry.ONE_HOUR to stringResource(R.string.wallet_receive_expires_1h),
+                    InvoiceExpiry.ONE_DAY to stringResource(R.string.wallet_receive_expires_24h),
+                    InvoiceExpiry.CUSTOM to stringResource(R.string.wallet_receive_expires_custom)
+                ).forEachIndexed { _, (expiry, label) ->
+                    val isSelected = selectedExpiry == expiry
+                    OutlinedButton(
+                        onClick = { selectedExpiry = expiry },
+                        modifier = Modifier.weight(1f),
+                        colors = ButtonDefaults.outlinedButtonColors(
+                            containerColor = if (isSelected) MaterialTheme.colorScheme.primary.copy(alpha = 0.12f) else Color.Transparent,
+                            contentColor = if (isSelected) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.onSurfaceVariant
+                        ),
+                        border = BorderStroke(
+                            1.dp,
+                            if (isSelected) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.outline
+                        ),
+                        contentPadding = PaddingValues(horizontal = 8.dp, vertical = 6.dp)
+                    ) { Text(label, style = MaterialTheme.typography.labelMedium) }
+                }
+            }
+            if (selectedExpiry == InvoiceExpiry.CUSTOM) {
+                Spacer(Modifier.height(8.dp))
+                OutlinedTextField(
+                    value = customHours,
+                    onValueChange = { customHours = it.filter { c -> c.isDigit() } },
+                    label = { Text(stringResource(R.string.wallet_receive_expires_hours)) },
+                    singleLine = true,
+                    keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
+                    modifier = Modifier.fillMaxWidth()
+                )
+            }
+
             Spacer(Modifier.height(24.dp))
 
             if (isLoading) {
@@ -2317,7 +2529,7 @@ private fun ReceiveAmountContent(
                 Button(
                     onClick = {
                         val sats = satAmount ?: return@Button
-                        onGenerate(sats, description)
+                        onGenerate(sats, description, expirySecs)
                     },
                     enabled = canCreate,
                     modifier = Modifier
@@ -2338,6 +2550,371 @@ private fun ReceiveAmountContent(
                     )
                 }
             }
+
+            // Lightning address — shown below invoice form as "or receive via" row
+            if (!lightningAddress.isNullOrBlank()) {
+                Spacer(Modifier.height(24.dp))
+                HorizontalDivider(color = MaterialTheme.colorScheme.outline.copy(alpha = 0.3f))
+                Spacer(Modifier.height(16.dp))
+                Text(
+                    stringResource(R.string.wallet_receive_via_address),
+                    style = MaterialTheme.typography.labelMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    modifier = Modifier.fillMaxWidth(),
+                    textAlign = TextAlign.Center
+                )
+                Spacer(Modifier.height(12.dp))
+                LightningAddressReceiveRow(address = lightningAddress)
+            }
+        }
+
+        Spacer(Modifier.height(24.dp))
+    }
+}
+
+// Lightning address displayed below the invoice form
+@Composable
+private fun LightningAddressReceiveRow(address: String) {
+    val clipboardManager = LocalClipboardManager.current
+    val context = LocalContext.current
+    val actionShape = RoundedCornerShape(14.dp)
+    val actionBg = MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.4f)
+
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .background(actionBg, actionShape)
+            .padding(horizontal = 16.dp, vertical = 12.dp)
+    ) {
+        Text(
+            address,
+            style = MaterialTheme.typography.bodyMedium,
+            color = MaterialTheme.colorScheme.onSurface,
+            textAlign = TextAlign.Center,
+            modifier = Modifier.fillMaxWidth()
+        )
+        Spacer(Modifier.height(10.dp))
+        Row(
+            verticalAlignment = Alignment.CenterVertically,
+            modifier = Modifier.fillMaxWidth()
+        ) {
+            TextButton(
+                onClick = { clipboardManager.setText(AnnotatedString(address)) },
+                modifier = Modifier.weight(1f),
+                colors = ButtonDefaults.textButtonColors(contentColor = WispThemeColors.zapColor)
+            ) {
+                Icon(Icons.Default.ContentCopy, contentDescription = null, modifier = Modifier.size(16.dp))
+                Spacer(Modifier.width(4.dp))
+                Text(stringResource(R.string.wallet_copy_address), fontWeight = FontWeight.Medium, style = MaterialTheme.typography.labelMedium)
+            }
+            VerticalDivider(modifier = Modifier.height(20.dp))
+            TextButton(
+                onClick = {
+                    val intent = Intent(Intent.ACTION_SEND).apply {
+                        type = "text/plain"
+                        putExtra(Intent.EXTRA_TEXT, address)
+                    }
+                    context.startActivity(Intent.createChooser(intent, context.getString(R.string.wallet_share_address)))
+                },
+                modifier = Modifier.weight(1f),
+                colors = ButtonDefaults.textButtonColors(contentColor = WispThemeColors.zapColor)
+            ) {
+                Icon(Icons.Default.Share, contentDescription = null, modifier = Modifier.size(16.dp))
+                Spacer(Modifier.width(4.dp))
+                Text(stringResource(R.string.wallet_share), fontWeight = FontWeight.Medium, style = MaterialTheme.typography.labelMedium)
+            }
+        }
+    }
+}
+
+// Bitcoin on-chain deposit address block (Spark only)
+@Composable
+private fun ReceiveBitcoinBlock(
+    address: String?,
+    isLoading: Boolean,
+    error: String?,
+    onRetry: () -> Unit
+) {
+    val clipboardManager = LocalClipboardManager.current
+    val context = LocalContext.current
+    val cardShape = RoundedCornerShape(16.dp)
+    val cardBg = MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.35f)
+    val actionShape = RoundedCornerShape(14.dp)
+    val actionBg = MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.4f)
+
+    when {
+        isLoading -> {
+            Box(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .background(cardBg, cardShape)
+                    .padding(40.dp),
+                contentAlignment = Alignment.Center
+            ) {
+                CircularProgressIndicator(strokeWidth = 2.dp, modifier = Modifier.size(32.dp))
+            }
+        }
+        error != null -> {
+            Column(
+                horizontalAlignment = Alignment.CenterHorizontally,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .background(cardBg, cardShape)
+                    .padding(24.dp)
+            ) {
+                Text(error, style = MaterialTheme.typography.bodyMedium, color = MaterialTheme.colorScheme.error, textAlign = TextAlign.Center)
+                Spacer(Modifier.height(16.dp))
+                OutlinedButton(onClick = onRetry) { Text(stringResource(R.string.retry)) }
+            }
+        }
+        address != null -> {
+            val qrBitmap = remember(address) {
+                val writer = QRCodeWriter()
+                val matrix = writer.encode("bitcoin:$address", BarcodeFormat.QR_CODE, 512, 512)
+                val bitmap = Bitmap.createBitmap(matrix.width, matrix.height, Bitmap.Config.RGB_565)
+                for (x in 0 until matrix.width) {
+                    for (y in 0 until matrix.height) {
+                        bitmap.setPixel(x, y, if (matrix.get(x, y)) android.graphics.Color.BLACK else android.graphics.Color.WHITE)
+                    }
+                }
+                bitmap
+            }
+            Column(horizontalAlignment = Alignment.CenterHorizontally) {
+                Column(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .background(cardBg, cardShape)
+                        .padding(20.dp),
+                    horizontalAlignment = Alignment.CenterHorizontally
+                ) {
+                    Image(
+                        bitmap = qrBitmap.asImageBitmap(),
+                        contentDescription = stringResource(R.string.cd_bitcoin_address_qr),
+                        modifier = Modifier
+                            .size(260.dp)
+                            .background(Color.White, RoundedCornerShape(12.dp))
+                            .padding(8.dp)
+                    )
+                    Spacer(Modifier.height(12.dp))
+                    Text(
+                        address,
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        textAlign = TextAlign.Center,
+                        fontFamily = androidx.compose.ui.text.font.FontFamily.Monospace
+                    )
+                }
+                Spacer(Modifier.height(16.dp))
+                Row(
+                    verticalAlignment = Alignment.CenterVertically,
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .background(actionBg, actionShape)
+                ) {
+                    TextButton(
+                        onClick = { clipboardManager.setText(AnnotatedString(address)) },
+                        modifier = Modifier.weight(1f),
+                        colors = ButtonDefaults.textButtonColors(contentColor = WispThemeColors.zapColor)
+                    ) {
+                        Icon(Icons.Default.ContentCopy, contentDescription = null, modifier = Modifier.size(18.dp))
+                        Spacer(Modifier.width(6.dp))
+                        Text(stringResource(R.string.wallet_copy_address), fontWeight = FontWeight.Medium)
+                    }
+                    VerticalDivider(modifier = Modifier.height(24.dp))
+                    TextButton(
+                        onClick = {
+                            val intent = Intent(Intent.ACTION_SEND).apply {
+                                type = "text/plain"
+                                putExtra(Intent.EXTRA_TEXT, address)
+                            }
+                            context.startActivity(Intent.createChooser(intent, context.getString(R.string.wallet_share_address)))
+                        },
+                        modifier = Modifier.weight(1f),
+                        colors = ButtonDefaults.textButtonColors(contentColor = WispThemeColors.zapColor)
+                    ) {
+                        Icon(Icons.Default.Share, contentDescription = null, modifier = Modifier.size(18.dp))
+                        Spacer(Modifier.width(6.dp))
+                        Text(stringResource(R.string.wallet_share), fontWeight = FontWeight.Medium)
+                    }
+                }
+            }
+        }
+        else -> {
+            // Initial state — trigger load
+            LaunchedEffect(Unit) { onRetry() }
+        }
+    }
+}
+
+// On-chain send: amount entry (with inline fee quote)
+@Composable
+private fun OnchainSendAmountContent(
+    address: String,
+    amount: String,
+    balanceSats: Long,
+    isLoading: Boolean,
+    error: String?,
+    feeQuote: OnchainFeeQuote?,
+    onAmountChange: (String) -> Unit,
+    onUseAll: () -> Unit,
+    onGetFeeQuote: () -> Unit,
+    onContinue: () -> Unit,
+    onBack: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    val amountSats = amount.toLongOrNull() ?: 0L
+    val fieldShape = RoundedCornerShape(14.dp)
+    val fieldBg = MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.4f)
+    val accent = WispThemeColors.zapColor
+
+    Column(
+        modifier = modifier
+            .fillMaxSize()
+            .padding(horizontal = 20.dp)
+            .verticalScroll(rememberScrollState())
+    ) {
+        Spacer(Modifier.height(8.dp))
+        Row(verticalAlignment = Alignment.CenterVertically) {
+            IconButton(onClick = onBack) {
+                Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = stringResource(R.string.btn_back))
+            }
+            Icon(Icons.Default.ArrowUpward, contentDescription = null, tint = accent, modifier = Modifier.size(20.dp))
+            Spacer(Modifier.width(8.dp))
+            Text(stringResource(R.string.wallet_onchain_send_title), style = MaterialTheme.typography.titleLarge, fontWeight = FontWeight.SemiBold)
+        }
+
+        Spacer(Modifier.height(20.dp))
+
+        // Recipient address (read-only)
+        Box(
+            modifier = Modifier
+                .fillMaxWidth()
+                .background(fieldBg, fieldShape)
+                .padding(16.dp)
+        ) {
+            Text(
+                address,
+                style = MaterialTheme.typography.bodyMedium,
+                fontFamily = androidx.compose.ui.text.font.FontFamily.Monospace,
+                color = MaterialTheme.colorScheme.onSurface
+            )
+        }
+        Spacer(Modifier.height(10.dp))
+        Row(verticalAlignment = Alignment.CenterVertically) {
+            Icon(Icons.Default.CurrencyBitcoin, contentDescription = null, tint = accent, modifier = Modifier.size(16.dp))
+            Spacer(Modifier.width(6.dp))
+            Text(
+                stringResource(R.string.wallet_onchain_bitcoin_detected),
+                style = MaterialTheme.typography.bodySmall,
+                color = accent
+            )
+        }
+
+        Spacer(Modifier.height(20.dp))
+
+        // Amount label + Use All
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.SpaceBetween,
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Text(
+                stringResource(R.string.wallet_onchain_amount_sats),
+                style = MaterialTheme.typography.labelMedium,
+                fontWeight = FontWeight.SemiBold,
+                letterSpacing = 0.5.sp,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+            Text(
+                stringResource(R.string.wallet_onchain_use_all, balanceSats),
+                style = MaterialTheme.typography.labelMedium,
+                fontWeight = FontWeight.SemiBold,
+                color = accent,
+                modifier = Modifier.clickable(onClick = onUseAll)
+            )
+        }
+        Spacer(Modifier.height(8.dp))
+        Box(
+            modifier = Modifier
+                .fillMaxWidth()
+                .background(fieldBg, fieldShape)
+                .padding(horizontal = 16.dp, vertical = 16.dp)
+        ) {
+            val amountStyle = MaterialTheme.typography.titleLarge.copy(color = MaterialTheme.colorScheme.onSurface)
+            BasicTextField(
+                value = amount,
+                onValueChange = { onAmountChange(it.filter { c -> c.isDigit() }) },
+                textStyle = amountStyle,
+                singleLine = true,
+                keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
+                cursorBrush = androidx.compose.ui.graphics.SolidColor(MaterialTheme.colorScheme.primary),
+                modifier = Modifier.fillMaxWidth(),
+                decorationBox = { inner ->
+                    if (amount.isEmpty()) Text("0", style = amountStyle.copy(color = MaterialTheme.colorScheme.onSurfaceVariant))
+                    inner()
+                }
+            )
+        }
+
+        if (error != null) {
+            Spacer(Modifier.height(12.dp))
+            Text(error, color = MaterialTheme.colorScheme.error, style = MaterialTheme.typography.bodySmall)
+        }
+
+        Spacer(Modifier.height(20.dp))
+
+        if (feeQuote != null) {
+            val feeSats = feeQuote.mediumFeeSats
+            val totalSats = amountSats + feeSats
+            Column(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .background(fieldBg, fieldShape)
+                    .padding(16.dp),
+                verticalArrangement = Arrangement.spacedBy(10.dp)
+            ) {
+                OnchainAmountRow(stringResource(R.string.wallet_onchain_amount), "%,d sats".format(amountSats))
+                OnchainAmountRow(stringResource(R.string.wallet_onchain_fee), "%,d sats".format(feeSats))
+                HorizontalDivider()
+                OnchainAmountRow(stringResource(R.string.wallet_onchain_total), "%,d sats".format(totalSats), emphasize = true)
+            }
+            Spacer(Modifier.height(16.dp))
+            Button(
+                onClick = onContinue,
+                modifier = Modifier.fillMaxWidth().height(52.dp),
+                shape = fieldShape,
+                colors = ButtonDefaults.buttonColors(containerColor = accent, contentColor = Color.White)
+            ) {
+                Icon(Icons.Default.ArrowUpward, contentDescription = null, modifier = Modifier.size(18.dp))
+                Spacer(Modifier.width(8.dp))
+                Text(stringResource(R.string.wallet_onchain_continue), style = MaterialTheme.typography.titleSmall, fontWeight = FontWeight.SemiBold)
+            }
+        } else if (isLoading) {
+            Box(
+                modifier = Modifier.fillMaxWidth().background(fieldBg, fieldShape).padding(vertical = 14.dp),
+                contentAlignment = Alignment.Center
+            ) {
+                Row(verticalAlignment = Alignment.CenterVertically) {
+                    CircularProgressIndicator(strokeWidth = 2.dp, modifier = Modifier.size(18.dp))
+                    Spacer(Modifier.width(10.dp))
+                    Text(stringResource(R.string.wallet_onchain_fetching_fee), style = MaterialTheme.typography.bodyMedium, color = MaterialTheme.colorScheme.onSurfaceVariant)
+                }
+            }
+        } else {
+            Button(
+                onClick = onGetFeeQuote,
+                enabled = amountSats > 0L,
+                modifier = Modifier.fillMaxWidth().height(52.dp),
+                shape = fieldShape,
+                colors = ButtonDefaults.buttonColors(
+                    containerColor = accent,
+                    contentColor = Color.White,
+                    disabledContainerColor = fieldBg,
+                    disabledContentColor = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+            ) {
+                Text(stringResource(R.string.wallet_onchain_get_fee_quote), style = MaterialTheme.typography.titleSmall, fontWeight = FontWeight.SemiBold)
+            }
         }
 
         Spacer(Modifier.height(24.dp))
@@ -2345,85 +2922,192 @@ private fun ReceiveAmountContent(
 }
 
 @Composable
-private fun ReceiveAddressBlock(address: String) {
-    val clipboardManager = LocalClipboardManager.current
-    val context = LocalContext.current
+private fun OnchainAmountRow(label: String, value: String, emphasize: Boolean = false) {
+    Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.SpaceBetween) {
+        Text(
+            label,
+            style = if (emphasize) MaterialTheme.typography.titleSmall else MaterialTheme.typography.bodyMedium,
+            fontWeight = if (emphasize) FontWeight.SemiBold else FontWeight.Normal,
+            color = if (emphasize) MaterialTheme.colorScheme.onSurface else MaterialTheme.colorScheme.onSurfaceVariant
+        )
+        Text(
+            value,
+            style = if (emphasize) MaterialTheme.typography.titleSmall else MaterialTheme.typography.bodyMedium,
+            fontWeight = if (emphasize) FontWeight.SemiBold else FontWeight.Normal,
+            color = if (emphasize) WispThemeColors.zapColor else MaterialTheme.colorScheme.onSurface
+        )
+    }
+}
 
-    val qrBitmap = remember(address) {
-        val writer = QRCodeWriter()
-        val matrix = writer.encode(address, BarcodeFormat.QR_CODE, 512, 512)
-        val bitmap = Bitmap.createBitmap(matrix.width, matrix.height, Bitmap.Config.RGB_565)
-        for (x in 0 until matrix.width) {
-            for (y in 0 until matrix.height) {
-                bitmap.setPixel(x, y, if (matrix.get(x, y)) android.graphics.Color.BLACK else android.graphics.Color.WHITE)
+// On-chain send: confirm (chunked address, big amount hero, irreversibility warning)
+@Composable
+private fun OnchainSendConfirmContent(
+    address: String,
+    amountSats: Long,
+    feeQuote: OnchainFeeQuote,
+    isLoading: Boolean,
+    onConfirm: () -> Unit,
+    onBack: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    val feeSats = feeQuote.mediumFeeSats
+    val accent = WispThemeColors.zapColor
+    val fieldShape = RoundedCornerShape(14.dp)
+    val fieldBg = MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.4f)
+
+    val chunked = remember(address) {
+        buildAnnotatedString {
+            address.chunked(4).forEachIndexed { i, group ->
+                withStyle(SpanStyle(color = if (i % 2 == 0) androidx.compose.ui.graphics.Color(0xFFE6E6E6) else accent)) {
+                    append(group)
+                }
+                append(" ")
             }
         }
-        bitmap
     }
 
-    val cardShape = RoundedCornerShape(16.dp)
-    val cardBg = MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.35f)
-    val actionShape = RoundedCornerShape(14.dp)
-    val actionBg = MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.4f)
+    Column(
+        modifier = modifier
+            .fillMaxSize()
+            .padding(horizontal = 20.dp)
+            .verticalScroll(rememberScrollState()),
+        horizontalAlignment = Alignment.CenterHorizontally
+    ) {
+        Spacer(Modifier.height(8.dp))
+        Row(modifier = Modifier.fillMaxWidth(), verticalAlignment = Alignment.CenterVertically) {
+            IconButton(onClick = onBack) {
+                Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = stringResource(R.string.btn_back))
+            }
+            Icon(Icons.Default.ArrowUpward, contentDescription = null, tint = accent, modifier = Modifier.size(20.dp))
+            Spacer(Modifier.width(8.dp))
+            Text(stringResource(R.string.wallet_onchain_send_title), style = MaterialTheme.typography.titleLarge, fontWeight = FontWeight.SemiBold)
+        }
 
-    Column(horizontalAlignment = Alignment.CenterHorizontally) {
+        Spacer(Modifier.height(32.dp))
+
+        Text(
+            "%,d sats".format(amountSats),
+            style = MaterialTheme.typography.headlineLarge,
+            fontWeight = FontWeight.Bold,
+            color = accent
+        )
+        Spacer(Modifier.height(4.dp))
+        Text(
+            stringResource(R.string.wallet_onchain_plus_fee, feeSats),
+            style = MaterialTheme.typography.bodyMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant
+        )
+
+        Spacer(Modifier.height(28.dp))
+
         Column(
             modifier = Modifier
                 .fillMaxWidth()
-                .background(cardBg, cardShape)
+                .background(fieldBg, fieldShape)
                 .padding(20.dp),
             horizontalAlignment = Alignment.CenterHorizontally
         ) {
-            Image(
-                bitmap = qrBitmap.asImageBitmap(),
-                contentDescription = stringResource(R.string.cd_invoice_qr_code),
-                modifier = Modifier
-                    .size(260.dp)
-                    .background(Color.White, RoundedCornerShape(12.dp))
-                    .padding(8.dp)
-            )
-            Spacer(Modifier.height(12.dp))
             Text(
-                address,
-                style = MaterialTheme.typography.bodyMedium,
-                color = MaterialTheme.colorScheme.onSurfaceVariant,
-                textAlign = TextAlign.Center
+                stringResource(R.string.wallet_onchain_sending_to),
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+            Spacer(Modifier.height(10.dp))
+            Text(
+                chunked,
+                style = MaterialTheme.typography.bodyLarge,
+                fontFamily = androidx.compose.ui.text.font.FontFamily.Monospace,
+                textAlign = TextAlign.Center,
+                lineHeight = 28.sp
             )
         }
 
         Spacer(Modifier.height(20.dp))
 
-        Row(
-            verticalAlignment = Alignment.CenterVertically,
-            modifier = Modifier
-                .fillMaxWidth()
-                .background(actionBg, actionShape)
-        ) {
-            TextButton(
-                onClick = { clipboardManager.setText(AnnotatedString(address)) },
-                modifier = Modifier.weight(1f),
-                colors = ButtonDefaults.textButtonColors(contentColor = WispThemeColors.zapColor)
-            ) {
-                Icon(Icons.Default.ContentCopy, contentDescription = null, modifier = Modifier.size(18.dp))
-                Spacer(Modifier.width(6.dp))
-                Text("Copy address", fontWeight = FontWeight.Medium)
+        Text(
+            stringResource(R.string.wallet_onchain_irreversible_warning),
+            style = MaterialTheme.typography.bodySmall,
+            color = accent,
+            textAlign = TextAlign.Center
+        )
+
+        Spacer(Modifier.height(24.dp))
+
+        if (isLoading) {
+            CircularProgressIndicator()
+        } else {
+            Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.spacedBy(12.dp)) {
+                OutlinedButton(
+                    onClick = onBack,
+                    modifier = Modifier.weight(1f).height(52.dp),
+                    shape = fieldShape
+                ) {
+                    Text(stringResource(R.string.btn_back))
+                }
+                Button(
+                    onClick = onConfirm,
+                    modifier = Modifier.weight(1f).height(52.dp),
+                    shape = fieldShape,
+                    colors = ButtonDefaults.buttonColors(containerColor = accent, contentColor = Color.White)
+                ) {
+                    Icon(Icons.Default.ArrowUpward, contentDescription = null, modifier = Modifier.size(18.dp))
+                    Spacer(Modifier.width(8.dp))
+                    Text(stringResource(R.string.wallet_onchain_send_confirm), fontWeight = FontWeight.SemiBold)
+                }
             }
-            VerticalDivider(modifier = Modifier.height(24.dp))
-            TextButton(
-                onClick = {
-                    val intent = Intent(Intent.ACTION_SEND).apply {
-                        type = "text/plain"
-                        putExtra(Intent.EXTRA_TEXT, address)
-                    }
-                    context.startActivity(Intent.createChooser(intent, "Share Lightning Address"))
-                },
-                modifier = Modifier.weight(1f),
-                colors = ButtonDefaults.textButtonColors(contentColor = WispThemeColors.zapColor)
-            ) {
-                Icon(Icons.Default.Share, contentDescription = null, modifier = Modifier.size(18.dp))
-                Spacer(Modifier.width(6.dp))
-                Text("Share", fontWeight = FontWeight.Medium)
+        }
+
+        Spacer(Modifier.height(24.dp))
+    }
+}
+
+// On-chain send: result
+@Composable
+private fun OnchainSendResultContent(
+    success: Boolean,
+    paymentId: String?,
+    message: String,
+    onDone: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    val context = LocalContext.current
+
+    Column(
+        modifier = modifier.fillMaxSize().padding(horizontal = 16.dp),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.Center
+    ) {
+        Icon(
+            if (success) Icons.Default.Check else Icons.Default.Close,
+            contentDescription = null,
+            modifier = Modifier.size(72.dp),
+            tint = if (success) WispThemeColors.zapColor else MaterialTheme.colorScheme.error
+        )
+        Spacer(Modifier.height(16.dp))
+        Text(
+            stringResource(if (success) R.string.wallet_onchain_payment_sent else R.string.wallet_onchain_payment_failed),
+            style = MaterialTheme.typography.headlineMedium,
+            color = MaterialTheme.colorScheme.onSurface
+        )
+        Spacer(Modifier.height(8.dp))
+        Text(
+            message,
+            style = MaterialTheme.typography.bodyMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            textAlign = TextAlign.Center
+        )
+        if (success && paymentId != null) {
+            Spacer(Modifier.height(16.dp))
+            TextButton(onClick = {
+                val intent = Intent(Intent.ACTION_VIEW, android.net.Uri.parse("https://mempool.space/tx/$paymentId"))
+                context.startActivity(intent)
+            }) {
+                Text(stringResource(R.string.wallet_onchain_view_mempool))
             }
+        }
+        Spacer(Modifier.height(24.dp))
+        FilledTonalButton(onClick = onDone, modifier = Modifier.fillMaxWidth()) {
+            Text(stringResource(R.string.btn_done))
         }
     }
 }

--- a/app/src/main/kotlin/com/darkwisp/app/ui/screen/WalletScreen.kt
+++ b/app/src/main/kotlin/com/darkwisp/app/ui/screen/WalletScreen.kt
@@ -94,6 +94,7 @@ import androidx.compose.material.icons.filled.SwapHoriz
 import androidx.compose.material.icons.filled.CloudUpload
 import androidx.compose.material.icons.filled.Share
 import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.BottomSheetDefaults
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.Card
@@ -190,6 +191,22 @@ import com.darkwisp.app.viewmodel.WalletPage
 import com.darkwisp.app.viewmodel.WalletState
 import com.darkwisp.app.viewmodel.WalletViewModel
 
+// Full-screen wallet bottom sheets (Transactions, Send, Receive) expand all
+// the way to the top of the window — push the grab handle below the status
+// bar/camera cutout so it isn't visually clipped by device chrome.
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun WalletSheetDragHandle() {
+    Box(
+        modifier = Modifier
+            .fillMaxWidth()
+            .statusBarsPadding(),
+        contentAlignment = Alignment.Center
+    ) {
+        BottomSheetDefaults.DragHandle()
+    }
+}
+
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun WalletScreen(
@@ -216,7 +233,26 @@ fun WalletScreen(
         currentPage is WalletPage.ModeSelection ||
         currentPage is WalletPage.NwcSetup ||
         currentPage is WalletPage.SparkSetup ||
-        currentPage is WalletPage.SparkRestoreSeed
+        currentPage is WalletPage.SparkRestoreSeed ||
+        currentPage is WalletPage.SendInput ||
+        currentPage is WalletPage.SendAmount ||
+        currentPage is WalletPage.SendConfirm ||
+        currentPage is WalletPage.Sending ||
+        currentPage is WalletPage.SendResult ||
+        currentPage is WalletPage.ReceiveAmount ||
+        currentPage is WalletPage.ReceiveInvoice ||
+        currentPage is WalletPage.ReceiveSuccess
+
+    // Send and Receive each render as a full-screen bottom sheet over the
+    // Home dashboard, matching the Transactions sheet treatment.
+    val isSendFlow = currentPage is WalletPage.SendInput ||
+        currentPage is WalletPage.SendAmount ||
+        currentPage is WalletPage.SendConfirm ||
+        currentPage is WalletPage.Sending ||
+        currentPage is WalletPage.SendResult
+    val isReceiveFlow = currentPage is WalletPage.ReceiveAmount ||
+        currentPage is WalletPage.ReceiveInvoice ||
+        currentPage is WalletPage.ReceiveSuccess
     Scaffold(
         contentWindowInsets = WindowInsets(0, 0, 0, 0),
         topBar = {
@@ -429,15 +465,6 @@ fun WalletScreen(
                             modifier = Modifier.padding(padding)
                         )
                     }
-                    is WalletPage.SendInput -> SendInputContent(
-                        input = viewModel.sendInput.collectAsState().value,
-                        error = viewModel.sendError.collectAsState().value,
-                        walletMode = viewModel.walletMode.collectAsState().value,
-                        onInputChange = { viewModel.updateSendInput(it) },
-                        onNext = { viewModel.processInput() },
-                        onScanQR = { viewModel.navigateTo(WalletPage.ScanQR) },
-                        modifier = Modifier.padding(padding)
-                    )
                     is WalletPage.ScanQR -> ScanQRContent(
                         onResult = { scanned ->
                             viewModel.updateSendInput(scanned)
@@ -445,85 +472,81 @@ fun WalletScreen(
                         },
                         modifier = Modifier.padding(padding)
                     )
-                    is WalletPage.SendAmount -> {
-                        val page = currentPage as WalletPage.SendAmount
-                        // For a CLINK offer, show the service's profile name
-                        // instead of the raw noffer string.
-                        val nofferPayee = remember(page.address) {
-                            com.darkwisp.app.nostr.Noffer.decodeOrNull(page.address)
-                                ?.let { viewModel.getProfileData(it.pubkey)?.displayString }
-                        }
-                        SendAmountContent(
-                            address = nofferPayee ?: page.address,
-                            amount = viewModel.sendAmount.collectAsState().value,
-                            error = viewModel.sendError.collectAsState().value,
-                            isLoading = viewModel.isLoading.collectAsState().value,
-                            onDigit = { viewModel.updateSendAmount(it) },
-                            onBackspace = { viewModel.sendAmountBackspace() },
-                            onConfirm = {
-                                val sats = viewModel.sendAmount.value.toLongOrNull() ?: return@SendAmountContent
-                                viewModel.resolveLightningAddress(page.address, sats)
-                            },
-                            modifier = Modifier.padding(padding)
-                        )
-                    }
-                    is WalletPage.SendConfirm -> {
-                        val page = currentPage as WalletPage.SendConfirm
-                        val feeState by viewModel.feeState.collectAsState()
-                        val walletMode by viewModel.walletMode.collectAsState()
-                        LaunchedEffect(page.invoice) {
-                            viewModel.prepareFee(page.invoice)
-                        }
-                        SendConfirmContent(
-                            invoice = page.invoice,
-                            amountSats = page.amountSats,
-                            description = page.description,
-                            feeState = feeState,
-                            networkName = when (walletMode) {
-                                WalletMode.SPARK -> "Spark"
-                                WalletMode.NWC -> "NWC"
-                                else -> "Unknown"
-                            },
-                            onPay = { viewModel.payInvoice(page.invoice) },
-                            onCancel = { viewModel.navigateBack() },
-                            modifier = Modifier.padding(padding)
-                        )
-                    }
-                    is WalletPage.Sending -> SendingContent(
-                        modifier = Modifier.padding(padding)
-                    )
+                    is WalletPage.SendInput,
+                    is WalletPage.SendAmount,
+                    is WalletPage.SendConfirm,
+                    is WalletPage.Sending,
                     is WalletPage.SendResult -> {
-                        val page = currentPage as WalletPage.SendResult
-                        SendResultContent(
-                            success = page.success,
-                            message = page.message,
-                            onDone = { viewModel.navigateHome() },
+                        // Home stays visible behind the send bottom sheet.
+                        val profileKey = viewModel.profileRefreshKey.collectAsState().value
+                        WalletHomeContent(
+                            balanceMsats = balanceMsats,
+                            walletMode = viewModel.walletMode.collectAsState().value,
+                            balanceUnit = viewModel.balanceUnit.collectAsState().value,
+                            showSettingsAlert = viewModel.walletMode.collectAsState().value == WalletMode.SPARK
+                                    && !viewModel.seedBackupAcked.collectAsState().value,
+                            seedBackupAcked = viewModel.seedBackupAcked.collectAsState().value,
+                            backupMissing = viewModel.backupMissing.collectAsState().value,
+                            onSend = {},
+                            onReceive = { viewModel.navigateTo(WalletPage.ReceiveAmount) },
+                            onTransactions = {
+                                viewModel.loadTransactions()
+                                viewModel.navigateTo(WalletPage.Transactions)
+                            },
+                            onRefresh = { viewModel.refreshBalance() },
+                            onSettings = { viewModel.navigateTo(WalletPage.Settings) },
+                            onBackupToRelay = {
+                                viewModel.resetBackupStatus()
+                                viewModel.navigateTo(WalletPage.BackupToRelay)
+                            },
+                            onViewSeed = { viewModel.showMnemonicBackup() },
+                            lightningAddress = viewModel.lightningAddress.collectAsState().value,
+                            onSetupAddress = {
+                                viewModel.resetAddressSetupState()
+                                viewModel.navigateTo(WalletPage.LightningAddressSetup)
+                            },
+                            recentTransactions = viewModel.transactions.collectAsState().value,
+                            profileLookup = remember(profileKey) { { viewModel.getProfileData(it) } },
+                            nwcNodeAlias = viewModel.nwcNodeAlias.collectAsState().value,
+                            pubkey = viewModel.keyRepo.getPubkeyHex(),
                             modifier = Modifier.padding(padding)
                         )
                     }
-                    is WalletPage.ReceiveAmount -> ReceiveAmountContent(
-                        amount = viewModel.receiveAmount.collectAsState().value,
-                        isLoading = viewModel.isLoading.collectAsState().value,
-                        lightningAddress = viewModel.lightningAddress.collectAsState().value,
-                        onAmountChange = { viewModel.setReceiveAmount(it) },
-                        onGenerate = { sats, note, expirySecs -> viewModel.generateInvoice(sats, note, expirySecs) },
-                        onShowAddressQR = { viewModel.navigateTo(WalletPage.LightningAddressQR) },
-                        modifier = Modifier.padding(padding)
-                    )
-                    is WalletPage.ReceiveInvoice -> {
-                        val page = currentPage as WalletPage.ReceiveInvoice
-                        ReceiveInvoiceContent(
-                            invoice = page.invoice,
-                            amountSats = page.amountSats,
-                            onDone = { viewModel.navigateHome() },
-                            modifier = Modifier.padding(padding)
-                        )
-                    }
+                    is WalletPage.ReceiveAmount,
+                    is WalletPage.ReceiveInvoice,
                     is WalletPage.ReceiveSuccess -> {
-                        val page = currentPage as WalletPage.ReceiveSuccess
-                        ReceiveSuccessContent(
-                            amountSats = page.amountSats,
-                            onDone = { viewModel.navigateHome() },
+                        // Home stays visible behind the receive bottom sheet.
+                        val profileKey = viewModel.profileRefreshKey.collectAsState().value
+                        WalletHomeContent(
+                            balanceMsats = balanceMsats,
+                            walletMode = viewModel.walletMode.collectAsState().value,
+                            balanceUnit = viewModel.balanceUnit.collectAsState().value,
+                            showSettingsAlert = viewModel.walletMode.collectAsState().value == WalletMode.SPARK
+                                    && !viewModel.seedBackupAcked.collectAsState().value,
+                            seedBackupAcked = viewModel.seedBackupAcked.collectAsState().value,
+                            backupMissing = viewModel.backupMissing.collectAsState().value,
+                            onSend = { viewModel.navigateTo(WalletPage.SendInput) },
+                            onReceive = {},
+                            onTransactions = {
+                                viewModel.loadTransactions()
+                                viewModel.navigateTo(WalletPage.Transactions)
+                            },
+                            onRefresh = { viewModel.refreshBalance() },
+                            onSettings = { viewModel.navigateTo(WalletPage.Settings) },
+                            onBackupToRelay = {
+                                viewModel.resetBackupStatus()
+                                viewModel.navigateTo(WalletPage.BackupToRelay)
+                            },
+                            onViewSeed = { viewModel.showMnemonicBackup() },
+                            lightningAddress = viewModel.lightningAddress.collectAsState().value,
+                            onSetupAddress = {
+                                viewModel.resetAddressSetupState()
+                                viewModel.navigateTo(WalletPage.LightningAddressSetup)
+                            },
+                            recentTransactions = viewModel.transactions.collectAsState().value,
+                            profileLookup = remember(profileKey) { { viewModel.getProfileData(it) } },
+                            nwcNodeAlias = viewModel.nwcNodeAlias.collectAsState().value,
+                            pubkey = viewModel.keyRepo.getPubkeyHex(),
                             modifier = Modifier.padding(padding)
                         )
                     }
@@ -683,6 +706,7 @@ fun WalletScreen(
                     ModalBottomSheet(
                         onDismissRequest = { viewModel.navigateBack() },
                         sheetState = txSheetState,
+                        dragHandle = { WalletSheetDragHandle() }
                     ) {
                         TransactionHistoryContent(
                             transactions = viewModel.transactions.collectAsState().value,
@@ -695,6 +719,108 @@ fun WalletScreen(
                             profileRefreshKey = txProfileKey,
                             pubkey = viewModel.keyRepo.getPubkeyHex(),
                         )
+                    }
+                }
+
+                // Send flow full-screen bottom sheet — swipe down to dismiss back to Home.
+                // Content swaps internally as the user moves through SendInput →
+                // SendAmount → SendConfirm → Sending → SendResult so the sheet
+                // itself never closes and reopens mid-flow.
+                if (isSendFlow) {
+                    val sendSheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
+                    ModalBottomSheet(
+                        onDismissRequest = { viewModel.navigateHome() },
+                        sheetState = sendSheetState,
+                        dragHandle = { WalletSheetDragHandle() }
+                    ) {
+                        when (val page = currentPage) {
+                            is WalletPage.SendInput -> SendInputContent(
+                                input = viewModel.sendInput.collectAsState().value,
+                                error = viewModel.sendError.collectAsState().value,
+                                walletMode = viewModel.walletMode.collectAsState().value,
+                                onInputChange = { viewModel.updateSendInput(it) },
+                                onNext = { viewModel.processInput() },
+                                onScanQR = { viewModel.navigateTo(WalletPage.ScanQR) }
+                            )
+                            is WalletPage.SendAmount -> {
+                                // For a CLINK offer, show the service's profile name
+                                // instead of the raw noffer string.
+                                val nofferPayee = remember(page.address) {
+                                    com.darkwisp.app.nostr.Noffer.decodeOrNull(page.address)
+                                        ?.let { viewModel.getProfileData(it.pubkey)?.displayString }
+                                }
+                                SendAmountContent(
+                                    address = nofferPayee ?: page.address,
+                                    amount = viewModel.sendAmount.collectAsState().value,
+                                    error = viewModel.sendError.collectAsState().value,
+                                    isLoading = viewModel.isLoading.collectAsState().value,
+                                    onDigit = { viewModel.updateSendAmount(it) },
+                                    onBackspace = { viewModel.sendAmountBackspace() },
+                                    onConfirm = {
+                                        val sats = viewModel.sendAmount.value.toLongOrNull() ?: return@SendAmountContent
+                                        viewModel.resolveLightningAddress(page.address, sats)
+                                    }
+                                )
+                            }
+                            is WalletPage.SendConfirm -> {
+                                val feeState by viewModel.feeState.collectAsState()
+                                val walletMode by viewModel.walletMode.collectAsState()
+                                LaunchedEffect(page.invoice) {
+                                    viewModel.prepareFee(page.invoice)
+                                }
+                                SendConfirmContent(
+                                    invoice = page.invoice,
+                                    amountSats = page.amountSats,
+                                    description = page.description,
+                                    feeState = feeState,
+                                    networkName = when (walletMode) {
+                                        WalletMode.SPARK -> "Spark"
+                                        WalletMode.NWC -> "NWC"
+                                        else -> "Unknown"
+                                    },
+                                    onPay = { viewModel.payInvoice(page.invoice) },
+                                    onCancel = { viewModel.navigateBack() }
+                                )
+                            }
+                            is WalletPage.Sending -> SendingContent()
+                            is WalletPage.SendResult -> SendResultContent(
+                                success = page.success,
+                                message = page.message,
+                                onDone = { viewModel.navigateHome() }
+                            )
+                            else -> {}
+                        }
+                    }
+                }
+
+                // Receive flow full-screen bottom sheet — swipe down to dismiss back to Home.
+                if (isReceiveFlow) {
+                    val receiveSheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
+                    ModalBottomSheet(
+                        onDismissRequest = { viewModel.navigateHome() },
+                        sheetState = receiveSheetState,
+                        dragHandle = { WalletSheetDragHandle() }
+                    ) {
+                        when (val page = currentPage) {
+                            is WalletPage.ReceiveAmount -> ReceiveAmountContent(
+                                amount = viewModel.receiveAmount.collectAsState().value,
+                                isLoading = viewModel.isLoading.collectAsState().value,
+                                lightningAddress = viewModel.lightningAddress.collectAsState().value,
+                                onAmountChange = { viewModel.setReceiveAmount(it) },
+                                onGenerate = { sats, note, expirySecs -> viewModel.generateInvoice(sats, note, expirySecs) },
+                                onShowAddressQR = { viewModel.navigateTo(WalletPage.LightningAddressQR) }
+                            )
+                            is WalletPage.ReceiveInvoice -> ReceiveInvoiceContent(
+                                invoice = page.invoice,
+                                amountSats = page.amountSats,
+                                onDone = { viewModel.navigateHome() }
+                            )
+                            is WalletPage.ReceiveSuccess -> ReceiveSuccessContent(
+                                amountSats = page.amountSats,
+                                onDone = { viewModel.navigateHome() }
+                            )
+                            else -> {}
+                        }
                     }
                 }
             }

--- a/app/src/main/kotlin/com/darkwisp/app/ui/screen/WalletScreen.kt
+++ b/app/src/main/kotlin/com/darkwisp/app/ui/screen/WalletScreen.kt
@@ -2599,16 +2599,6 @@ private fun ReceiveAmountContent(
             // Lightning address — shown below invoice form as "or receive via" row
             if (!lightningAddress.isNullOrBlank()) {
                 Spacer(Modifier.height(24.dp))
-                HorizontalDivider(color = MaterialTheme.colorScheme.outline.copy(alpha = 0.3f))
-                Spacer(Modifier.height(16.dp))
-                Text(
-                    stringResource(R.string.wallet_receive_via_address),
-                    style = MaterialTheme.typography.labelMedium,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant,
-                    modifier = Modifier.fillMaxWidth(),
-                    textAlign = TextAlign.Center
-                )
-                Spacer(Modifier.height(12.dp))
                 LightningAddressReceiveRow(address = lightningAddress, onShowQR = onShowAddressQR)
             }
         }

--- a/app/src/main/kotlin/com/darkwisp/app/viewmodel/WalletViewModel.kt
+++ b/app/src/main/kotlin/com/darkwisp/app/viewmodel/WalletViewModel.kt
@@ -30,7 +30,6 @@ import com.darkwisp.app.repo.NwcRepository
 import com.darkwisp.app.repo.SparkRepository
 import com.darkwisp.app.repo.WalletMode
 import com.darkwisp.app.repo.WalletModeRepository
-import com.darkwisp.app.repo.OnchainFeeQuote
 import com.darkwisp.app.repo.WalletProvider
 import android.util.Log
 import com.darkwisp.app.repo.WalletTransaction
@@ -126,14 +125,6 @@ sealed class WalletPage {
     data class SendResult(val success: Boolean, val message: String) : WalletPage()
     object ReceiveAmount : WalletPage()
     data class ReceiveInvoice(val invoice: String, val amountSats: Long) : WalletPage()
-    data class OnchainSendAmount(val address: String) : WalletPage()
-    data class OnchainSendConfirm(
-        val address: String,
-        val amountSats: Long,
-        val feeQuote: OnchainFeeQuote,
-        val prepareData: Any
-    ) : WalletPage()
-    data class OnchainSendResult(val success: Boolean, val paymentId: String?, val message: String) : WalletPage()
     data class ReceiveSuccess(val amountSats: Long) : WalletPage()
     object Transactions : WalletPage()
     object Settings : WalletPage()
@@ -204,25 +195,6 @@ class WalletViewModel(
     // Receive flow
     private val _receiveAmount = MutableStateFlow("")
     val receiveAmount: StateFlow<String> = _receiveAmount
-
-    // On-chain deposit address (Spark only)
-    private val _depositAddress = MutableStateFlow<String?>(null)
-    val depositAddress: StateFlow<String?> = _depositAddress
-
-    private val _depositAddressLoading = MutableStateFlow(false)
-    val depositAddressLoading: StateFlow<Boolean> = _depositAddressLoading
-
-    private val _depositAddressError = MutableStateFlow<String?>(null)
-    val depositAddressError: StateFlow<String?> = _depositAddressError
-
-    // On-chain send (Spark only)
-    private val _onchainFeeQuote = MutableStateFlow<OnchainFeeQuote?>(null)
-    val onchainFeeQuote: StateFlow<OnchainFeeQuote?> = _onchainFeeQuote
-
-    private var _onchainPrepareData: Any? = null
-
-    private val _onchainSendLoading = MutableStateFlow(false)
-    val onchainSendLoading: StateFlow<Boolean> = _onchainSendLoading
 
     // Transactions
     private val _transactions = MutableStateFlow<List<WalletTransaction>>(emptyList())
@@ -346,11 +318,6 @@ class WalletViewModel(
         // would otherwise stay at the prior wallet's acknowledged value
         // until the next refreshState() call.
         _seedBackupAcked.value = false
-        _depositAddress.value = null
-        _depositAddressError.value = null
-        _depositAddressLoading.value = false
-        _onchainFeeQuote.value = null
-        _onchainPrepareData = null
     }
 
     /**
@@ -577,8 +544,6 @@ class WalletViewModel(
         _deleteConfirmText.value = ""
         _lightningAddressError.value = null
         _addressAvailable.value = null
-        _onchainFeeQuote.value = null
-        _onchainPrepareData = null
     }
 
     val isOnHome: Boolean get() = pageStack.size <= 1
@@ -1301,14 +1266,6 @@ class WalletViewModel(
         }
     }
 
-    private fun isBtcAddress(s: String): Boolean {
-        val lower = s.lowercase()
-        if (lower.startsWith("bc1") && s.length >= 14) return true
-        if ((s.startsWith("1") || s.startsWith("3")) && s.length in 26..35 &&
-            s.all { it.isLetterOrDigit() && it != '0' && it != 'O' && it != 'I' && it != 'l' }) return true
-        return false
-    }
-
     fun processInput(input: String = _sendInput.value) {
         val trimmed = input.trim()
             .removePrefix("lightning:").removePrefix("LIGHTNING:")
@@ -1333,10 +1290,6 @@ class WalletViewModel(
                     navigateTo(WalletPage.SendAmount(noffer.raw))
                 }
             }
-            _walletMode.value == WalletMode.SPARK && isBtcAddress(trimmed) -> {
-                clearOnchainQuote()
-                navigateTo(WalletPage.OnchainSendAmount(trimmed))
-            }
             trimmed.lowercase().startsWith("lnbc") -> {
                 val decoded = Bolt11.decode(trimmed)
                 if (decoded == null) {
@@ -1359,10 +1312,7 @@ class WalletViewModel(
                 navigateTo(WalletPage.SendAmount(trimmed))
             }
             else -> {
-                _sendError.value = if (_walletMode.value == WalletMode.SPARK)
-                    "Enter a lightning address, BOLT11 invoice, CLINK offer, or Bitcoin address"
-                else
-                    "Enter a lightning address (user@domain), BOLT11 invoice, or CLINK offer"
+                _sendError.value = "Enter a lightning address (user@domain), BOLT11 invoice, or CLINK offer"
             }
         }
     }
@@ -1549,74 +1499,6 @@ class WalletViewModel(
                 },
                 onFailure = { e ->
                     _sendError.value = e.message ?: "Failed to create invoice"
-                }
-            )
-            _isLoading.value = false
-        }
-    }
-
-    // --- On-chain receive (Spark only) ---
-
-    fun loadDepositAddress(force: Boolean = false) {
-        if (!force && _depositAddress.value != null) return
-        _depositAddressLoading.value = true
-        _depositAddressError.value = null
-        viewModelScope.launch {
-            sparkRepo.getDepositAddress().fold(
-                onSuccess = { address -> _depositAddress.value = address },
-                onFailure = { e -> _depositAddressError.value = e.message ?: "Failed to load address" }
-            )
-            _depositAddressLoading.value = false
-        }
-    }
-
-    // --- On-chain send (Spark only) ---
-
-    fun clearOnchainQuote() {
-        _onchainFeeQuote.value = null
-        _onchainPrepareData = null
-    }
-
-    fun prepareOnchainSend(address: String, amountSats: Long) {
-        clearOnchainQuote()
-        _onchainSendLoading.value = true
-        _sendError.value = null
-        viewModelScope.launch {
-            sparkRepo.prepareOnchainSend(address, amountSats).fold(
-                onSuccess = { (quote, prepareData) ->
-                    _onchainFeeQuote.value = quote
-                    _onchainPrepareData = prepareData
-                },
-                onFailure = { e -> _sendError.value = e.message ?: "Failed to estimate fee" }
-            )
-            _onchainSendLoading.value = false
-        }
-    }
-
-    fun continueToOnchainConfirm(address: String, amountSats: Long) {
-        val quote = _onchainFeeQuote.value ?: return
-        val prepareData = _onchainPrepareData ?: return
-        navigateTo(WalletPage.OnchainSendConfirm(address, amountSats, quote, prepareData))
-    }
-
-    fun sendOnchain(prepareData: Any) {
-        if (_isLoading.value) return
-        _isLoading.value = true
-        viewModelScope.launch {
-            sparkRepo.sendOnchain(prepareData).fold(
-                onSuccess = { paymentId ->
-                    pageStack.removeAt(pageStack.lastIndex)
-                    val resultPage = WalletPage.OnchainSendResult(true, paymentId, "Bitcoin sent!")
-                    pageStack.add(resultPage)
-                    _currentPage.value = resultPage
-                    clearOnchainQuote()
-                    refreshBalance()
-                },
-                onFailure = { e ->
-                    pageStack.removeAt(pageStack.lastIndex)
-                    val resultPage = WalletPage.OnchainSendResult(false, null, e.message ?: "Send failed")
-                    pageStack.add(resultPage)
-                    _currentPage.value = resultPage
                 }
             )
             _isLoading.value = false

--- a/app/src/main/kotlin/com/darkwisp/app/viewmodel/WalletViewModel.kt
+++ b/app/src/main/kotlin/com/darkwisp/app/viewmodel/WalletViewModel.kt
@@ -30,6 +30,7 @@ import com.darkwisp.app.repo.NwcRepository
 import com.darkwisp.app.repo.SparkRepository
 import com.darkwisp.app.repo.WalletMode
 import com.darkwisp.app.repo.WalletModeRepository
+import com.darkwisp.app.repo.OnchainFeeQuote
 import com.darkwisp.app.repo.WalletProvider
 import android.util.Log
 import com.darkwisp.app.repo.WalletTransaction
@@ -125,6 +126,14 @@ sealed class WalletPage {
     data class SendResult(val success: Boolean, val message: String) : WalletPage()
     object ReceiveAmount : WalletPage()
     data class ReceiveInvoice(val invoice: String, val amountSats: Long) : WalletPage()
+    data class OnchainSendAmount(val address: String) : WalletPage()
+    data class OnchainSendConfirm(
+        val address: String,
+        val amountSats: Long,
+        val feeQuote: OnchainFeeQuote,
+        val prepareData: Any
+    ) : WalletPage()
+    data class OnchainSendResult(val success: Boolean, val paymentId: String?, val message: String) : WalletPage()
     data class ReceiveSuccess(val amountSats: Long) : WalletPage()
     object Transactions : WalletPage()
     object Settings : WalletPage()
@@ -195,6 +204,25 @@ class WalletViewModel(
     // Receive flow
     private val _receiveAmount = MutableStateFlow("")
     val receiveAmount: StateFlow<String> = _receiveAmount
+
+    // On-chain deposit address (Spark only)
+    private val _depositAddress = MutableStateFlow<String?>(null)
+    val depositAddress: StateFlow<String?> = _depositAddress
+
+    private val _depositAddressLoading = MutableStateFlow(false)
+    val depositAddressLoading: StateFlow<Boolean> = _depositAddressLoading
+
+    private val _depositAddressError = MutableStateFlow<String?>(null)
+    val depositAddressError: StateFlow<String?> = _depositAddressError
+
+    // On-chain send (Spark only)
+    private val _onchainFeeQuote = MutableStateFlow<OnchainFeeQuote?>(null)
+    val onchainFeeQuote: StateFlow<OnchainFeeQuote?> = _onchainFeeQuote
+
+    private var _onchainPrepareData: Any? = null
+
+    private val _onchainSendLoading = MutableStateFlow(false)
+    val onchainSendLoading: StateFlow<Boolean> = _onchainSendLoading
 
     // Transactions
     private val _transactions = MutableStateFlow<List<WalletTransaction>>(emptyList())
@@ -318,6 +346,11 @@ class WalletViewModel(
         // would otherwise stay at the prior wallet's acknowledged value
         // until the next refreshState() call.
         _seedBackupAcked.value = false
+        _depositAddress.value = null
+        _depositAddressError.value = null
+        _depositAddressLoading.value = false
+        _onchainFeeQuote.value = null
+        _onchainPrepareData = null
     }
 
     /**
@@ -544,6 +577,8 @@ class WalletViewModel(
         _deleteConfirmText.value = ""
         _lightningAddressError.value = null
         _addressAvailable.value = null
+        _onchainFeeQuote.value = null
+        _onchainPrepareData = null
     }
 
     val isOnHome: Boolean get() = pageStack.size <= 1
@@ -1248,6 +1283,10 @@ class WalletViewModel(
         _sendError.value = null
     }
 
+    fun setSendAmount(value: String) {
+        _sendAmount.value = value
+    }
+
     fun updateSendAmount(digit: Char) {
         val current = _sendAmount.value
         if (current.length < 10) {
@@ -1262,8 +1301,18 @@ class WalletViewModel(
         }
     }
 
+    private fun isBtcAddress(s: String): Boolean {
+        val lower = s.lowercase()
+        if (lower.startsWith("bc1") && s.length >= 14) return true
+        if ((s.startsWith("1") || s.startsWith("3")) && s.length in 26..35 &&
+            s.all { it.isLetterOrDigit() && it != '0' && it != 'O' && it != 'I' && it != 'l' }) return true
+        return false
+    }
+
     fun processInput(input: String = _sendInput.value) {
-        val trimmed = input.trim().removePrefix("lightning:")
+        val trimmed = input.trim()
+            .removePrefix("lightning:").removePrefix("LIGHTNING:")
+            .let { it.removePrefix("bitcoin:").removePrefix("BITCOIN:") }
         _sendError.value = null
 
         when {
@@ -1283,6 +1332,10 @@ class WalletViewModel(
                     _sendAmount.value = ""
                     navigateTo(WalletPage.SendAmount(noffer.raw))
                 }
+            }
+            _walletMode.value == WalletMode.SPARK && isBtcAddress(trimmed) -> {
+                clearOnchainQuote()
+                navigateTo(WalletPage.OnchainSendAmount(trimmed))
             }
             trimmed.lowercase().startsWith("lnbc") -> {
                 val decoded = Bolt11.decode(trimmed)
@@ -1306,7 +1359,10 @@ class WalletViewModel(
                 navigateTo(WalletPage.SendAmount(trimmed))
             }
             else -> {
-                _sendError.value = "Enter a lightning address (user@domain), BOLT11 invoice, or CLINK offer"
+                _sendError.value = if (_walletMode.value == WalletMode.SPARK)
+                    "Enter a lightning address, BOLT11 invoice, CLINK offer, or Bitcoin address"
+                else
+                    "Enter a lightning address (user@domain), BOLT11 invoice, or CLINK offer"
             }
         }
     }
@@ -1482,10 +1538,10 @@ class WalletViewModel(
         _receiveAmount.value = value
     }
 
-    fun generateInvoice(amountSats: Long, description: String = "") {
+    fun generateInvoice(amountSats: Long, description: String = "", expirySecs: Int = 3600) {
         _isLoading.value = true
         viewModelScope.launch {
-            val result = activeProvider.makeInvoice(amountSats * 1000, description)
+            val result = activeProvider.makeInvoice(amountSats * 1000, description, expirySecs)
             result.fold(
                 onSuccess = { invoice ->
                     navigateTo(WalletPage.ReceiveInvoice(invoice, amountSats))
@@ -1493,6 +1549,74 @@ class WalletViewModel(
                 },
                 onFailure = { e ->
                     _sendError.value = e.message ?: "Failed to create invoice"
+                }
+            )
+            _isLoading.value = false
+        }
+    }
+
+    // --- On-chain receive (Spark only) ---
+
+    fun loadDepositAddress(force: Boolean = false) {
+        if (!force && _depositAddress.value != null) return
+        _depositAddressLoading.value = true
+        _depositAddressError.value = null
+        viewModelScope.launch {
+            sparkRepo.getDepositAddress().fold(
+                onSuccess = { address -> _depositAddress.value = address },
+                onFailure = { e -> _depositAddressError.value = e.message ?: "Failed to load address" }
+            )
+            _depositAddressLoading.value = false
+        }
+    }
+
+    // --- On-chain send (Spark only) ---
+
+    fun clearOnchainQuote() {
+        _onchainFeeQuote.value = null
+        _onchainPrepareData = null
+    }
+
+    fun prepareOnchainSend(address: String, amountSats: Long) {
+        clearOnchainQuote()
+        _onchainSendLoading.value = true
+        _sendError.value = null
+        viewModelScope.launch {
+            sparkRepo.prepareOnchainSend(address, amountSats).fold(
+                onSuccess = { (quote, prepareData) ->
+                    _onchainFeeQuote.value = quote
+                    _onchainPrepareData = prepareData
+                },
+                onFailure = { e -> _sendError.value = e.message ?: "Failed to estimate fee" }
+            )
+            _onchainSendLoading.value = false
+        }
+    }
+
+    fun continueToOnchainConfirm(address: String, amountSats: Long) {
+        val quote = _onchainFeeQuote.value ?: return
+        val prepareData = _onchainPrepareData ?: return
+        navigateTo(WalletPage.OnchainSendConfirm(address, amountSats, quote, prepareData))
+    }
+
+    fun sendOnchain(prepareData: Any) {
+        if (_isLoading.value) return
+        _isLoading.value = true
+        viewModelScope.launch {
+            sparkRepo.sendOnchain(prepareData).fold(
+                onSuccess = { paymentId ->
+                    pageStack.removeAt(pageStack.lastIndex)
+                    val resultPage = WalletPage.OnchainSendResult(true, paymentId, "Bitcoin sent!")
+                    pageStack.add(resultPage)
+                    _currentPage.value = resultPage
+                    clearOnchainQuote()
+                    refreshBalance()
+                },
+                onFailure = { e ->
+                    pageStack.removeAt(pageStack.lastIndex)
+                    val resultPage = WalletPage.OnchainSendResult(false, null, e.message ?: "Send failed")
+                    pageStack.add(resultPage)
+                    _currentPage.value = resultPage
                 }
             )
             _isLoading.value = false

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -776,6 +776,46 @@
     <string name="wallet_receive_note_label">NOTE (OPTIONAL)</string>
     <string name="wallet_receive_note_placeholder">For coffee, etc.</string>
     <string name="wallet_receive_create_invoice">Create invoice</string>
+    <!-- Updated tab labels for Spark on-chain receive -->
+    <string name="wallet_receive_lightning_tab">Lightning</string>
+    <string name="wallet_receive_bitcoin_tab">Bitcoin</string>
+    <!-- Invoice expiry selector -->
+    <string name="wallet_receive_expires_label">EXPIRES</string>
+    <string name="wallet_receive_expires_1h">1 hour</string>
+    <string name="wallet_receive_expires_24h">24 hours</string>
+    <string name="wallet_receive_expires_custom">Custom</string>
+    <string name="wallet_receive_expires_hours">Hours until expiry</string>
+    <!-- Lightning address receive row -->
+    <string name="wallet_receive_via_address">or receive to your Lightning address</string>
+    <string name="wallet_copy_address">Copy address</string>
+    <string name="wallet_share_address">Share address</string>
+    <string name="wallet_share">Share</string>
+    <!-- Bitcoin on-chain deposit address -->
+    <string name="cd_bitcoin_address_qr">Bitcoin address QR code</string>
+    <!-- On-chain send flow -->
+    <string name="wallet_onchain_send_title">Send Payment</string>
+    <string name="wallet_onchain_bitcoin_detected">Bitcoin address detected – on-chain payment</string>
+    <string name="wallet_onchain_amount_sats">Amount (sats)</string>
+    <string name="wallet_onchain_use_all" formatted="false">Use All (%,d sats)</string>
+    <string name="wallet_onchain_fetching_fee">Estimating fee…</string>
+    <string name="wallet_onchain_get_fee_quote">Get Fee Quote</string>
+    <string name="wallet_onchain_amount">Amount</string>
+    <string name="wallet_onchain_fee">Network Fee</string>
+    <string name="wallet_onchain_total">Total</string>
+    <string name="wallet_onchain_continue">Continue</string>
+    <string name="wallet_onchain_plus_fee" formatted="false">+ %,d sats fee</string>
+    <string name="wallet_onchain_sending_to">Sending to:</string>
+    <string name="wallet_onchain_irreversible_warning">Bitcoin transactions cannot be reversed. Please verify the address is correct.</string>
+    <string name="wallet_onchain_send_confirm">Confirm Send</string>
+    <string name="wallet_onchain_payment_sent">Sent</string>
+    <string name="wallet_onchain_payment_failed">Send Failed</string>
+    <string name="wallet_onchain_view_mempool">View on mempool.space</string>
+    <!-- Spark send placeholder (accepts Lightning + Bitcoin addresses) -->
+    <string name="placeholder_send_spark">Lightning invoice or Bitcoin address</string>
+    <!-- Generic actions -->
+    <string name="retry">Retry</string>
+    <string name="cancel">Cancel</string>
+    <string name="done">Done</string>
     <string name="wallet_backup_missing_title">Wallet backup not found</string>
     <string name="wallet_backup_missing_body">Your wallet recovery phrase is not backed up to any relay. If you lose this device, you could lose your funds.</string>
     <string name="wallet_backup_now">Backup Now</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -812,6 +812,7 @@
     <string name="wallet_onchain_view_mempool">View on mempool.space</string>
     <!-- Spark send placeholder (accepts Lightning + Bitcoin addresses) -->
     <string name="placeholder_send_spark">Lightning invoice or Bitcoin address</string>
+    <string name="wallet_send_input_hint_onchain">Lightning or Bitcoin address, invoice, or CLINK offer</string>
     <!-- Generic actions -->
     <string name="retry">Retry</string>
     <string name="cancel">Cancel</string>
@@ -901,6 +902,8 @@
     <string name="section_invite_codes">Invite codes</string>
     <string name="action_generate_invite">Generate invite code</string>
     <string name="label_latest_invite_code">Latest invite code</string>
+    <string name="action_copy">Copy</string>
+    <string name="wallet_tx_pending">Pending</string>
     <string name="action_copy_code">Copy code</string>
     <string name="action_copy_invite_link">Copy invite link</string>
     <string name="title_assign_role">Assign role</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -776,9 +776,6 @@
     <string name="wallet_receive_note_label">NOTE (OPTIONAL)</string>
     <string name="wallet_receive_note_placeholder">For coffee, etc.</string>
     <string name="wallet_receive_create_invoice">Create invoice</string>
-    <!-- Updated tab labels for Spark on-chain receive -->
-    <string name="wallet_receive_lightning_tab">Lightning</string>
-    <string name="wallet_receive_bitcoin_tab">Bitcoin</string>
     <!-- Invoice expiry selector -->
     <string name="wallet_receive_expires_label">EXPIRES</string>
     <string name="wallet_receive_expires_1h">1 hour</string>
@@ -790,29 +787,7 @@
     <string name="wallet_copy_address">Copy address</string>
     <string name="wallet_share_address">Share address</string>
     <string name="wallet_share">Share</string>
-    <!-- Bitcoin on-chain deposit address -->
-    <string name="cd_bitcoin_address_qr">Bitcoin address QR code</string>
-    <!-- On-chain send flow -->
-    <string name="wallet_onchain_send_title">Send Payment</string>
-    <string name="wallet_onchain_bitcoin_detected">Bitcoin address detected – on-chain payment</string>
-    <string name="wallet_onchain_amount_sats">Amount (sats)</string>
-    <string name="wallet_onchain_use_all" formatted="false">Use All (%,d sats)</string>
-    <string name="wallet_onchain_fetching_fee">Estimating fee…</string>
-    <string name="wallet_onchain_get_fee_quote">Get Fee Quote</string>
-    <string name="wallet_onchain_amount">Amount</string>
-    <string name="wallet_onchain_fee">Network Fee</string>
-    <string name="wallet_onchain_total">Total</string>
-    <string name="wallet_onchain_continue">Continue</string>
-    <string name="wallet_onchain_plus_fee" formatted="false">+ %,d sats fee</string>
-    <string name="wallet_onchain_sending_to">Sending to:</string>
-    <string name="wallet_onchain_irreversible_warning">Bitcoin transactions cannot be reversed. Please verify the address is correct.</string>
-    <string name="wallet_onchain_send_confirm">Confirm Send</string>
-    <string name="wallet_onchain_payment_sent">Sent</string>
-    <string name="wallet_onchain_payment_failed">Send Failed</string>
-    <string name="wallet_onchain_view_mempool">View on mempool.space</string>
-    <!-- Spark send placeholder (accepts Lightning + Bitcoin addresses) -->
-    <string name="placeholder_send_spark">Lightning invoice or Bitcoin address</string>
-    <string name="wallet_send_input_hint_onchain">Lightning or Bitcoin address, invoice, or CLINK offer</string>
+    <string name="wallet_send_input_hint_onchain">Lightning address, invoice, or CLINK offer</string>
     <!-- Generic actions -->
     <string name="retry">Retry</string>
     <string name="cancel">Cancel</string>


### PR DESCRIPTION
## Summary
- Redesigned Receive screen (amount/note/expiry, lightning address row) and iOS-style send input with lightning address QR
- Transaction history, Send, and Receive each present as full-page bottom sheets over the Home dashboard (swipe down to dismiss), matching iOS
- Expandable transaction detail drawer in history (status, type, amount, network fee, date, note, payment hash/txid with copy)
- On-chain Spark transactions (deposits/withdrawals made from another app on the same seed) are correctly detected and displayed — type, txid, mempool.space link — without adding in-app on-chain send/receive
- Paper-airplane send icon, lightning address QR polish, pending-payment indicator

This supersedes #47, which included in-app on-chain send/receive UI that we've decided not to ship. That UI has been removed; on-chain transaction detection and display in history remains so deposits/withdrawals made via another wallet app on the same Spark seed still show up correctly.

## Test plan
- [x] Send a lightning invoice/address payment via the new Send bottom sheet
- [x] Receive via the new Receive bottom sheet (amount entry, invoice QR, lightning address)
- [x] Open transaction history sheet, expand a transaction to see the detail drawer
- [x] Verify on-chain transactions received via another Spark app show "On-chain" type + mempool.space link
- [x] Confirm sheet grab handles clear the status bar/camera cutout on all three sheets
- [x] Build and install on device