### PR TITLE
fix(security): extend nsec paste guard to every remaining text input

### DIFF
--- a/app/src/main/kotlin/com/darkwisp/app/ui/component/AddToListDialog.kt
+++ b/app/src/main/kotlin/com/darkwisp/app/ui/component/AddToListDialog.kt
@@ -103,7 +103,7 @@ fun AddNoteToListDialog(
                 ) {
                     OutlinedTextField(
                         value = newListName,
-                        onValueChange = { newListName = it },
+                        onValueChange = { new -> if (!NsecPasteGuard.blockIfNsec(newListName, new)) newListName = new },
                         placeholder = { Text("New list name") },
                         singleLine = true,
                         modifier = Modifier.weight(1f)

--- a/app/src/main/kotlin/com/darkwisp/app/ui/component/WispDrawerContent.kt
+++ b/app/src/main/kotlin/com/darkwisp/app/ui/component/WispDrawerContent.kt
@@ -286,7 +286,7 @@ fun WispDrawerContent(
                         text = {
                             androidx.compose.material3.OutlinedTextField(
                                 value = statusText,
-                                onValueChange = { statusText = it },
+                                onValueChange = { new -> if (!com.darkwisp.app.ui.component.NsecPasteGuard.blockIfNsec(statusText, new)) statusText = new },
                                 label = { Text("What are you up to?") },
                                 singleLine = true,
                                 modifier = Modifier.fillMaxWidth()

--- a/app/src/main/kotlin/com/darkwisp/app/ui/screen/AuthScreen.kt
+++ b/app/src/main/kotlin/com/darkwisp/app/ui/screen/AuthScreen.kt
@@ -29,6 +29,7 @@ import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
@@ -64,6 +65,7 @@ import androidx.compose.ui.res.stringResource
 import com.darkwisp.app.R
 import com.darkwisp.app.nostr.RemoteSignerBridge
 import com.darkwisp.app.nostr.toHex
+import com.darkwisp.app.ui.component.NsecPasteGuard
 import com.darkwisp.app.ui.component.TorCornerButton
 import com.darkwisp.app.viewmodel.AuthViewModel
 
@@ -105,6 +107,11 @@ fun AuthScreen(
         }
         viewModel.loginWithSigner(pubkeyHex, pkg)
         signerLoginComplete = true
+    }
+
+    DisposableEffect(Unit) {
+        NsecPasteGuard.nsecPasteAllowed = true
+        onDispose { NsecPasteGuard.nsecPasteAllowed = false }
     }
 
     Box(modifier = Modifier.fillMaxSize()) {

--- a/app/src/main/kotlin/com/darkwisp/app/ui/screen/BlossomServersScreen.kt
+++ b/app/src/main/kotlin/com/darkwisp/app/ui/screen/BlossomServersScreen.kt
@@ -45,6 +45,7 @@ import androidx.compose.ui.zIndex
 import androidx.compose.ui.res.stringResource
 import com.darkwisp.app.R
 import com.darkwisp.app.relay.RelayPool
+import com.darkwisp.app.ui.component.NsecPasteGuard
 import com.darkwisp.app.viewmodel.BlossomServersViewModel
 import kotlin.math.roundToInt
 
@@ -95,7 +96,7 @@ fun BlossomServersScreen(
             ) {
                 OutlinedTextField(
                     value = newServerUrl,
-                    onValueChange = { viewModel.updateNewServerUrl(it) },
+                    onValueChange = { new -> if (!NsecPasteGuard.blockIfNsec(newServerUrl, new)) viewModel.updateNewServerUrl(new) },
                     label = { Text("https://...") },
                     singleLine = true,
                     modifier = Modifier.weight(1f)

--- a/app/src/main/kotlin/com/darkwisp/app/ui/screen/ComposeScreen.kt
+++ b/app/src/main/kotlin/com/darkwisp/app/ui/screen/ComposeScreen.kt
@@ -323,7 +323,11 @@ fun ComposeScreen(
                     }
                     OutlinedTextField(
                         value = content,
-                        onValueChange = { viewModel.updateContent(it) },
+                        onValueChange = { new ->
+                            if (!com.darkwisp.app.ui.component.NsecPasteGuard.blockIfNsec(content.text, new.text)) {
+                                viewModel.updateContent(new)
+                            }
+                        },
                         label = { Text(stringResource(R.string.compose_gallery_placeholder)) },
                         enabled = !publishing && countdownSeconds == null,
                         visualTransformation = galleryEmojiVisual,
@@ -709,6 +713,7 @@ fun ComposeScreen(
                             }),
                         enabled = enabled,
                         keyboardOptions = KeyboardOptions(capitalization = KeyboardCapitalization.Sentences),
+                        inputTransformation = com.darkwisp.app.ui.component.NsecPasteGuard.inputTransformation,
                         lineLimits = TextFieldLineLimits.MultiLine(),
                         outputTransformation = outputTransformation,
                         textStyle = MaterialTheme.typography.bodyLarge.copy(

--- a/app/src/main/kotlin/com/darkwisp/app/ui/screen/CustomEmojiScreen.kt
+++ b/app/src/main/kotlin/com/darkwisp/app/ui/screen/CustomEmojiScreen.kt
@@ -63,6 +63,7 @@ import com.darkwisp.app.nostr.CustomEmoji
 import com.darkwisp.app.nostr.EmojiSet
 import com.darkwisp.app.repo.CustomEmojiRepository
 import com.darkwisp.app.ui.component.EmojiLibrarySheet
+import com.darkwisp.app.ui.component.NsecPasteGuard
 import com.darkwisp.app.ui.component.pendingEmojiReactCallback
 
 @OptIn(ExperimentalMaterial3Api::class, ExperimentalLayoutApi::class)
@@ -403,7 +404,7 @@ fun CustomEmojiScreen(
                     ) {
                         OutlinedTextField(
                             value = url,
-                            onValueChange = { url = it },
+                            onValueChange = { new -> if (!NsecPasteGuard.blockIfNsec(url, new)) url = new },
                             placeholder = { Text("Image URL") },
                             singleLine = true,
                             modifier = Modifier.weight(1f)
@@ -562,7 +563,7 @@ private fun CreateEmojiSetDialog(
         text = {
             OutlinedTextField(
                 value = name,
-                onValueChange = { name = it },
+                onValueChange = { new -> if (!NsecPasteGuard.blockIfNsec(name, new)) name = new },
                 placeholder = { Text("Set name") },
                 singleLine = true
             )
@@ -611,7 +612,7 @@ private fun EditEmojiSetDialog(
             Column {
                 OutlinedTextField(
                     value = title,
-                    onValueChange = { title = it },
+                    onValueChange = { new -> if (!NsecPasteGuard.blockIfNsec(title, new)) title = new },
                     label = { Text("Set name") },
                     singleLine = true
                 )
@@ -628,7 +629,7 @@ private fun EditEmojiSetDialog(
                     Spacer(Modifier.width(4.dp))
                     OutlinedTextField(
                         value = url,
-                        onValueChange = { url = it },
+                        onValueChange = { new -> if (!NsecPasteGuard.blockIfNsec(url, new)) url = new },
                         placeholder = { Text("URL") },
                         singleLine = true,
                         modifier = Modifier.weight(1f)

--- a/app/src/main/kotlin/com/darkwisp/app/ui/screen/DmConversationScreen.kt
+++ b/app/src/main/kotlin/com/darkwisp/app/ui/screen/DmConversationScreen.kt
@@ -559,7 +559,12 @@ fun DmConversationScreen(
                             }
                             androidx.compose.foundation.text.BasicTextField(
                                 value = dmTfv,
-                                onValueChange = { dmTfv = it; viewModel.updateMessageText(it.text) },
+                                onValueChange = { new ->
+                                    if (!com.darkwisp.app.ui.component.NsecPasteGuard.blockIfNsec(dmTfv.text, new.text)) {
+                                        dmTfv = new
+                                        viewModel.updateMessageText(new.text)
+                                    }
+                                },
                                 modifier = Modifier.weight(1f).heightIn(min = 28.dp).padding(top = 4.dp),
                                 enabled = uploadProgress == null,
                                 keyboardOptions = KeyboardOptions(capitalization = KeyboardCapitalization.Sentences),

--- a/app/src/main/kotlin/com/darkwisp/app/ui/screen/GroupRoomScreen.kt
+++ b/app/src/main/kotlin/com/darkwisp/app/ui/screen/GroupRoomScreen.kt
@@ -578,6 +578,7 @@ fun GroupRoomScreen(
                             .then(pasteImagesModifier),
                         enabled = uploadProgress == null,
                         keyboardOptions = KeyboardOptions(capitalization = KeyboardCapitalization.Sentences),
+                        inputTransformation = com.darkwisp.app.ui.component.NsecPasteGuard.inputTransformation,
                         outputTransformation = groupEmojiTransformation,
                         lineLimits = lineLimits,
                         textStyle = MaterialTheme.typography.bodyLarge.copy(

--- a/app/src/main/kotlin/com/darkwisp/app/ui/screen/ProfileEditScreen.kt
+++ b/app/src/main/kotlin/com/darkwisp/app/ui/screen/ProfileEditScreen.kt
@@ -213,7 +213,7 @@ fun ProfileEditScreen(
             Column(modifier = Modifier.padding(horizontal = 16.dp).offset(y = (-16).dp)) {
             OutlinedTextField(
                 value = name,
-                onValueChange = { viewModel.updateName(it) },
+                onValueChange = { new -> if (!NsecPasteGuard.blockIfNsec(name, new)) viewModel.updateName(new) },
                 label = { Text(stringResource(R.string.placeholder_name)) },
                 singleLine = true,
                 modifier = Modifier.fillMaxWidth().scrollOnFocus()
@@ -221,7 +221,7 @@ fun ProfileEditScreen(
             Spacer(Modifier.height(12.dp))
             OutlinedTextField(
                 value = about,
-                onValueChange = { viewModel.updateAbout(it) },
+                onValueChange = { new -> if (!NsecPasteGuard.blockIfNsec(about, new)) viewModel.updateAbout(new) },
                 label = { Text(stringResource(R.string.placeholder_about)) },
                 minLines = 3,
                 modifier = Modifier.fillMaxWidth().scrollOnFocus()
@@ -229,7 +229,7 @@ fun ProfileEditScreen(
             Spacer(Modifier.height(12.dp))
             OutlinedTextField(
                 value = nip05,
-                onValueChange = { viewModel.updateNip05(it) },
+                onValueChange = { new -> if (!NsecPasteGuard.blockIfNsec(nip05, new)) viewModel.updateNip05(new) },
                 label = { Text(stringResource(R.string.placeholder_nip05)) },
                 singleLine = true,
                 modifier = Modifier.fillMaxWidth().scrollOnFocus()
@@ -237,7 +237,7 @@ fun ProfileEditScreen(
             Spacer(Modifier.height(12.dp))
             OutlinedTextField(
                 value = lud16,
-                onValueChange = { viewModel.updateLud16(it) },
+                onValueChange = { new -> if (!NsecPasteGuard.blockIfNsec(lud16, new)) viewModel.updateLud16(new) },
                 label = { Text(stringResource(R.string.placeholder_lightning_address)) },
                 singleLine = true,
                 modifier = Modifier.fillMaxWidth().scrollOnFocus()

--- a/app/src/main/kotlin/com/darkwisp/app/ui/screen/RelayDetailScreen.kt
+++ b/app/src/main/kotlin/com/darkwisp/app/ui/screen/RelayDetailScreen.kt
@@ -50,6 +50,7 @@ import com.darkwisp.app.relay.RelayHealthTracker
 import com.darkwisp.app.repo.RelayInfoRepository
 import com.darkwisp.app.nostr.ProfileData
 import com.darkwisp.app.nostr.RelaySet
+import com.darkwisp.app.ui.component.NsecPasteGuard
 import com.darkwisp.app.ui.component.ProfilePicture
 import com.darkwisp.app.ui.component.RelayIcon
 import com.darkwisp.app.ui.theme.WispThemeColors
@@ -377,7 +378,7 @@ private fun RelayHeader(
                                     // Create new set
                                     androidx.compose.material3.OutlinedTextField(
                                         value = newSetName,
-                                        onValueChange = { newSetName = it },
+                                        onValueChange = { new -> if (!NsecPasteGuard.blockIfNsec(newSetName, new)) newSetName = new },
                                         placeholder = { Text(stringResource(R.string.placeholder_new_set_name)) },
                                         singleLine = true,
                                         modifier = Modifier.fillMaxWidth(),

--- a/app/src/main/kotlin/com/darkwisp/app/ui/screen/RelayScreen.kt
+++ b/app/src/main/kotlin/com/darkwisp/app/ui/screen/RelayScreen.kt
@@ -51,6 +51,7 @@ import com.darkwisp.app.relay.RelayConfig
 import com.darkwisp.app.relay.RelayPool
 import com.darkwisp.app.relay.RelaySetType
 import com.darkwisp.app.R
+import com.darkwisp.app.ui.component.NsecPasteGuard
 import com.darkwisp.app.ui.theme.wispSwitchColors
 import com.darkwisp.app.viewmodel.RelayViewModel
 
@@ -117,7 +118,7 @@ fun RelayScreen(
                         ) {
                             OutlinedTextField(
                                 value = newRelayUrl,
-                                onValueChange = { viewModel.updateNewRelayUrl(it) },
+                                onValueChange = { new -> if (!NsecPasteGuard.blockIfNsec(newRelayUrl, new)) viewModel.updateNewRelayUrl(new) },
                                 label = { Text(stringResource(R.string.local_relay_url_hint)) },
                                 singleLine = true,
                                 modifier = Modifier.weight(1f)
@@ -139,7 +140,7 @@ fun RelayScreen(
                     ) {
                         OutlinedTextField(
                             value = newRelayUrl,
-                            onValueChange = { viewModel.updateNewRelayUrl(it) },
+                            onValueChange = { new -> if (!NsecPasteGuard.blockIfNsec(newRelayUrl, new)) viewModel.updateNewRelayUrl(new) },
                             label = { Text(stringResource(R.string.placeholder_relay_url)) },
                             singleLine = true,
                             modifier = Modifier.weight(1f)

--- a/app/src/main/kotlin/com/darkwisp/app/ui/screen/SafetyScreen.kt
+++ b/app/src/main/kotlin/com/darkwisp/app/ui/screen/SafetyScreen.kt
@@ -43,6 +43,7 @@ import com.darkwisp.app.repo.ExtendedNetworkCache
 import com.darkwisp.app.repo.MuteRepository
 import com.darkwisp.app.repo.ProfileRepository
 import com.darkwisp.app.repo.SafetyPreferences
+import com.darkwisp.app.ui.component.NsecPasteGuard
 import com.darkwisp.app.ui.component.ProfilePicture
 import kotlinx.coroutines.flow.StateFlow
 
@@ -145,7 +146,7 @@ private fun MutedWordsTab(
         ) {
             OutlinedTextField(
                 value = newWord,
-                onValueChange = { newWord = it },
+                onValueChange = { new -> if (!NsecPasteGuard.blockIfNsec(newWord, new)) newWord = new },
                 placeholder = { Text(stringResource(R.string.placeholder_add_word_phrase)) },
                 singleLine = true,
                 modifier = Modifier.weight(1f)

--- a/app/src/main/kotlin/com/darkwisp/app/ui/screen/SearchScreen.kt
+++ b/app/src/main/kotlin/com/darkwisp/app/ui/screen/SearchScreen.kt
@@ -78,6 +78,7 @@ import com.darkwisp.app.repo.TranslationRepository
 import com.darkwisp.app.repo.TranslationState
 import com.darkwisp.app.ui.component.FollowButton
 import com.darkwisp.app.ui.component.NoteActions
+import com.darkwisp.app.ui.component.NsecPasteGuard
 import com.darkwisp.app.ui.component.PostCard
 import com.darkwisp.app.ui.component.ProfilePicture
 import com.darkwisp.app.viewmodel.RelayOption
@@ -207,7 +208,7 @@ fun SearchScreen(
                     ) {
                         TextField(
                             value = query,
-                            onValueChange = { viewModel.updateQuery(it) },
+                            onValueChange = { new -> if (!NsecPasteGuard.blockIfNsec(query, new)) viewModel.updateQuery(new) },
                             singleLine = true,
                             placeholder = { Text(stringResource(R.string.title_search)) },
                             leadingIcon = {
@@ -668,7 +669,7 @@ private fun AddRelayDialog(
         text = {
             OutlinedTextField(
                 value = url,
-                onValueChange = { url = it },
+                onValueChange = { new -> if (!NsecPasteGuard.blockIfNsec(url, new)) url = new },
                 placeholder = { Text(stringResource(R.string.placeholder_add_relay)) },
                 singleLine = true,
                 modifier = Modifier.fillMaxWidth(),
@@ -742,7 +743,7 @@ private fun AuthorFilter(
             ) {
                 OutlinedTextField(
                     value = authorQuery,
-                    onValueChange = { authorQuery = it },
+                    onValueChange = { new -> if (!NsecPasteGuard.blockIfNsec(authorQuery, new)) authorQuery = new },
                     placeholder = { Text("Search for author") },
                     singleLine = true,
                     modifier = Modifier.weight(1f),

--- a/app/src/main/kotlin/com/darkwisp/app/ui/screen/WalletScreen.kt
+++ b/app/src/main/kotlin/com/darkwisp/app/ui/screen/WalletScreen.kt
@@ -3885,7 +3885,7 @@ private fun SparkRestoreSeedContent(
 
         OutlinedTextField(
             value = restoreMnemonic,
-            onValueChange = onRestoreMnemonicChange,
+            onValueChange = { new -> if (!NsecPasteGuard.blockIfNsec(restoreMnemonic, new)) onRestoreMnemonicChange(new) },
             label = { Text("Recovery phrase") },
             placeholder = { Text("Enter 12 or 24 words...") },
             modifier = Modifier.fillMaxWidth(),
@@ -4825,7 +4825,7 @@ private fun DeleteWalletConfirmContent(
 
             OutlinedTextField(
                 value = confirmText,
-                onValueChange = onConfirmTextChange,
+                onValueChange = { new -> if (!NsecPasteGuard.blockIfNsec(confirmText, new)) onConfirmTextChange(new) },
                 label = { Text("Type DELETE to confirm") },
                 modifier = Modifier.fillMaxWidth(),
                 singleLine = true


### PR DESCRIPTION
## Summary
- `NsecPasteGuard` existed but was only wired into `MainActivity` plus a handful of `ProfileEditScreen`/`WalletScreen` fields — most of the app's text inputs would silently accept a pasted nsec instead of blocking it
- Wire the guard into every remaining input: drawer status field, list names, relay set/URL fields (including the local-relay tab, which wisp no longer has), DM/group-room/compose message boxes, safety mute words, custom emoji fields, search fields, and the rest of the wallet screen (send input + paste button, restore mnemonic, delete-confirm text)
- Matches wisp's existing full app-wide coverage (PR #553)
- `nsecPasteAllowed = true` remains scoped to exactly one place — the sign-in screen — everywhere else blocks unconditionally

## Test plan
- [ ] Build and install on device
- [ ] Copy an nsec, attempt to paste it into each of: profile fields, relay URL fields, DM/group/compose message boxes, search, custom emoji fields, wallet fields — confirm each blocks with the warning pill
- [ ] Confirm pasting an nsec on the sign-in screen still works normally