### PR TITLE
fix(security): require auth for key reveal and block screen capture o…

### DIFF
--- a/app/src/main/kotlin/com/darkwisp/app/ui/component/SecureWindow.kt
+++ b/app/src/main/kotlin/com/darkwisp/app/ui/component/SecureWindow.kt
@@ -1,0 +1,33 @@
+package com.darkwisp.app.ui.component
+
+import android.app.Activity
+import android.content.Context
+import android.content.ContextWrapper
+import android.view.WindowManager
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.ui.platform.LocalContext
+
+private fun Context.findActivity(): Activity? {
+    var ctx = this
+    while (ctx is ContextWrapper) {
+        if (ctx is Activity) return ctx
+        ctx = ctx.baseContext
+    }
+    return null
+}
+
+/**
+ * Blocks screenshots, screen recording, and the recents thumbnail
+ * (FLAG_SECURE) while the calling composable is in composition. Use on any
+ * screen that can display private key material.
+ */
+@Composable
+fun SecureWindow() {
+    val activity = LocalContext.current.findActivity()
+    DisposableEffect(activity) {
+        val window = activity?.window
+        window?.addFlags(WindowManager.LayoutParams.FLAG_SECURE)
+        onDispose { window?.clearFlags(WindowManager.LayoutParams.FLAG_SECURE) }
+    }
+}

--- a/app/src/main/kotlin/com/darkwisp/app/ui/screen/AuthScreen.kt
+++ b/app/src/main/kotlin/com/darkwisp/app/ui/screen/AuthScreen.kt
@@ -66,6 +66,7 @@ import com.darkwisp.app.R
 import com.darkwisp.app.nostr.RemoteSignerBridge
 import com.darkwisp.app.nostr.toHex
 import com.darkwisp.app.ui.component.NsecPasteGuard
+import com.darkwisp.app.ui.component.SecureWindow
 import com.darkwisp.app.ui.component.TorCornerButton
 import com.darkwisp.app.viewmodel.AuthViewModel
 
@@ -80,6 +81,10 @@ fun AuthScreen(
     val nsecInput by viewModel.nsecInput.collectAsState()
     val error by viewModel.error.collectAsState()
     var nsecVisible by remember { mutableStateOf(false) }
+
+    // An nsec can be typed and made visible here — block screenshots, screen
+    // recording, and the recents thumbnail while this screen is up.
+    SecureWindow()
     val signerAvailable = remember { RemoteSignerBridge.isSignerAvailable(context) }
 
     // Track when signer login completes so we can navigate after the composable

--- a/app/src/main/kotlin/com/darkwisp/app/ui/screen/KeysScreen.kt
+++ b/app/src/main/kotlin/com/darkwisp/app/ui/screen/KeysScreen.kt
@@ -49,6 +49,7 @@ import com.darkwisp.app.nostr.Nip19
 import com.darkwisp.app.nostr.hexToByteArray
 import com.darkwisp.app.repo.KeyRepository
 import com.darkwisp.app.repo.SigningMode
+import com.darkwisp.app.ui.component.SecureWindow
 
 private fun android.content.Context.findFragmentActivity(): FragmentActivity? {
     var ctx = this
@@ -77,6 +78,10 @@ fun KeysScreen(
 
     val revealPrivateKeyTitle = stringResource(R.string.btn_reveal_private_key)
     val revealPrivateKeyDescription = stringResource(R.string.settings_authenticate_view_key)
+
+    // This screen can display the private key — block screenshots, screen
+    // recording, and the recents thumbnail while it is visible.
+    SecureWindow()
 
     // Clear nsec from memory when the composable leaves composition
     DisposableEffect(Unit) {
@@ -226,11 +231,17 @@ fun KeysScreen(
                                     ?: return@Button
 
                                 val biometricManager = BiometricManager.from(context)
-                                val canAuth = biometricManager.canAuthenticate(
+                                val authenticators = BiometricManager.Authenticators.BIOMETRIC_STRONG or
                                     BiometricManager.Authenticators.DEVICE_CREDENTIAL
-                                )
+                                val canAuth = biometricManager.canAuthenticate(authenticators)
                                 if (canAuth != BiometricManager.BIOMETRIC_SUCCESS) {
-                                    keypair?.let { nsec = Nip19.nsecEncode(it.privkey) }
+                                    // Never reveal the key without authentication — require a
+                                    // screen lock instead of falling through.
+                                    Toast.makeText(
+                                        context,
+                                        context.getString(R.string.settings_reveal_requires_lock),
+                                        Toast.LENGTH_LONG
+                                    ).show()
                                     return@Button
                                 }
 
@@ -252,7 +263,7 @@ fun KeysScreen(
                                 val promptInfo = BiometricPrompt.PromptInfo.Builder()
                                     .setTitle(revealPrivateKeyTitle)
                                     .setDescription(revealPrivateKeyDescription)
-                                    .setAllowedAuthenticators(BiometricManager.Authenticators.DEVICE_CREDENTIAL)
+                                    .setAllowedAuthenticators(authenticators)
                                     .build()
 
                                 BiometricPrompt(activity, executor, callback).authenticate(promptInfo)

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -530,6 +530,7 @@
     <string name="settings_private_key_copied">Private key copied</string>
     <string name="settings_authenticate_view_key">Authenticate to view your private key</string>
     <string name="settings_auth_failed">Authentication failed: %s</string>
+    <string name="settings_reveal_requires_lock">Set up a screen lock (PIN, pattern, or biometric) to reveal your private key.</string>
     <string name="settings_never_share_key">Never share your private key. Anyone with your nsec has full control of your account.</string>
     <string name="settings_muted_words_description">Notes containing these words will be hidden from your feed.</string>
     <string name="settings_no_muted_users">No muted users</string>


### PR DESCRIPTION
Two security hardening fixes for screens that handle the private key:

**Require authentication for "Reveal Private Key"**

The Keys screen previously fell through to revealing the nsec without any authentication when `canAuthenticate(DEVICE_CREDENTIAL)` didn't return success. That hits two real cases:

- devices with no screen lock configured
- any device on API 28–29, even with a lock set. androidx.biometric doesn't support `DEVICE_CREDENTIAL`-only prompts on those API levels (minSdk is 26)

The reveal flow now checks and prompts with `BIOMETRIC_STRONG or DEVICE_CREDENTIAL`, which:

- closes the unauthenticated fallback. if no auth method is available, the key stays hidden and a toast asks the user to set up a screen lock
- lets fingerprint/face users authenticate instead of PIN/pattern only
- works on all supported API levels

**Block screen capture on key-exposing screens (FLAG_SECURE)**

New `SecureWindow()` composable sets `FLAG_SECURE` on the activity window while it's in composition and clears it on dispose. Applied to:

- **KeysScreen** displays the revealed nsec
- **AuthScreen** nsec can be typed and toggled visible

This blocks screenshots, screen recording / media-projection capture, and the recents-screen thumbnail while key material can be on screen.
