### PR TITLE
fix(content): parse hashtags with non-ASCII Unicode letters

### DIFF
--- a/app/src/main/kotlin/com/darkwisp/app/ui/component/RichContent.kt
+++ b/app/src/main/kotlin/com/darkwisp/app/ui/component/RichContent.kt
@@ -276,7 +276,7 @@ private fun isBlossomUrl(url: String): Boolean {
     }
 }
 
-private val combinedRegex = Regex("""nostr:(note1|nevent1|npub1|nprofile1|naddr1)[a-z0-9]+|(?<!\w)(npub1[a-z0-9]{58})(?!\w|\.[a-zA-Z])|(?:https?|wss?)://\S+|(?<!\w)((?:[a-zA-Z0-9](?:[a-zA-Z0-9-]*[a-zA-Z0-9])?\.)+(?:com|net|org|io|dev|app|pro|ai|co|me|info|xyz|cc|tv|to|gg|sh|im|is|it|rs|ly|site|online|store|tech|cloud|social|world|earth|space|lol|wtf|family|life|art|design|blog|news|live|video|media|chat|games|money|finance|agency|studio|build|run|codes|systems|network|zone|pub|blue|limo|fyi|wiki|page|link|click|exchange|markets|fun|club|today)(?:/\S*)?)(?!\w)|(?<!\w)#([a-zA-Z0-9_][a-zA-Z0-9_-]*)|(?<!\w)((?:note1|nevent1|nprofile1|naddr1)[a-z0-9]{10,})(?!\w)""", RegexOption.IGNORE_CASE)
+private val combinedRegex = Regex("""nostr:(note1|nevent1|npub1|nprofile1|naddr1)[a-z0-9]+|(?<!\w)(npub1[a-z0-9]{58})(?!\w|\.[a-zA-Z])|(?:https?|wss?)://\S+|(?<!\w)((?:[a-zA-Z0-9](?:[a-zA-Z0-9-]*[a-zA-Z0-9])?\.)+(?:com|net|org|io|dev|app|pro|ai|co|me|info|xyz|cc|tv|to|gg|sh|im|is|it|rs|ly|site|online|store|tech|cloud|social|world|earth|space|lol|wtf|family|life|art|design|blog|news|live|video|media|chat|games|money|finance|agency|studio|build|run|codes|systems|network|zone|pub|blue|limo|fyi|wiki|page|link|click|exchange|markets|fun|club|today)(?:/\S*)?)(?!\w)|(?<!\w)#([\p{L}0-9_][\p{L}\p{M}0-9_-]*)|(?<!\w)((?:note1|nevent1|nprofile1|naddr1)[a-z0-9]{10,})(?!\w)""", RegexOption.IGNORE_CASE)
 
 private val emojiShortcodeRegex = Regex(""":([a-zA-Z0-9_-]+):""")
 

--- a/app/src/main/kotlin/com/darkwisp/app/viewmodel/ComposeViewModel.kt
+++ b/app/src/main/kotlin/com/darkwisp/app/viewmodel/ComposeViewModel.kt
@@ -55,7 +55,7 @@ import kotlinx.coroutines.withTimeoutOrNull
 private val NOSTR_URI_REGEX = Regex("nostr:(npub1[a-z0-9]{58}|nprofile1[a-z0-9]+|note1[a-z0-9]{58}|nevent1[a-z0-9]+)")
 // Matches bare bech32 IDs not already preceded by "nostr:" or embedded in a URL
 private val BARE_BECH32_REGEX = Regex("(?<!nostr:)(?<![a-z0-9/.:#])((note1|nevent1|npub1|nprofile1|naddr1)[a-z0-9]{10,})")
-private val HASHTAG_REGEX = Regex("(?:^|(?<=\\s))#([a-zA-Z0-9_]+)")
+private val HASHTAG_REGEX = Regex("(?:^|(?<=\\s))#([\\p{L}\\p{M}0-9_]+)")
 
 /** Tracks an inserted @mention as a range in the compose text, mapped to its pubkey. */
 data class Mention(val start: Int, val end: Int, val pubkey: String)


### PR DESCRIPTION
## Summary

Hashtags containing non-ASCII Unicode letters (umlauts, accents, non-Latin scripts) were truncated at the first non-ASCII character — the rest of the tag rendered as plain, non-tappable text.

- `#Kreuzworträtsel` → `#Kreuzwortr` + `ätsel` (plain)
- `#Weltbürger` → `#Weltb` + `ürger` (plain)

## Cause

The hashtag character class was ASCII-only:

```
#([a-zA-Z0-9_][a-zA-Z0-9_-]*)
```

`[a-zA-Z0-9_-]` excludes Unicode letters, so the match stops at the first non-ASCII codepoint.

## Fix

Two one-line regex changes:

- **`RichContent.kt` `combinedRegex`** (render/highlight path): `#([a-zA-Z0-9_][a-zA-Z0-9_-]*)` → `#([\p{L}0-9_][\p{L}\p{M}0-9_-]*)`
- **`ComposeViewModel.kt` `HASHTAG_REGEX`** (write path — generates `t` tags): `#([a-zA-Z0-9_]+)` → `#([\p{L}\p{M}0-9_]+)`

Using the Unicode letter (`\p{L}`) and combining-mark (`\p{M}`) property classes parses the full tag as one token, and ensures composed notes tag non-ASCII hashtags correctly (not just render them).

## Testing

Verified the German hashtags render as single fully-tappable tags, and typing `#Weltbürger` in the composer highlights and tags the whole word. Regression-checked plain ASCII tags and hyphenated tags (`#tag-with-dash`) — unchanged.