### PR TITLE
Fix crash on zero/negative blurhash dimensions

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -26,8 +26,8 @@ android {
         applicationId = baseApplicationId
         minSdk = 26
         targetSdk = 35
-        versionCode = 3
-        versionName = "1.2.0"
+        versionCode = 4
+        versionName = "1.2.1"
         resValue("string", "app_name", "Dark Wisp")
 
         ndk {

--- a/app/src/main/kotlin/com/darkwisp/app/ui/component/RichContent.kt
+++ b/app/src/main/kotlin/com/darkwisp/app/ui/component/RichContent.kt
@@ -2987,8 +2987,8 @@ internal fun rememberMediaPlaceholderPainter(
             return@produceState
         }
         val dims = dimension?.split('x')
-        val width = dims?.getOrNull(0)?.toIntOrNull()?.coerceAtMost(100) ?: 32
-        val height = dims?.getOrNull(1)?.toIntOrNull()?.coerceAtMost(100) ?: 32
+        val width = dims?.getOrNull(0)?.toIntOrNull()?.takeIf { it > 0 }?.coerceAtMost(100) ?: 32
+        val height = dims?.getOrNull(1)?.toIntOrNull()?.takeIf { it > 0 }?.coerceAtMost(100) ?: 32
         value = withContext(Dispatchers.Default) {
             MediaHashDecoder.decode(thumbhash, blurhash, width, height)
                 ?.asImageBitmap()

--- a/app/src/main/kotlin/com/darkwisp/app/util/BlurHashDecoder.kt
+++ b/app/src/main/kotlin/com/darkwisp/app/util/BlurHashDecoder.kt
@@ -10,6 +10,7 @@ object BlurHashDecoder {
 
     fun decode(blurHash: String?, width: Int, height: Int, punch: Float = 1f): Bitmap? {
         if (blurHash == null || blurHash.length < 6) return null
+        if (width <= 0 || height <= 0) return null
 
         val numComponents = decode83(blurHash, 0, 1)
         val nx = (numComponents % 9) + 1

--- a/app/src/main/kotlin/com/darkwisp/app/util/MediaHashDecoder.kt
+++ b/app/src/main/kotlin/com/darkwisp/app/util/MediaHashDecoder.kt
@@ -7,6 +7,7 @@ import com.madebyevan.thumbhash.ThumbHash
 
 object MediaHashDecoder {
     fun decode(thumbHash: String?, blurHash: String?, width: Int, height: Int): Bitmap? {
+        if (width <= 0 || height <= 0) return null
         decodeThumbHash(thumbHash, width, height)?.let { return it }
         return BlurHashDecoder.decode(blurHash, width, height)
     }


### PR DESCRIPTION
## Summary
- Guard `BlurHashDecoder.decode` and `MediaHashDecoder.decode` against zero/negative width or height, returning null instead of crashing
- Sanitize parsed dimensions in `RichContent.kt` so a malformed `dim` tag (e.g. `0x0`) can't produce a non-positive width/height
- Bump version to 1.2.1 (versionCode 4)

## Test plan
- [ ] Build debug APK and verify a note with a malformed/zero `dim` tag no longer crashes the placeholder painter