### PR TITLE
fix(relay): gate publish success on NIP-20 OK instead of socket enqueue

### DIFF
--- a/app/src/main/kotlin/com/darkwisp/app/relay/RelayPool.kt
+++ b/app/src/main/kotlin/com/darkwisp/app/relay/RelayPool.kt
@@ -8,6 +8,7 @@ import com.darkwisp.app.repo.DiagnosticLogger
 import com.darkwisp.app.nostr.NostrEvent
 import com.darkwisp.app.nostr.RelayMessage
 import com.darkwisp.app.nostr.RelayMessage.Auth
+import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
@@ -28,6 +29,7 @@ import java.util.concurrent.CopyOnWriteArrayList
 
 data class RelayEvent(val event: NostrEvent, val relayUrl: String, val subscriptionId: String)
 data class PublishResult(val relayUrl: String, val eventId: String, val accepted: Boolean, val message: String)
+data class PublishOutcome(val sentCount: Int, val confirmed: Boolean)
 data class BroadcastState(val accepted: Int, val sent: Int)
 
 class RelayPool(private val prefs: SharedPreferences? = null) {
@@ -131,6 +133,8 @@ class RelayPool(private val prefs: SharedPreferences? = null) {
         const val MAX_PERSISTENT = 30
         const val MAX_DM_RELAYS = 10
         const val MAX_EPHEMERAL = 50
+        /** How long publishWithConfirmation waits for the first accepted OK. */
+        const val PUBLISH_OK_TIMEOUT_MS = 8000L
         const val COOLDOWN_DOWN_MS = 10 * 60 * 1000L    // 10 min — 5xx, connection failures (ephemeral only)
         const val COOLDOWN_REJECTED_MS = 1 * 60 * 1000L // 1 min — 4xx like 401/403/429
         const val COOLDOWN_NETWORK_MS = 5_000L           // 5s — DNS/network failures on persistent relays
@@ -736,6 +740,85 @@ class RelayPool(private val prefs: SharedPreferences? = null) {
             delay(1500)
             _broadcastState.value = null
         }
+    }
+
+    /**
+     * Runs [send] and waits for the first accepted NIP-20 OK for [eventId].
+     *
+     * The OK collector is started BEFORE [send] runs so a fast acknowledgment
+     * cannot be missed. While waiting it also drives [broadcastState] for the
+     * broadcast pill, replacing [trackPublish] for callers of this method.
+     *
+     * Returns the sent count from [send] plus whether any relay accepted the
+     * event within [timeoutMs]. An unconfirmed outcome means no relay
+     * acknowledged the event; with a half-open socket (e.g. after device
+     * sleep) OkHttp still reports the enqueue as successful, so this is the
+     * only reliable delivery signal.
+     */
+    suspend fun publishWithConfirmation(
+        eventId: String,
+        timeoutMs: Long = PUBLISH_OK_TIMEOUT_MS,
+        send: () -> Int
+    ): PublishOutcome {
+        val firstAccepted = CompletableDeferred<Unit>()
+        var accepted = 0
+        var sent = 0
+        val collector = scope.launch {
+            publishResults
+                .filter { it.eventId == eventId }
+                .collect { result ->
+                    if (result.accepted) {
+                        accepted++
+                        if (!firstAccepted.isCompleted) firstAccepted.complete(Unit)
+                    }
+                    _broadcastState.value = BroadcastState(accepted = accepted, sent = sent)
+                }
+        }
+        sent = send()
+        if (sent == 0) {
+            collector.cancel()
+            return PublishOutcome(0, false)
+        }
+        _broadcastState.value = BroadcastState(accepted = accepted, sent = sent)
+        val confirmed = withTimeoutOrNull(timeoutMs) {
+            firstAccepted.await()
+            true
+        } ?: false
+        // Keep counting straggler OKs for the pill briefly, then clear it
+        // (mirrors trackPublish's lifecycle).
+        scope.launch {
+            delay(4000)
+            collector.cancel()
+            delay(1500)
+            _broadcastState.value = null
+        }
+        return PublishOutcome(sent, confirmed)
+    }
+
+    /**
+     * Force-reconnects all write relays by tearing down their sockets and
+     * reconnecting. Unlike [ensureWriteRelaysConnected], this also recycles
+     * relays whose [Relay.isConnected] flag is stale (half-open TCP after
+     * device sleep, where OkHttp has not yet noticed the dead socket).
+     * Returns the number of write relays connected after waiting up to
+     * [timeoutMs].
+     */
+    suspend fun cycleWriteRelays(timeoutMs: Long = 5000): Int {
+        val writeRelays = relays.filter { it.config.write }
+        if (writeRelays.isEmpty()) return 0
+        Log.d("RLC", "[Pool] cycleWriteRelays — recycling ${writeRelays.size} write relay socket(s)")
+        for (relay in writeRelays) {
+            relay.forceDisconnect()
+            relay.resetBackoff()
+            relay.connect()
+        }
+        val deadline = System.currentTimeMillis() + timeoutMs
+        while (System.currentTimeMillis() < deadline) {
+            val connected = writeRelays.count { it.isConnected }
+            if (connected > 0) return connected
+            delay(200)
+        }
+        return writeRelays.count { it.isConnected }
     }
 
     fun sendToReadRelays(message: String) {

--- a/app/src/main/kotlin/com/darkwisp/app/viewmodel/ComposeViewModel.kt
+++ b/app/src/main/kotlin/com/darkwisp/app/viewmodel/ComposeViewModel.kt
@@ -861,28 +861,45 @@ class ComposeViewModel(app: Application, private val savedStateHandle: SavedStat
         val event = signer.signEvent(kind = eventKind, content = finalContent, tags = tags)
         android.util.Log.d("GALLERY", "[ComposeVM] publishNote kind=$eventKind id=${event.id.take(12)} content='${finalContent.take(50)}' tags=${tags.size} galleryMode=${_galleryMode.value} uploadedUrls=${_uploadedUrls.value.size}")
         val msg = ClientMessage.event(event)
-        var sentCount = if (outboxRouter != null && inboxPubkeys.isNotEmpty()) {
-            outboxRouter.publishToInbox(msg, inboxPubkeys)
-        } else {
-            relayPool.sendToWriteRelays(msg)
-        }
-        // If no relays were reachable, try reconnecting write relays and retry once
-        if (sentCount == 0) {
-            val reconnected = relayPool.ensureWriteRelaysConnected()
-            if (reconnected > 0) {
-                sentCount = if (outboxRouter != null && inboxPubkeys.isNotEmpty()) {
-                    outboxRouter.publishToInbox(msg, inboxPubkeys)
-                } else {
-                    relayPool.sendToWriteRelays(msg)
-                }
+        val doSend = {
+            if (outboxRouter != null && inboxPubkeys.isNotEmpty()) {
+                outboxRouter.publishToInbox(msg, inboxPubkeys)
+            } else {
+                relayPool.sendToWriteRelays(msg)
             }
         }
-        if (sentCount == 0) {
+        // Success is gated on a NIP-20 OK from at least one relay. A send that
+        // merely enqueued into OkHttp is not delivery: after device sleep the
+        // sockets can be half-open, where isConnected is stale and the enqueue
+        // "succeeds" into a connection the relay already dropped.
+        var outcome = relayPool.publishWithConfirmation(event.id, send = doSend)
+        // If no relays were reachable, try reconnecting write relays and retry once
+        if (outcome.sentCount == 0) {
+            val reconnected = relayPool.ensureWriteRelaysConnected()
+            if (reconnected > 0) {
+                outcome = relayPool.publishWithConfirmation(event.id, send = doSend)
+            }
+        }
+        if (outcome.sentCount == 0) {
             _error.value = getApplication<Application>().getString(R.string.error_no_relays_connected)
             _publishing.value = false
             return 0
         }
-        relayPool.trackPublish(event.id, sentCount)
+        if (!outcome.confirmed) {
+            // Sent but nothing acknowledged: recycle the write sockets and
+            // resend the same signed event. Relays dedupe by event id, so a
+            // resend can never duplicate the note.
+            if (relayPool.cycleWriteRelays() > 0) {
+                outcome = relayPool.publishWithConfirmation(event.id, send = doSend)
+            }
+        }
+        if (!outcome.confirmed) {
+            // Keep the composed text and publishing state intact so the user
+            // can retry instead of silently losing the note.
+            _error.value = getApplication<Application>().getString(R.string.error_publish_unconfirmed)
+            _publishing.value = false
+            return 0
+        }
         // Insert into feed so the note appears immediately without waiting for relay echo
         eventRepo?.addEvent(event)
         if (replyTo != null) {
@@ -901,7 +918,7 @@ class ComposeViewModel(app: Application, private val savedStateHandle: SavedStat
         _uploadedMediaMeta.clear()
         _error.value = null
         _publishing.value = false
-        return sentCount
+        return outcome.sentCount
     }
 
     private suspend fun publishPrivateReply(

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -714,6 +714,7 @@
     <string name="error_poll_options">Poll needs at least 2 options</string>
     <string name="error_scheduler_relay">Could not connect to scheduler relay</string>
     <string name="error_no_relays_connected">No relays connected — note was not published</string>
+    <string name="error_publish_unconfirmed">No relay confirmed your note. Check your connection and tap Publish to retry.</string>
 
     <!-- Logout Warning -->
     <string name="logout_warning">Make sure you\'ve backed up your private key before logging out. You can find it in Keys settings. Without it, you won\'t be able to recover your account.</string>


### PR DESCRIPTION
After device sleep, relay sockets can be half-open: isConnected is stale and OkHttp's WebSocket.send() returns true for messages enqueued into a connection the relay already dropped. sendToWriteRelays counted those as sent, so the UI reported success for notes that never reached any relay.

- RelayPool.publishWithConfirmation() starts an OK collector before sending (a fast acknowledgment cannot be missed), drives the existing broadcastState pill, and reports whether any relay accepted the event within 8s
- RelayPool.cycleWriteRelays() force-reconnects write relay sockets, covering the half-open case where ensureWriteRelaysConnected sees a stale isConnected and does nothing
- ComposeViewModel.publishNote now requires an accepted OK: on timeout it recycles the write sockets and resends the same signed event (idempotent by event id), and if still unconfirmed it keeps the composed text and shows an error instead of claiming success