### PR TITLE
fix(keys): key-handling polish: clear typed key on exit, clipboard clear

### DIFF
--- a/app/src/main/kotlin/com/darkwisp/app/ui/screen/AuthScreen.kt
+++ b/app/src/main/kotlin/com/darkwisp/app/ui/screen/AuthScreen.kt
@@ -1,5 +1,6 @@
 package com.darkwisp.app.ui.screen
 
+import android.widget.Toast
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.Image
@@ -111,7 +112,12 @@ fun AuthScreen(
 
     DisposableEffect(Unit) {
         NsecPasteGuard.nsecPasteAllowed = true
-        onDispose { NsecPasteGuard.nsecPasteAllowed = false }
+        onDispose {
+            NsecPasteGuard.nsecPasteAllowed = false
+            // Don't let a typed-but-unsubmitted key linger in the ViewModel
+            // after the user backs out of this screen.
+            viewModel.updateNsecInput("")
+        }
     }
 
     Box(modifier = Modifier.fillMaxSize()) {
@@ -207,7 +213,19 @@ fun AuthScreen(
     
             OutlinedButton(
                 onClick = {
-                    if (viewModel.logIn()) onAuthenticated(false)
+                    if (viewModel.logIn()) {
+                        // npub/hex logins are watch-only; say so explicitly. A
+                        // pasted hex private key is indistinguishable from a
+                        // pubkey and would otherwise silently lack posting.
+                        if (viewModel.keyRepo.isReadOnly()) {
+                            Toast.makeText(
+                                context,
+                                context.getString(R.string.auth_read_only_notice),
+                                Toast.LENGTH_LONG
+                            ).show()
+                        }
+                        onAuthenticated(false)
+                    }
                 },
                 modifier = Modifier.fillMaxWidth()
             ) {

--- a/app/src/main/kotlin/com/darkwisp/app/ui/screen/KeysScreen.kt
+++ b/app/src/main/kotlin/com/darkwisp/app/ui/screen/KeysScreen.kt
@@ -4,6 +4,8 @@ import android.content.ClipData
 import android.content.ClipboardManager
 import android.content.ContextWrapper
 import android.os.Build
+import android.os.Handler
+import android.os.Looper
 import android.os.PersistableBundle
 import android.widget.Toast
 import androidx.biometric.BiometricManager
@@ -49,6 +51,8 @@ import com.darkwisp.app.nostr.Nip19
 import com.darkwisp.app.nostr.hexToByteArray
 import com.darkwisp.app.repo.KeyRepository
 import com.darkwisp.app.repo.SigningMode
+
+private const val NSEC_CLIPBOARD_CLEAR_MS = 60_000L
 
 private fun android.content.Context.findFragmentActivity(): FragmentActivity? {
     var ctx = this
@@ -208,7 +212,27 @@ fun KeysScreen(
                                         }
                                         val cm = context.getSystemService(ClipboardManager::class.java)
                                         cm.setPrimaryClip(clip)
-                                        Toast.makeText(context, context.getString(R.string.settings_private_key_copied), Toast.LENGTH_SHORT).show()
+                                        Toast.makeText(context, context.getString(R.string.settings_private_key_copied_autoclear), Toast.LENGTH_SHORT).show()
+                                        // Auto-clear so the key doesn't sit on the clipboard
+                                        // indefinitely. Only clears if the clipboard still holds
+                                        // this key, leaving any newer copy alone. On Android 10+
+                                        // clipboard access requires focus, so if the app is in
+                                        // the background at that point the clear is skipped.
+                                        Handler(Looper.getMainLooper()).postDelayed({
+                                            val current = try {
+                                                cm.primaryClip?.takeIf { it.itemCount > 0 }
+                                                    ?.getItemAt(0)?.text?.toString()
+                                            } catch (_: SecurityException) {
+                                                null
+                                            }
+                                            if (current == key) {
+                                                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
+                                                    cm.clearPrimaryClip()
+                                                } else {
+                                                    cm.setPrimaryClip(ClipData.newPlainText("", ""))
+                                                }
+                                            }
+                                        }, NSEC_CLIPBOARD_CLEAR_MS)
                                     }
                                 }) {
                                     Icon(

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -68,6 +68,7 @@
     <string name="auth_tagline">a wee interface to scroll posts</string>
     <string name="auth_hide_key">Hide key</string>
     <string name="auth_show_key">Show key</string>
+    <string name="auth_read_only_notice">Logged in read-only with a public key. You can browse, but posting and reactions are disabled.</string>
 
     <!-- Buttons -->
     <string name="btn_continue">Continue</string>
@@ -528,6 +529,7 @@
     <string name="settings_private_key">Private Key</string>
     <string name="settings_public_key_copied">Public key copied</string>
     <string name="settings_private_key_copied">Private key copied</string>
+    <string name="settings_private_key_copied_autoclear">Private key copied. Clipboard clears in 60 seconds.</string>
     <string name="settings_authenticate_view_key">Authenticate to view your private key</string>
     <string name="settings_auth_failed">Authentication failed: %s</string>
     <string name="settings_never_share_key">Never share your private key. Anyone with your nsec has full control of your account.</string>


### PR DESCRIPTION
Three small key-handling improvements, follow-ups from a security review of the key creation and storage flow.

- **Clear typed key on exit**: a typed-but-unsubmitted nsec previously stayed in the AuthViewModel until process death after backing out of the login screen. It is now cleared when the screen leaves composition.
- **Clipboard auto-clear**: copying the nsec on the Keys screen now clears the clipboard after 60 seconds. The clear only fires if the clipboard still holds that key, so anything copied afterwards is untouched. On Android 10+ the clear is skipped if the app is backgrounded at that moment (OS clipboard restriction).
- **Read-only login notice**: logging in with an npub or 64-char hex now shows a toast explaining the session is watch-only. A pasted hex *private* key is indistinguishable from a pubkey, and previously produced a silent read-only session with no hint that posting would fail.