### PR TITLE
feat(drawer): account switcher as a modal sheet + reordering

### DIFF
--- a/app/src/main/kotlin/com/darkwisp/app/Navigation.kt
+++ b/app/src/main/kotlin/com/darkwisp/app/Navigation.kt
@@ -876,6 +876,7 @@ fun WispNavHost(
                 accounts = accounts,
                 onSwitchAccount = onSwitchAccount,
                 onAddAccount = onAddAccount,
+                onMoveAccount = { pubkeyHex, offset -> authViewModel.moveAccount(pubkeyHex, offset) },
                 hasEmbeddedWallet = walletViewModel.walletMode.collectAsState().value == com.darkwisp.app.repo.WalletMode.SPARK,
                 onLogout = {
                     feedViewModel.clearSigner()

--- a/app/src/main/kotlin/com/darkwisp/app/repo/EventRepository.kt
+++ b/app/src/main/kotlin/com/darkwisp/app/repo/EventRepository.kt
@@ -358,6 +358,7 @@ class EventRepository(val profileRepo: ProfileRepository? = null, val muteRepo: 
                 if (updated != null) {
                     profileDirty = true
                     markVersionDirty()
+                    updateAccountRegistryIfKnownAccount(event.pubkey, updated)
                 }
             }
             1 -> {
@@ -771,6 +772,7 @@ class EventRepository(val profileRepo: ProfileRepository? = null, val muteRepo: 
             if (updated != null) {
                 profileDirty = true
                 markVersionDirty()
+                updateAccountRegistryIfKnownAccount(event.pubkey, updated)
             }
         }
         // NIP-38: process user status in cacheEvent path too (addEvent dedup may skip it)
@@ -876,7 +878,8 @@ class EventRepository(val profileRepo: ProfileRepository? = null, val muteRepo: 
             if (!seenEventIds.add(event.id)) continue
             eventCache[event.id] = event
             if (event.kind == 0) {
-                profileRepo?.updateFromEvent(event)
+                val updated = profileRepo?.updateFromEvent(event)
+                if (updated != null) updateAccountRegistryIfKnownAccount(event.pubkey, updated)
             }
         }
     }
@@ -886,6 +889,21 @@ class EventRepository(val profileRepo: ProfileRepository? = null, val muteRepo: 
     fun bumpEventCacheVersion() { _eventCacheVersion.value++ }
 
     fun getProfileData(pubkey: String): ProfileData? = profileRepo?.get(pubkey)
+
+    /**
+     * Keep the drawer's account switcher in sync with the newest kind 0 for
+     * every signed-in account, not just the active one. Previously only a
+     * one-shot check during startup wrote into the account registry, so a
+     * newly imported key whose kind 0 hadn't arrived yet by that moment
+     * would show a bare npub in the switcher forever — this fires whenever
+     * a fresh kind 0 for ANY account in the registry lands, from any of the
+     * three ingestion paths (live subscription, direct cache, ObjectBox seed).
+     */
+    private fun updateAccountRegistryIfKnownAccount(pubkey: String, profile: ProfileData) {
+        val repo = keyRepo ?: return
+        if (repo.getAccountList().none { it.pubkeyHex == pubkey }) return
+        repo.updateAccountMetadata(pubkey, profile.displayString, profile.picture)
+    }
 
     /**
      * Build maps of bolt11 payment hash → counterparty pubkey from persisted zap receipts (kind 9735).

--- a/app/src/main/kotlin/com/darkwisp/app/repo/KeyRepository.kt
+++ b/app/src/main/kotlin/com/darkwisp/app/repo/KeyRepository.kt
@@ -204,6 +204,21 @@ class KeyRepository(private val context: Context) {
         _accounts.value = accounts
     }
 
+    /**
+     * Move an account one position earlier (offset -1) or later (offset +1)
+     * in the persisted account list. No-op if already at that end.
+     */
+    fun moveAccount(pubkeyHex: String, offset: Int) {
+        val accounts = loadAccountList().toMutableList()
+        val index = accounts.indexOfFirst { it.pubkeyHex == pubkeyHex }
+        val target = index + offset
+        if (index < 0 || target < 0 || target >= accounts.size) return
+        val moved = accounts.removeAt(index)
+        accounts.add(target, moved)
+        encPrefs.edit().putString("accounts", json.encodeToString(accounts)).apply()
+        _accounts.value = accounts
+    }
+
     private fun loadAccountList(): List<AccountInfo> {
         val str = encPrefs.getString("accounts", null) ?: return emptyList()
         return try {

--- a/app/src/main/kotlin/com/darkwisp/app/ui/component/AccountSwitcherSheet.kt
+++ b/app/src/main/kotlin/com/darkwisp/app/ui/component/AccountSwitcherSheet.kt
@@ -1,0 +1,214 @@
+package com.darkwisp.app.ui.component
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.navigationBarsPadding
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Add
+import androidx.compose.material.icons.filled.Check
+import androidx.compose.material.icons.filled.KeyboardArrowDown
+import androidx.compose.material.icons.filled.KeyboardArrowUp
+import androidx.compose.material.icons.outlined.Visibility
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.material3.Text
+import androidx.compose.material3.rememberModalBottomSheetState
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.platform.LocalConfiguration
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import com.darkwisp.app.R
+import com.darkwisp.app.nostr.ProfileData
+import com.darkwisp.app.nostr.toNpub
+import com.darkwisp.app.repo.AccountInfo
+import com.darkwisp.app.repo.SigningMode
+
+/**
+ * Modal bottom sheet for switching between signed-in accounts or adding a new
+ * one. Replaces the old inline expand/collapse panel in [WispDrawerContent] —
+ * a bottom sheet is easier to reach, easier to dismiss, and gives the "add
+ * account" action a full-width, unambiguous row instead of competing with a
+ * cramped drawer header.
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun AccountSwitcherSheet(
+    accounts: List<AccountInfo>,
+    activePubkey: String?,
+    activeProfile: ProfileData?,
+    onSwitchAccount: (String) -> Unit,
+    onAddAccount: () -> Unit,
+    onMoveAccount: (pubkeyHex: String, offset: Int) -> Unit = { _, _ -> },
+    onDismiss: () -> Unit,
+) {
+    // skipPartiallyExpanded so the sheet opens fully expanded — guarantees
+    // the pinned "Sign in with another account" row is visible above the
+    // bottom nav/gesture chrome on first open, regardless of account count.
+    val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
+    ModalBottomSheet(
+        onDismissRequest = onDismiss,
+        sheetState = sheetState,
+        containerColor = MaterialTheme.colorScheme.surface,
+    ) {
+        // Cap the account list at ~45% of the screen so the "add account"
+        // row stays pinned below it (and above the gesture/nav bar) even
+        // with many accounts — the list scrolls within the cap instead of
+        // growing the sheet past the viewport.
+        val maxListHeight = LocalConfiguration.current.screenHeightDp.dp * 0.45f
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .navigationBarsPadding()
+                .padding(horizontal = 16.dp)
+                .padding(bottom = 24.dp),
+        ) {
+            Text(
+                text = stringResource(R.string.account_switcher_title),
+                style = MaterialTheme.typography.titleMedium,
+                fontWeight = FontWeight.SemiBold,
+            )
+            Spacer(Modifier.height(8.dp))
+
+            Column(
+                modifier = Modifier
+                    .heightIn(max = maxListHeight)
+                    .verticalScroll(rememberScrollState())
+            ) {
+                accounts.forEachIndexed { index, account ->
+                    val isActive = account.pubkeyHex == activePubkey
+                    Row(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .clickable(enabled = !isActive) {
+                                onSwitchAccount(account.pubkeyHex)
+                                onDismiss()
+                            }
+                            .padding(vertical = 6.dp),
+                        verticalAlignment = Alignment.CenterVertically,
+                    ) {
+                        // For the active account use the live profile picture; for others use cached AccountInfo
+                        val pictureUrl = if (isActive) activeProfile?.picture else account.picture
+                        ProfilePicture(url = pictureUrl, size = 40)
+                        Spacer(Modifier.width(12.dp))
+                        val displayText = if (isActive) {
+                            activeProfile?.displayString ?: account.displayName ?: account.pubkeyHex.toNpub().let { it.take(16) + "..." }
+                        } else {
+                            account.displayName ?: account.pubkeyHex.toNpub().let { it.take(16) + "..." }
+                        }
+                        Text(
+                            text = displayText,
+                            style = MaterialTheme.typography.bodyMedium,
+                            color = MaterialTheme.colorScheme.onSurface,
+                            maxLines = 1,
+                            overflow = TextOverflow.Ellipsis,
+                            modifier = Modifier.weight(1f),
+                        )
+                        if (account.signingMode == SigningMode.READ_ONLY) {
+                            Icon(
+                                Icons.Outlined.Visibility,
+                                contentDescription = stringResource(R.string.cd_watch_only),
+                                modifier = Modifier.size(18.dp),
+                                tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                            )
+                            Spacer(Modifier.width(4.dp))
+                        }
+                        if (isActive) {
+                            Icon(
+                                Icons.Filled.Check,
+                                contentDescription = stringResource(R.string.cd_active),
+                                modifier = Modifier.size(18.dp),
+                                tint = MaterialTheme.colorScheme.primary,
+                            )
+                            Spacer(Modifier.width(4.dp))
+                        }
+                        if (accounts.size > 1) {
+                            IconButton(
+                                onClick = { onMoveAccount(account.pubkeyHex, -1) },
+                                enabled = index > 0,
+                                modifier = Modifier.size(32.dp),
+                            ) {
+                                Icon(
+                                    Icons.Filled.KeyboardArrowUp,
+                                    contentDescription = stringResource(R.string.cd_move_account_up),
+                                    modifier = Modifier.size(18.dp),
+                                    tint = if (index > 0) MaterialTheme.colorScheme.onSurfaceVariant
+                                        else MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.3f),
+                                )
+                            }
+                            IconButton(
+                                onClick = { onMoveAccount(account.pubkeyHex, 1) },
+                                enabled = index < accounts.size - 1,
+                                modifier = Modifier.size(32.dp),
+                            ) {
+                                Icon(
+                                    Icons.Filled.KeyboardArrowDown,
+                                    contentDescription = stringResource(R.string.cd_move_account_down),
+                                    modifier = Modifier.size(18.dp),
+                                    tint = if (index < accounts.size - 1) MaterialTheme.colorScheme.onSurfaceVariant
+                                        else MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.3f),
+                                )
+                            }
+                        }
+                    }
+                }
+            }
+
+            HorizontalDivider(modifier = Modifier.padding(vertical = 8.dp))
+
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .clickable {
+                        onAddAccount()
+                        onDismiss()
+                    }
+                    .padding(vertical = 10.dp),
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                Box(
+                    modifier = Modifier
+                        .size(40.dp)
+                        .clip(CircleShape)
+                        .background(MaterialTheme.colorScheme.surfaceVariant),
+                    contentAlignment = Alignment.Center,
+                ) {
+                    Icon(
+                        Icons.Filled.Add,
+                        contentDescription = null,
+                        modifier = Modifier.size(20.dp),
+                        tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                }
+                Spacer(Modifier.width(12.dp))
+                Text(
+                    text = stringResource(R.string.account_switcher_add),
+                    style = MaterialTheme.typography.bodyMedium,
+                    fontWeight = FontWeight.Medium,
+                    color = MaterialTheme.colorScheme.onSurface,
+                )
+            }
+        }
+    }
+}

--- a/app/src/main/kotlin/com/darkwisp/app/ui/component/WispDrawerContent.kt
+++ b/app/src/main/kotlin/com/darkwisp/app/ui/component/WispDrawerContent.kt
@@ -43,7 +43,7 @@ import androidx.compose.material.icons.outlined.Hub
 import androidx.compose.material.icons.outlined.Palette
 import androidx.compose.material.icons.outlined.Settings
 import androidx.compose.material.icons.outlined.Shield
-import androidx.compose.material.icons.filled.Add
+import androidx.compose.material.icons.outlined.People
 import androidx.compose.material.icons.filled.Check
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.IconButton
@@ -74,6 +74,7 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import com.darkwisp.app.nostr.ProfileData
+import com.darkwisp.app.nostr.toNpub
 import com.darkwisp.app.relay.TorManager
 import com.darkwisp.app.repo.AccountInfo
 
@@ -91,6 +92,7 @@ fun WispDrawerContent(
     accounts: List<AccountInfo> = emptyList(),
     onSwitchAccount: (String) -> Unit = {},
     onAddAccount: () -> Unit = {},
+    onMoveAccount: (pubkeyHex: String, offset: Int) -> Unit = { _, _ -> },
     anonModeActive: Boolean = false,
     anonName: String? = null,
     onEnterAnonMode: () -> Unit = {},
@@ -132,7 +134,7 @@ fun WispDrawerContent(
             .verticalScroll(scrollState)
         ) {
         var showProfileQr by remember { mutableStateOf(false) }
-        var accountPickerExpanded by remember { mutableStateOf(false) }
+        var showAccountSwitcher by remember { mutableStateOf(false) }
 
         Column(modifier = Modifier.padding(16.dp)) {
             Row(
@@ -157,50 +159,32 @@ fun WispDrawerContent(
                     ProfilePicture(url = profile?.picture, size = 64)
                 }
                 Spacer(modifier = Modifier.width(8.dp))
+                // Icon-only affordance that opens the account switcher modal.
+                // Same action (switch or add an account) regardless of how many
+                // accounts are signed in; shows a "+N" badge counting the other
+                // accounts when more than one is signed in.
                 val otherAccountCount = (accounts.size - 1).coerceAtLeast(0)
-                if (otherAccountCount == 0) {
-                    Box(
-                        modifier = Modifier
-                            .size(26.dp)
-                            .clip(CircleShape)
-                            .background(MaterialTheme.colorScheme.surfaceVariant)
-                            .clickable { onAddAccount() },
-                        contentAlignment = Alignment.Center
-                    ) {
-                        Icon(
-                            Icons.Filled.Add,
-                            contentDescription = "Add account",
-                            modifier = Modifier.size(16.dp),
-                            tint = MaterialTheme.colorScheme.onSurfaceVariant
-                        )
-                    }
-                } else {
-                    Row(
-                        verticalAlignment = Alignment.CenterVertically,
-                        modifier = Modifier.clickable { accountPickerExpanded = !accountPickerExpanded }
-                    ) {
-                        Box(
-                            modifier = Modifier
-                                .height(26.dp)
-                                .clip(CircleShape)
-                                .background(MaterialTheme.colorScheme.surfaceVariant)
-                                .padding(horizontal = 10.dp),
-                            contentAlignment = Alignment.Center
-                        ) {
-                            Text(
-                                text = "+ $otherAccountCount",
-                                style = MaterialTheme.typography.labelSmall,
-                                fontWeight = androidx.compose.ui.text.font.FontWeight.Bold,
-                                color = MaterialTheme.colorScheme.onSurfaceVariant
-                            )
-                        }
-                        Spacer(modifier = Modifier.width(2.dp))
-                        Icon(
-                            if (accountPickerExpanded) Icons.Outlined.KeyboardArrowDown
-                            else Icons.Outlined.KeyboardArrowRight,
-                            contentDescription = null,
-                            modifier = Modifier.size(18.dp),
-                            tint = MaterialTheme.colorScheme.onSurfaceVariant
+                Row(
+                    verticalAlignment = Alignment.CenterVertically,
+                    modifier = Modifier
+                        .clip(RoundedCornerShape(16.dp))
+                        .background(MaterialTheme.colorScheme.surfaceVariant)
+                        .clickable { showAccountSwitcher = true }
+                        .padding(horizontal = 10.dp, vertical = 6.dp)
+                ) {
+                    Icon(
+                        Icons.Outlined.People,
+                        contentDescription = stringResource(R.string.cd_switch_account),
+                        modifier = Modifier.size(16.dp),
+                        tint = MaterialTheme.colorScheme.onSurfaceVariant
+                    )
+                    if (otherAccountCount > 0) {
+                        Spacer(modifier = Modifier.width(4.dp))
+                        Text(
+                            text = "+$otherAccountCount",
+                            style = MaterialTheme.typography.labelSmall,
+                            fontWeight = androidx.compose.ui.text.font.FontWeight.Bold,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant
                         )
                     }
                 }
@@ -223,11 +207,7 @@ fun WispDrawerContent(
                 }
             }
             Row(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .clickable(enabled = accounts.isNotEmpty()) {
-                        accountPickerExpanded = !accountPickerExpanded
-                    },
+                modifier = Modifier.fillMaxWidth(),
                 verticalAlignment = Alignment.CenterVertically
             ) {
                 Text(
@@ -248,7 +228,7 @@ fun WispDrawerContent(
                 )
             } else if (pubkey != null) {
                 Text(
-                    text = pubkey.take(16) + "...",
+                    text = pubkey.toNpub().let { it.take(16) + "..." },
                     style = MaterialTheme.typography.bodySmall,
                     color = MaterialTheme.colorScheme.onSurfaceVariant,
                     maxLines = 1,
@@ -329,149 +309,84 @@ fun WispDrawerContent(
                 }
             }
 
-            // Account picker dropdown
-            AnimatedVisibility(visible = accountPickerExpanded) {
-                Column(modifier = Modifier.padding(top = 8.dp)) {
-                    accounts.forEach { account ->
-                        val isActive = account.pubkeyHex == pubkey
-                        Row(
-                            modifier = Modifier
-                                .fillMaxWidth()
-                                .clickable(enabled = !isActive) {
-                                    accountPickerExpanded = false
-                                    onSwitchAccount(account.pubkeyHex)
-                                }
-                                .padding(vertical = 8.dp),
-                            verticalAlignment = Alignment.CenterVertically
-                        ) {
-                            // For the active account use the live profile picture; for others use cached AccountInfo
-                            val pictureUrl = if (isActive) profile?.picture else account.picture
-                            ProfilePicture(url = pictureUrl, size = 36)
-                            Spacer(modifier = Modifier.width(12.dp))
-                            val displayText = if (isActive) {
-                                profile?.displayString ?: account.displayName ?: account.pubkeyHex.take(16) + "..."
-                            } else {
-                                account.displayName ?: account.pubkeyHex.take(16) + "..."
-                            }
-                            Text(
-                                text = displayText,
-                                style = MaterialTheme.typography.bodyMedium,
-                                color = MaterialTheme.colorScheme.onSurface,
-                                maxLines = 1,
-                                overflow = TextOverflow.Ellipsis,
-                                modifier = Modifier.weight(1f)
-                            )
-                            if (isActive) {
-                                Icon(
-                                    Icons.Filled.Check,
-                                    contentDescription = stringResource(R.string.cd_active),
-                                    modifier = Modifier.size(18.dp),
-                                    tint = MaterialTheme.colorScheme.primary
-                                )
-                            }
-                        }
-                    }
-                    // Add account row
-                    Row(
-                        modifier = Modifier
-                            .fillMaxWidth()
-                            .clickable {
-                                accountPickerExpanded = false
-                                onAddAccount()
-                            }
-                            .padding(vertical = 8.dp),
-                        verticalAlignment = Alignment.CenterVertically
+            // Anon mode row — always visible (not tied to the account switcher sheet)
+            HorizontalDivider(modifier = Modifier.padding(top = 8.dp, bottom = 4.dp))
+            if (anonModeActive) {
+                Row(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(vertical = 8.dp),
+                    verticalAlignment = Alignment.CenterVertically
+                ) {
+                    Box(
+                        modifier = Modifier.size(36.dp),
+                        contentAlignment = Alignment.Center
                     ) {
-                        Box(
-                            modifier = Modifier.size(36.dp),
-                            contentAlignment = Alignment.Center
-                        ) {
-                            Icon(
-                                Icons.Filled.Add,
-                                contentDescription = stringResource(R.string.cd_add_account),
-                                modifier = Modifier.size(20.dp),
-                                tint = MaterialTheme.colorScheme.onSurfaceVariant
-                            )
-                        }
-                        Spacer(modifier = Modifier.width(12.dp))
-                        Text(
-                            text = stringResource(R.string.cd_add_account),
-                            style = MaterialTheme.typography.bodyMedium,
-                            color = MaterialTheme.colorScheme.onSurfaceVariant
-                        )
+                        androidx.compose.material3.Text("🕶️", fontSize = MaterialTheme.typography.titleMedium.fontSize)
                     }
-
-                    // Anon mode row
-                    HorizontalDivider(modifier = Modifier.padding(vertical = 4.dp))
-                    if (anonModeActive) {
-                        Row(
-                            modifier = Modifier
-                                .fillMaxWidth()
-                                .padding(vertical = 8.dp),
-                            verticalAlignment = Alignment.CenterVertically
-                        ) {
-                            Box(
-                                modifier = Modifier.size(36.dp),
-                                contentAlignment = Alignment.Center
-                            ) {
-                                androidx.compose.material3.Text("🕶️", fontSize = MaterialTheme.typography.titleMedium.fontSize)
-                            }
-                            Spacer(modifier = Modifier.width(12.dp))
-                            Column(modifier = Modifier.weight(1f)) {
-                                Text(
-                                    text = "Anon Mode",
-                                    style = MaterialTheme.typography.bodyMedium,
-                                    color = AnonGreen
-                                )
-                                if (anonName != null) {
-                                    Text(
-                                        text = anonName,
-                                        style = MaterialTheme.typography.bodySmall,
-                                        color = MaterialTheme.colorScheme.onSurfaceVariant
-                                    )
-                                }
-                            }
-                            Icon(
-                                Icons.Filled.Check,
-                                contentDescription = stringResource(R.string.cd_active),
-                                modifier = Modifier.size(18.dp),
-                                tint = AnonGreen
-                            )
-                        }
-                    } else {
-                        Row(
-                            modifier = Modifier
-                                .fillMaxWidth()
-                                .clickable {
-                                    accountPickerExpanded = false
-                                    onEnterAnonMode()
-                                }
-                                .padding(vertical = 8.dp),
-                            verticalAlignment = Alignment.CenterVertically
-                        ) {
-                            Box(
-                                modifier = Modifier.size(36.dp),
-                                contentAlignment = Alignment.Center
-                            ) {
-                                androidx.compose.material3.Text("🕶️", fontSize = MaterialTheme.typography.titleMedium.fontSize)
-                            }
-                            Spacer(modifier = Modifier.width(12.dp))
+                    Spacer(modifier = Modifier.width(12.dp))
+                    Column(modifier = Modifier.weight(1f)) {
+                        Text(
+                            text = "Anon Mode",
+                            style = MaterialTheme.typography.bodyMedium,
+                            color = AnonGreen
+                        )
+                        if (anonName != null) {
                             Text(
-                                text = "Anon Mode",
-                                style = MaterialTheme.typography.bodyMedium,
+                                text = anonName,
+                                style = MaterialTheme.typography.bodySmall,
                                 color = MaterialTheme.colorScheme.onSurfaceVariant
                             )
-                            Spacer(modifier = Modifier.weight(1f))
-                            Icon(
-                                Icons.Outlined.KeyboardArrowRight,
-                                contentDescription = stringResource(R.string.cd_switch_account),
-                                modifier = Modifier.size(20.dp),
-                                tint = MaterialTheme.colorScheme.onSurfaceVariant
-                            )
                         }
                     }
+                    Icon(
+                        Icons.Filled.Check,
+                        contentDescription = stringResource(R.string.cd_active),
+                        modifier = Modifier.size(18.dp),
+                        tint = AnonGreen
+                    )
+                }
+            } else {
+                Row(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .clickable { onEnterAnonMode() }
+                        .padding(vertical = 8.dp),
+                    verticalAlignment = Alignment.CenterVertically
+                ) {
+                    Box(
+                        modifier = Modifier.size(36.dp),
+                        contentAlignment = Alignment.Center
+                    ) {
+                        androidx.compose.material3.Text("🕶️", fontSize = MaterialTheme.typography.titleMedium.fontSize)
+                    }
+                    Spacer(modifier = Modifier.width(12.dp))
+                    Text(
+                        text = "Anon Mode",
+                        style = MaterialTheme.typography.bodyMedium,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                    )
+                    Spacer(modifier = Modifier.weight(1f))
+                    Icon(
+                        Icons.Outlined.KeyboardArrowRight,
+                        contentDescription = stringResource(R.string.cd_switch_account),
+                        modifier = Modifier.size(20.dp),
+                        tint = MaterialTheme.colorScheme.onSurfaceVariant
+                    )
                 }
             }
+        }
+
+        if (showAccountSwitcher) {
+            AccountSwitcherSheet(
+                accounts = accounts,
+                activePubkey = pubkey,
+                activeProfile = profile,
+                onSwitchAccount = onSwitchAccount,
+                onAddAccount = onAddAccount,
+                onMoveAccount = onMoveAccount,
+                onDismiss = { showAccountSwitcher = false }
+            )
         }
 
         // Anon mode persistent banner

--- a/app/src/main/kotlin/com/darkwisp/app/ui/screen/FeedScreen.kt
+++ b/app/src/main/kotlin/com/darkwisp/app/ui/screen/FeedScreen.kt
@@ -171,6 +171,7 @@ fun FeedScreen(
     accounts: List<AccountInfo> = emptyList(),
     onSwitchAccount: (String) -> Unit = {},
     onAddAccount: () -> Unit = {},
+    onMoveAccount: (pubkeyHex: String, offset: Int) -> Unit = { _, _ -> },
     onLogout: () -> Unit = {},
     hasEmbeddedWallet: Boolean = false,
     onMediaServers: () -> Unit = {},
@@ -752,6 +753,7 @@ fun FeedScreen(
                     scope.launch { drawerState.close() }
                     onAddAccount()
                 },
+                onMoveAccount = onMoveAccount,
                 onProfile = {
                     scope.launch { drawerState.close() }
                     onProfileEdit()

--- a/app/src/main/kotlin/com/darkwisp/app/viewmodel/AuthViewModel.kt
+++ b/app/src/main/kotlin/com/darkwisp/app/viewmodel/AuthViewModel.kt
@@ -142,6 +142,11 @@ class AuthViewModel(app: Application) : AndroidViewModel(app) {
         _signingMode.value = keyRepo.getSigningMode()
     }
 
+    /** Reorder the account list in the switcher — offset -1 moves it up, +1 moves it down. */
+    fun moveAccount(pubkeyHex: String, offset: Int) {
+        keyRepo.moveAccount(pubkeyHex, offset)
+    }
+
     /**
      * Logs out the current account. Returns true if other accounts remain
      * (caller should switch to the next one), false if no accounts left

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -258,6 +258,11 @@
     <string name="cd_switch_account">Switch account</string>
     <string name="cd_add_account">Add account</string>
     <string name="cd_active">Active</string>
+    <string name="cd_watch_only">Watch-only</string>
+    <string name="cd_move_account_up">Move account up</string>
+    <string name="cd_move_account_down">Move account down</string>
+    <string name="account_switcher_title">Accounts</string>
+    <string name="account_switcher_add">Sign in with another account</string>
     <string name="cd_seen_on">Seen on</string>
     <string name="cd_sent_with">Sent with</string>
     <string name="cd_filter_notifications">Filter notifications</string>


### PR DESCRIPTION
## Summary
- Replace the drawer's inline expand/collapse account picker with a proper `AccountSwitcherSheet` modal bottom sheet, matching the sheet conventions already used elsewhere (e.g. `ProfileQrSheet`).
- Drawer header's account affordance is now an icon-only People glyph with a "+N" badge counting other signed-in accounts (single tap target, opens the sheet) — replacing the old count-dependent icon-vs-chip toggle.
- Sheet opens fully expanded (`skipPartiallyExpanded`) and caps the account list at ~45% of screen height so the "Sign in with another account" row stays pinned and reachable even with many accounts, instead of being pushed below the fold.
- Added up/down buttons to each account row so accounts can be manually reordered in the switcher sheet, persisted via a new `KeyRepository.moveAccount`.
- The Anon Mode toggle, which previously only rendered inside the account picker's expanded state, now always renders in the drawer body since it's unrelated to account switching.
- Fixed the drawer header and account rows to show a truncated npub instead of raw hex when a profile has no NIP-05.

## Test plan
- [x] Build succeeds (`assembleDebug`)
- [x] Opened the account switcher sheet — list scrolls, "Sign in with another account" stays pinned and visible on first open
- [x] Confirmed switching accounts via the sheet works correctly
- [x] Confirmed reordering accounts via the up/down buttons works and the new order persists
- [x] Confirmed Anon Mode toggle still works, now always visible in the drawer body
- [x] Confirmed the header badge and per-account rows show a truncated npub (not raw hex) when a profile has no NIP-05
- [x] Verified on device