### PR TITLE
fix(safety): mute hashtags (t-tags) and re-filter already-shown posts

### DIFF
--- a/app/src/main/kotlin/com/darkwisp/app/repo/EventRepository.kt
+++ b/app/src/main/kotlin/com/darkwisp/app/repo/EventRepository.kt
@@ -325,7 +325,7 @@ class EventRepository(val profileRepo: ProfileRepository? = null, val muteRepo: 
         if (!seenEventIds.add(event.id)) return  // atomic dedup across all relay threads
         if (event.created_at > System.currentTimeMillis() / 1000 + 30) return  // reject future-dated notes (30s grace for clock skew)
         if (muteRepo?.isBlocked(event.pubkey) == true) return
-        if ((event.kind == 1 || event.kind == 30023 || event.kind == 20 || event.kind == 21 || event.kind == 22 || event.kind == Nip69.KIND_ZAP_POLL) && muteRepo?.containsMutedWord(event.content) == true) return
+        if ((event.kind == 1 || event.kind == 30023 || event.kind == 20 || event.kind == 21 || event.kind == 22 || event.kind == Nip69.KIND_ZAP_POLL) && muteRepo?.isEventMuted(event) == true) return
         if (event.kind == 1) {
             val threadRoot = Nip10.getRootId(event) ?: Nip10.getReplyTarget(event) ?: event.id
             if (muteRepo?.isThreadMuted(threadRoot) == true) return
@@ -379,7 +379,7 @@ class EventRepository(val profileRepo: ProfileRepository? = null, val muteRepo: 
                     try {
                         val inner = fromJson(event.content)
                         if (muteRepo?.isBlocked(inner.pubkey) == true) return
-                        if (muteRepo?.containsMutedWord(inner.content) == true) return
+                        if (muteRepo?.isEventMuted(inner) == true) return
                         if (isWotFiltered(event.pubkey, 6) && isWotFiltered(inner.pubkey, 1)) return
                         val authors = repostAuthors.get(inner.id)
                             ?: ConcurrentHashMap.newKeySet<String>().also { repostAuthors.put(inner.id, it) }
@@ -1311,6 +1311,7 @@ class EventRepository(val profileRepo: ProfileRepository? = null, val muteRepo: 
             if (event.kind != 1 && event.kind != 20 && event.kind != 21 && event.kind != 22 && event.kind != 1068 && event.kind != 6969 && event.kind != 30023) continue
             if (event.created_at < sinceTimestamp) continue
             if (event.created_at > System.currentTimeMillis() / 1000 + 30) continue  // skip future-dated (scheduled) notes
+            if (muteRepo?.isEventMuted(event) == true) continue
             if (muteRepo?.isBlocked(event.pubkey) == true) continue
             if (deletedEventsRepo?.isDeleted(event.id) == true) continue
             if (isWotFiltered(event.pubkey, event.kind)) continue
@@ -1349,7 +1350,35 @@ class EventRepository(val profileRepo: ProfileRepository? = null, val muteRepo: 
         if (removed.isNotEmpty()) feedInserted.trySend(Unit)
     }
 
-    // -- Isolated relay feed methods --
+    /**
+     * Drop events from the current feed that now match a muted word/hashtag —
+     * e.g. after the user adds one in Safety settings. Mute filtering normally
+     * happens at ingest ([addEvent]), so already-displayed notes need an
+     * explicit pass to disappear. Mirrors [purgeThread].
+     */
+    fun purgeMutedWords() {
+        val repo = muteRepo ?: return
+        val removed = mutableListOf<String>()
+        synchronized(feedList) {
+            val iter = feedList.iterator()
+            while (iter.hasNext()) {
+                val e = iter.next()
+                if (e.kind == 1 || e.kind == 30023 || e.kind == 20 || e.kind == 21 || e.kind == 22 || e.kind == Nip69.KIND_ZAP_POLL) {
+                    if (repo.isEventMuted(e)) {
+                        removed.add(e.id)
+                        iter.remove()
+                    }
+                }
+            }
+            if (removed.isNotEmpty()) {
+                val removedSet = removed.toSet()
+                feedIds.removeAll(removedSet)
+                filteredFeedIds.removeAll(removedSet)
+                filteredFeed.removeAll { it.id in removedSet }
+            }
+        }
+        if (removed.isNotEmpty()) feedInserted.trySend(Unit)
+    }
 
     fun addRelayFeedEvent(event: NostrEvent) {
         if (event.created_at > System.currentTimeMillis() / 1000 + 30) return
@@ -1387,7 +1416,7 @@ class EventRepository(val profileRepo: ProfileRepository? = null, val muteRepo: 
                     try {
                         val inner = NostrEvent.fromJson(event.content)
                         if (muteRepo?.isBlocked(inner.pubkey) == true) return
-                        if (muteRepo?.containsMutedWord(inner.content) == true) return
+                        if (muteRepo?.isEventMuted(inner) == true) return
                         // Track repost metadata for badges
                         val authors = repostAuthors.get(inner.id)
                             ?: ConcurrentHashMap.newKeySet<String>().also { repostAuthors.put(inner.id, it) }
@@ -1446,7 +1475,7 @@ class EventRepository(val profileRepo: ProfileRepository? = null, val muteRepo: 
                     try {
                         val inner = NostrEvent.fromJson(event.content)
                         if (muteRepo?.isBlocked(inner.pubkey) == true) return
-                        if (muteRepo?.containsMutedWord(inner.content) == true) return
+                        if (muteRepo?.isEventMuted(inner) == true) return
                         val authors = repostAuthors.get(inner.id)
                             ?: ConcurrentHashMap.newKeySet<String>().also { repostAuthors.put(inner.id, it) }
                         authors.add(event.pubkey)

--- a/app/src/main/kotlin/com/darkwisp/app/repo/MuteRepository.kt
+++ b/app/src/main/kotlin/com/darkwisp/app/repo/MuteRepository.kt
@@ -89,10 +89,37 @@ class MuteRepository(private val context: Context, pubkeyHex: String? = null) {
         saveToPrefs()
     }
 
-    fun containsMutedWord(content: String): Boolean {
+    /**
+     * True if [event] matches any muted word or hashtag rule:
+     *  - a muted word entered with a leading "#" matches the event's lowercase
+     *    `t` tag values (the "#" stripped), or appears literally in the content;
+     *  - any other muted word is matched as a case-insensitive substring of the
+     *    content.
+     *
+     * Hashtags are usually carried in `t` tags rather than the raw text, so
+     * checking the content alone misses tag-based hashtags like "#657".
+     */
+    fun isEventMuted(event: NostrEvent): Boolean {
         if (wordSet.isEmpty()) return false
-        val lower = content.lowercase()
-        return wordSet.any { lower.contains(it) }
+        val lowerContent = event.content.lowercase()
+        val hashtags: Set<String> =
+            if (wordSet.any { it.startsWith("#") }) {
+                event.tags.asSequence()
+                    .filter { it.size >= 2 && it[0] == "t" }
+                    .mapTo(HashSet()) { it[1].lowercase() }
+            } else {
+                emptySet()
+            }
+        for (word in wordSet) {
+            if (word.startsWith("#")) {
+                val tag = word.substring(1)
+                if (tag.isNotEmpty() && tag in hashtags) return true
+                if (lowerContent.contains(word)) return true
+            } else if (lowerContent.contains(word)) {
+                return true
+            }
+        }
+        return false
     }
 
     fun muteThread(rootEventId: String) {

--- a/app/src/main/kotlin/com/darkwisp/app/viewmodel/HashtagFeedViewModel.kt
+++ b/app/src/main/kotlin/com/darkwisp/app/viewmodel/HashtagFeedViewModel.kt
@@ -117,7 +117,7 @@ class HashtagFeedViewModel(app: Application) : AndroidViewModel(app) {
                         val event = relayEvent.event
                         if (event.kind == 1 && event.id !in seenIds) {
                             if (muteRepo?.isBlocked(event.pubkey) == true) return@collect
-                            if (muteRepo?.containsMutedWord(event.content) == true) return@collect
+                            if (muteRepo?.isEventMuted(event) == true) return@collect
                             seenIds.add(event.id)
                             eventRepo.cacheEvent(event)
                             eventRepo.requestProfileIfMissing(event.pubkey)

--- a/app/src/main/kotlin/com/darkwisp/app/viewmodel/SearchViewModel.kt
+++ b/app/src/main/kotlin/com/darkwisp/app/viewmodel/SearchViewModel.kt
@@ -293,7 +293,7 @@ class SearchViewModel(app: Application) : AndroidViewModel(app) {
                             val event = relayEvent.event
                             if (event.kind == 1 && event.id !in seenNoteIds) {
                                 if (muteRepo?.isBlocked(event.pubkey) == true) return@collect
-                                if (muteRepo?.containsMutedWord(event.content) == true) return@collect
+                                if (muteRepo?.isEventMuted(event) == true) return@collect
                                 seenNoteIds.add(event.id)
                                 _notes.value = _notes.value + event
                                 eventRepo.cacheEvent(event)

--- a/app/src/main/kotlin/com/darkwisp/app/viewmodel/SocialActionManager.kt
+++ b/app/src/main/kotlin/com/darkwisp/app/viewmodel/SocialActionManager.kt
@@ -203,6 +203,10 @@ class SocialActionManager(
     }
 
     fun updateMutedWords() {
+        // Drop now-matching notes from the live feed before re-publishing,
+        // since mute filtering otherwise only happens at ingest — without
+        // this, already-displayed posts stay until the feed is refetched.
+        eventRepo.purgeMutedWords()
         publishMuteList()
     }
 


### PR DESCRIPTION
## Summary
Resolves #57.

A user reported they couldn't mute `word5` or `#657` (mini-game spam). Two root causes:

1. **Hashtag muting was broken.** `MuteRepository.containsMutedWord(content)` only substring-matched the raw event text, so muting `#657` missed posts where the hashtag is carried in a `t` tag (often with no literal `#657` in the content).
2. **Muting was ingest-only.** The filter only ran when a note was first ingested, so already-displayed posts stayed after a word was added — and `updateMutedWords()` only re-published the list; it never re-filtered the feed.

### Changes
- `MuteRepository.isEventMuted(event)` replaces `containsMutedWord`: a muted word entered with a leading `#` matches the event's lowercase `t`-tag values (the `#` stripped) or the literal text; any other word substring-matches the content. All 6 filter sites updated (feed ingest + 3 repost inner-note checks, search, hashtag feed).
- `EventRepository.purgeMutedWords()` drops now-matching notes from the live feed (mirrors `purgeThread`); wired into `updateMutedWords()` so adding/removing a word in Safety immediately clears matching posts.
- `rebuildFeedFromCache()` now re-applies the mute check, so a later rebuild can't resurrect muted posts.

## Test plan
- [ ] Settings → Safety → mute `#657`, return to the feed → tagged spam disappears immediately.
- [ ] Mute a plain word (`word5`) → posts containing it disappear from the feed.
- [ ] Remove a muted word → newly-arriving matching posts show again.
- [ ] Mute a hashtag currently being viewed in the hashtag feed → posts filter out.