### PR TITLE
feat(wallet): delete relay backup (Spark + NWC) + removal confirmations

### DIFF
--- a/app/src/main/kotlin/com/darkwisp/app/ui/screen/WalletScreen.kt
+++ b/app/src/main/kotlin/com/darkwisp/app/ui/screen/WalletScreen.kt
@@ -2,6 +2,7 @@ package com.darkwisp.app.ui.screen
 
 import android.Manifest
 import android.content.ClipData
+import android.widget.Toast
 import android.content.ClipboardManager
 import android.content.Context
 import android.content.Intent
@@ -611,6 +612,9 @@ fun WalletScreen(
                         isLoggedIn = viewModel.keyRepo.isLoggedIn(),
                         onCheckRelayBackups = { viewModel.checkRelayBackupStatuses() },
                         onDeleteRelayBackup = { viewModel.deleteRelayBackup() },
+                        onDeleteNwcRelayBackup = { viewModel.deleteNwcRelayBackup() },
+                        onDeleteSparkRelayBackup = { viewModel.deleteSparkRelayBackup() },
+                        onResetDeleteBackupStatus = { viewModel.resetDeleteBackupStatus() },
                         sparkIdentityPubkey = viewModel.sparkIdentityPubkey.collectAsState().value,
                         nwcNodeAlias = viewModel.nwcNodeAlias.collectAsState().value,
                         nwcConnectionInfo = viewModel.nwcConnectionInfo.collectAsState().value,
@@ -633,14 +637,25 @@ fun WalletScreen(
                         address = viewModel.lightningAddress.value ?: "",
                         modifier = Modifier.padding(padding)
                     )
-                    is WalletPage.DeleteWalletConfirm -> DeleteWalletConfirmContent(
-                        confirmText = viewModel.deleteConfirmText.collectAsState().value,
-                        onConfirmTextChange = { viewModel.updateDeleteConfirmText(it) },
-                        onDelete = { viewModel.deleteWallet() },
-                        onCancel = { viewModel.navigateBack() },
-                        walletMode = viewModel.walletMode.collectAsState().value,
-                        modifier = Modifier.padding(padding)
-                    )
+                    is WalletPage.DeleteWalletConfirm -> {
+                        val context = LocalContext.current
+                        val walletMode = viewModel.walletMode.collectAsState().value
+                        DeleteWalletConfirmContent(
+                            confirmText = viewModel.deleteConfirmText.collectAsState().value,
+                            onConfirmTextChange = { viewModel.updateDeleteConfirmText(it) },
+                            onDelete = {
+                                viewModel.deleteWallet()
+                                Toast.makeText(
+                                    context,
+                                    if (walletMode == WalletMode.NWC) "Wallet disconnected" else "Wallet removed",
+                                    Toast.LENGTH_SHORT
+                                ).show()
+                            },
+                            onCancel = { viewModel.navigateBack() },
+                            walletMode = walletMode,
+                            modifier = Modifier.padding(padding)
+                        )
+                    }
                     is WalletPage.BackupToRelay -> BackupToRelayContent(
                         backupStatus = viewModel.backupStatus.collectAsState().value,
                         onBackup = { viewModel.backupToRelay() },
@@ -4094,6 +4109,9 @@ private fun WalletSettingsContent(
     isLoggedIn: Boolean = false,
     onCheckRelayBackups: () -> Unit = {},
     onDeleteRelayBackup: () -> Unit = {},
+    onDeleteNwcRelayBackup: () -> Unit = {},
+    onDeleteSparkRelayBackup: () -> Unit = {},
+    onResetDeleteBackupStatus: () -> Unit = {},
     sparkIdentityPubkey: String? = null,
     nwcNodeAlias: String? = null,
     nwcConnectionInfo: com.darkwisp.app.repo.NwcRepository.ConnectionInfo? = null,
@@ -4356,6 +4374,17 @@ private fun WalletSettingsContent(
                 Spacer(Modifier.width(8.dp))
                 Text("Backup to Nostr Relays")
             }
+
+            Spacer(Modifier.height(8.dp))
+
+            // Delete the saved Spark wallet backup from relays. Scoped to this
+            // wallet's d-tag so it won't touch an NWC connection backup.
+            DeleteRelayBackupControl(
+                label = "Delete Wallet Backup from Relays",
+                deleteBackupStatus = deleteBackupStatus,
+                onDelete = onDeleteSparkRelayBackup,
+                onResetStatus = onResetDeleteBackupStatus
+            )
         }
 
         // Disclaimer
@@ -4421,6 +4450,16 @@ private fun WalletSettingsContent(
                 style = MaterialTheme.typography.bodySmall,
                 color = MaterialTheme.colorScheme.onSurfaceVariant,
                 modifier = Modifier.padding(horizontal = 4.dp)
+            )
+
+            // Delete the saved NWC connection backup from relays. Scoped to the
+            // nwc-wallet-backup d-tag so it won't touch a Spark mnemonic backup.
+            Spacer(Modifier.height(16.dp))
+            DeleteRelayBackupControl(
+                label = "Delete Connection Backup from Relays",
+                deleteBackupStatus = deleteBackupStatus,
+                onDelete = onDeleteNwcRelayBackup,
+                onResetStatus = onResetDeleteBackupStatus
             )
         } else {
             Button(
@@ -4496,6 +4535,65 @@ private fun WalletSettingsContent(
         }
 
         Spacer(Modifier.height(32.dp))
+    }
+}
+
+/**
+ * Outlined button that deletes the user's wallet backup from Nostr relays
+ * (scoped per wallet mode by the caller's [onDelete]), with a confirm
+ * dialog and InProgress/Success/Error feedback via [deleteBackupStatus].
+ */
+@Composable
+private fun DeleteRelayBackupControl(
+    label: String,
+    deleteBackupStatus: DeleteBackupStatus,
+    onDelete: () -> Unit,
+    onResetStatus: () -> Unit,
+) {
+    var showConfirm by remember { mutableStateOf(false) }
+    val context = LocalContext.current
+    // Toast the outcome prominently, then clear status so re-entering the
+    // screen doesn't re-fire a stale toast.
+    LaunchedEffect(deleteBackupStatus) {
+        when (deleteBackupStatus) {
+            is DeleteBackupStatus.Success -> {
+                Toast.makeText(context, "Backup deleted from relays", Toast.LENGTH_SHORT).show()
+                onResetStatus()
+            }
+            is DeleteBackupStatus.Error -> {
+                Toast.makeText(context, deleteBackupStatus.message, Toast.LENGTH_LONG).show()
+                onResetStatus()
+            }
+            else -> {}
+        }
+    }
+    OutlinedButton(
+        onClick = { showConfirm = true },
+        enabled = deleteBackupStatus !is DeleteBackupStatus.InProgress,
+        modifier = Modifier.fillMaxWidth()
+    ) {
+        Text(
+            if (deleteBackupStatus is DeleteBackupStatus.InProgress) "Deleting…"
+            else label
+        )
+    }
+    if (showConfirm) {
+        AlertDialog(
+            onDismissRequest = { showConfirm = false },
+            title = { Text("Delete backup from relays") },
+            text = {
+                Text("Remove the saved wallet backup from your relays? You can reconnect or restore from your recovery phrase anytime, but it won't be available from relays on another device.")
+            },
+            confirmButton = {
+                TextButton(onClick = {
+                    showConfirm = false
+                    onDelete()
+                }) { Text("Delete") }
+            },
+            dismissButton = {
+                TextButton(onClick = { showConfirm = false }) { Text("Cancel") }
+            }
+        )
     }
 }
 

--- a/app/src/main/kotlin/com/darkwisp/app/viewmodel/WalletViewModel.kt
+++ b/app/src/main/kotlin/com/darkwisp/app/viewmodel/WalletViewModel.kt
@@ -2102,4 +2102,54 @@ class WalletViewModel(
     fun resetDeleteBackupStatus() {
         _deleteBackupStatus.value = DeleteBackupStatus.Idle
     }
+
+    /**
+     * Tombstone only the NWC connection backup (kind 30078, d-tag
+     * `nwc-wallet-backup`) on relays — scoped so it doesn't wipe a Spark
+     * mnemonic backup. Shares [_deleteBackupStatus] for UI feedback.
+     */
+    fun deleteNwcRelayBackup() = tombstoneRelayBackup(Nip78.NWC_BACKUP_D_TAG)
+
+    /**
+     * Tombstone only the active Spark wallet's backup (kind 30078, d-tag
+     * `spark-wallet-backup:<walletId>`) — scoped so it doesn't wipe an NWC
+     * connection backup.
+     */
+    fun deleteSparkRelayBackup() {
+        val mnemonic = sparkRepo.getMnemonic() ?: run {
+            _deleteBackupStatus.value = DeleteBackupStatus.Error("No Spark wallet loaded")
+            return
+        }
+        tombstoneRelayBackup(Nip78.buildBackupDTag(Nip78.computeWalletId(mnemonic)))
+    }
+
+    /**
+     * Publish an empty kind 30078 tombstone (replaceable by d-tag) for [dTag]
+     * so relays replace the stored backup with a deleted marker. Scoped
+     * counterpart to [deleteRelayBackup] (which nukes every backup d-tag).
+     */
+    private fun tombstoneRelayBackup(dTag: String) {
+        val signer = buildSigner() ?: run {
+            _deleteBackupStatus.value = DeleteBackupStatus.Error("No signing key available")
+            return
+        }
+        _deleteBackupStatus.value = DeleteBackupStatus.InProgress
+        viewModelScope.launch {
+            try {
+                relayPool.ensureWriteRelaysConnected()
+                val tombstone = withContext(Dispatchers.Default) {
+                    Nip78.createDeleteEventForDTag(signer, dTag)
+                }
+                val totalSent = relayPool.sendToAllRelays(ClientMessage.event(tombstone))
+                Log.d("WalletBackup", "delete: tombstone dTag=$dTag sent to $totalSent relay slots")
+                _deleteBackupStatus.value = if (totalSent > 0) {
+                    DeleteBackupStatus.Success
+                } else {
+                    DeleteBackupStatus.Error("No relays accepted the delete")
+                }
+            } catch (e: Exception) {
+                _deleteBackupStatus.value = DeleteBackupStatus.Error(e.message ?: "Delete failed")
+            }
+        }
+    }
 }


### PR DESCRIPTION
## Summary
Resolves #59.

The delete-from-relays plumbing (`deleteRelayBackup`) existed in the ViewModel but had **no UI entry point** for either wallet mode — the `onDeleteRelayBackup` / status params were wired into `WalletSettingsContent` but never rendered (dead wiring). This adds scoped per-wallet deletion and visible confirmations:

- **Scoped deletion**: `deleteNwcRelayBackup()` / `deleteSparkRelayBackup()` tombstone only the matching d-tag (`nwc-wallet-backup` / `spark-wallet-backup:<walletId>`), via a shared `tombstoneRelayBackup(dTag)` helper. So removing one backup never wipes the other (unlike the old global `deleteRelayBackup()`, which nuked every backup d-tag). Spark is matched by the active wallet's mnemonic-derived `walletId`.
- **UI**: Wallet settings gains a "Delete … Backup from Relays" button for **both** Spark and NWC (shared `DeleteRelayBackupControl`), with a confirm dialog and a toast on success/error. Status resets after firing so re-entering the screen doesn't re-show a stale toast.
- **Wallet removal** itself now toasts ("Wallet removed" / "Wallet disconnected").

## Out of scope (follow-up)
The type-DELETE confirmation gate for Spark wallet removal is intentionally left as-is here — it was never removed in dark-wisp (wisp only relaxes it for its nsec-derived *default* wallet, a feature dark-wisp removed). That'll be addressed separately.

## Test plan
- [ ] Spark wallet: Settings → "Delete Wallet Backup from Relays" → confirm → toast "Backup deleted from relays"; verify the `spark-wallet-backup:<walletId>` event is tombstoned on relays and an NWC backup (if any) is untouched.
- [ ] NWC wallet: Settings → "Delete Connection Backup from Relays" → confirm → toast; verify only `nwc-wallet-backup` is tombstoned.
- [ ] Delete/remove a wallet → toast ("Wallet removed" / "Wallet disconnected").
- [ ] Leave and re-enter wallet settings after deleting → no stale toast re-fires.