### PR TITLE
feat(notifications): expanded feed by default, with a compact toggle

### DIFF
--- a/app/src/main/kotlin/com/darkwisp/app/repo/InterfacePreferences.kt
+++ b/app/src/main/kotlin/com/darkwisp/app/repo/InterfacePreferences.kt
@@ -13,6 +13,23 @@ class InterfacePreferences(context: Context) {
         }
     }
 
+    /** How the notifications list renders each row. */
+    enum class NotificationFeedStyle(val key: String) {
+        /**
+         * Every row renders its detail (referenced note, zap message, poll,
+         * reply composer) inline without a tap — the default.
+         */
+        EXPANDED("expanded"),
+
+        /** One-line rows; tapping opens a single row at a time (accordion). */
+        COMPACT("compact");
+
+        companion object {
+            fun fromKey(key: String?): NotificationFeedStyle =
+                values().firstOrNull { it.key == key } ?: EXPANDED
+        }
+    }
+
     private val prefs = context.getSharedPreferences("wisp_settings", Context.MODE_PRIVATE)
 
     fun getAccentColor(): Int = prefs.getInt("accent_color", 0xFFFF9800.toInt())
@@ -40,6 +57,17 @@ class InterfacePreferences(context: Context) {
         MediaLayoutStyle.fromKey(prefs.getString("media_layout_style", null))
     fun setMediaLayoutStyle(style: MediaLayoutStyle) =
         prefs.edit().putString("media_layout_style", style.key).apply()
+
+    /**
+     * Display density of the notifications list. Defaults to
+     * [NotificationFeedStyle.EXPANDED] so the feed reads end-to-end without
+     * tapping every row; the user can flip back to the accordion from the
+     * notifications top bar or from interface settings.
+     */
+    fun getNotificationFeedStyle(): NotificationFeedStyle =
+        NotificationFeedStyle.fromKey(prefs.getString(KEY_NOTIFICATION_FEED_STYLE, null))
+    fun setNotificationFeedStyle(style: NotificationFeedStyle) =
+        prefs.edit().putString(KEY_NOTIFICATION_FEED_STYLE, style.key).apply()
 
     fun getLanguage(): String = prefs.getString("language", "system") ?: "system"
     fun setLanguage(language: String) = prefs.edit().putString("language", language).apply()
@@ -132,6 +160,12 @@ class InterfacePreferences(context: Context) {
         @Volatile var activePubkey: String? = null
         val postUndoTimerOptions = listOf(5, 10, 15, 20, 30)
         const val QUICK_ZAP_MAX_SATS = 10_000L
+
+        /**
+         * Pref key backing [NotificationFeedStyle]. Public so observers can
+         * filter their `OnSharedPreferenceChangeListener` callbacks by it.
+         */
+        const val KEY_NOTIFICATION_FEED_STYLE = "notification_feed_style"
     }
 
     /** Reset all interface preferences to defaults (called on full logout). */
@@ -149,6 +183,7 @@ class InterfacePreferences(context: Context) {
             .remove("post_undo_timer_seconds")
             .remove("post_undo_timer_for_replies")
             .remove("media_layout_style")
+            .remove(KEY_NOTIFICATION_FEED_STYLE)
             .apply()
     }
 }

--- a/app/src/main/kotlin/com/darkwisp/app/ui/screen/InterfaceScreen.kt
+++ b/app/src/main/kotlin/com/darkwisp/app/ui/screen/InterfaceScreen.kt
@@ -105,6 +105,7 @@ fun InterfaceScreen(
     var videoAutoPlay by remember { mutableStateOf(interfacePrefs.isVideoAutoPlay()) }
     var mediaLayout by remember { mutableStateOf(interfacePrefs.getMediaLayoutStyle()) }
     var liveStreamsHidden by remember { mutableStateOf(interfacePrefs.isLiveStreamsHidden()) }
+    var notifFeedStyle by remember { mutableStateOf(interfacePrefs.getNotificationFeedStyle()) }
     var selectedTheme by remember { mutableStateOf(interfacePrefs.getTheme()) }
     var isCustomTheme by remember { mutableStateOf(selectedTheme == "custom") }
     var selectedLanguage by remember { mutableStateOf(interfacePrefs.getLanguage()) }
@@ -520,6 +521,47 @@ fun InterfaceScreen(
                     },
                     colors = wispSwitchColors()
                 )
+            }
+
+            Spacer(Modifier.height(24.dp))
+
+            // Notifications section
+            Text(
+                text = stringResource(R.string.settings_notifications),
+                style = MaterialTheme.typography.titleMedium,
+                color = MaterialTheme.colorScheme.onSurface
+            )
+            Spacer(Modifier.height(8.dp))
+            Column(modifier = Modifier.fillMaxWidth()) {
+                Text(stringResource(R.string.settings_notif_list_style), style = MaterialTheme.typography.bodyMedium)
+                Text(
+                    stringResource(R.string.settings_notif_list_style_description),
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+                Spacer(Modifier.height(8.dp))
+                val notifStyleOptions = listOf(
+                    InterfacePreferences.NotificationFeedStyle.EXPANDED to R.string.settings_notif_list_style_expanded,
+                    InterfacePreferences.NotificationFeedStyle.COMPACT to R.string.settings_notif_list_style_compact
+                )
+                SingleChoiceSegmentedButtonRow(modifier = Modifier.fillMaxWidth()) {
+                    notifStyleOptions.forEachIndexed { index, (style, labelRes) ->
+                        SegmentedButton(
+                            selected = notifFeedStyle == style,
+                            onClick = {
+                                notifFeedStyle = style
+                                interfacePrefs.setNotificationFeedStyle(style)
+                                onChanged()
+                            },
+                            shape = SegmentedButtonDefaults.itemShape(
+                                index = index,
+                                count = notifStyleOptions.size
+                            )
+                        ) {
+                            Text(stringResource(labelRes))
+                        }
+                    }
+                }
             }
 
             Spacer(Modifier.height(24.dp))

--- a/app/src/main/kotlin/com/darkwisp/app/ui/screen/NotificationsScreen.kt
+++ b/app/src/main/kotlin/com/darkwisp/app/ui/screen/NotificationsScreen.kt
@@ -45,6 +45,8 @@ import androidx.compose.material.icons.outlined.AddReaction
 import androidx.compose.material.icons.outlined.MailOutline
 import androidx.compose.material.icons.outlined.Repeat
 import androidx.compose.material.icons.outlined.Tune
+import androidx.compose.material.icons.outlined.UnfoldLess
+import androidx.compose.material.icons.outlined.UnfoldMore
 import androidx.compose.ui.text.TextRange
 import androidx.compose.ui.text.input.TextFieldValue
 import com.darkwisp.app.ui.component.EmojiReactionPopup
@@ -97,6 +99,7 @@ import com.darkwisp.app.nostr.NotificationSummary
 import com.darkwisp.app.nostr.NotificationType
 import com.darkwisp.app.nostr.ProfileData
 import com.darkwisp.app.repo.EventRepository
+import com.darkwisp.app.repo.InterfacePreferences
 import com.darkwisp.app.repo.Nip05Repository
 import com.darkwisp.app.repo.TranslationRepository
 import com.darkwisp.app.ui.component.GalleryCard
@@ -200,8 +203,12 @@ fun NotificationsScreen(
     var showFilterSheet by remember { mutableStateOf(false) }
     val profileVersion = eventRepo?.profileVersion?.collectAsState()?.value ?: 0
 
-    // Track which notification is expanded (only one at a time)
-    var expandedId by rememberSaveable { mutableStateOf<String?>(null) }
+    // Row expansion lives on the view model, which resolves each row against
+    // the current feed style — expanded-by-default, or the one-at-a-time
+    // accordion. See NotificationsViewModel.isRowExpanded.
+    val feedStyle by viewModel.feedStyle.collectAsState()
+    val collapsedIds by viewModel.collapsedItemIds.collectAsState()
+    val expandedId by viewModel.expandedItemId.collectAsState()
 
     // Track inline replies sent by user: replyEventId -> list of sent content strings
     var inlineReplies by remember { mutableStateOf(mapOf<String, List<String>>()) }
@@ -308,12 +315,15 @@ fun NotificationsScreen(
                     Row(verticalAlignment = Alignment.CenterVertically) {
                         Text(
                             stringResource(R.string.nav_notifications),
-                            style = MaterialTheme.typography.titleMedium
+                            style = MaterialTheme.typography.titleMedium,
+                            maxLines = 1
                         )
                         Text(
-                            text = "  |  24h",
+                            text = " · 24h",
                             style = MaterialTheme.typography.titleSmall,
-                            color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.5f)
+                            color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.5f),
+                            maxLines = 1,
+                            softWrap = false
                         )
                     }
                 },
@@ -323,6 +333,19 @@ fun NotificationsScreen(
                     }
                 },
                 actions = {
+                    val isExpandedFeed = feedStyle == InterfacePreferences.NotificationFeedStyle.EXPANDED
+                    IconButton(onClick = {
+                        viewModel.setFeedStyle(
+                            if (isExpandedFeed) InterfacePreferences.NotificationFeedStyle.COMPACT
+                            else InterfacePreferences.NotificationFeedStyle.EXPANDED
+                        )
+                    }) {
+                        Icon(
+                            if (isExpandedFeed) Icons.Outlined.UnfoldLess else Icons.Outlined.UnfoldMore,
+                            contentDescription = if (isExpandedFeed) stringResource(R.string.cd_notif_style_compact)
+                                                 else stringResource(R.string.cd_notif_style_expanded)
+                        )
+                    }
                     val allEnabled = enabledTypes.size == NotificationFilter.entries.size && chatRoomsEnabled
                     IconButton(onClick = { showFilterSheet = true }) {
                         Icon(
@@ -386,7 +409,7 @@ fun NotificationsScreen(
                     )
                 }
                 itemsIndexed(items = notifications, key = { _, it -> it.id }, contentType = { _, _ -> "notification" }) { index, item ->
-                    val isExpanded = expandedId == item.id
+                    val isExpanded = viewModel.isRowExpanded(item, feedStyle, collapsedIds, expandedId)
                     val itemIndex = index + 1 // +1 for summary header
                     val coroutineScope = rememberCoroutineScope()
                     ZenNotificationRow(
@@ -404,7 +427,7 @@ fun NotificationsScreen(
                             if (item.type == NotificationType.DM_REACTION && item.dmPeerPubkey != null) {
                                 onDmConversationClick(item.dmPeerPubkey)
                             } else {
-                                expandedId = if (isExpanded) null else item.id
+                                viewModel.toggleRowExpansion(item)
                             }
                         },
                         onProfileClick = onProfileClick,

--- a/app/src/main/kotlin/com/darkwisp/app/viewmodel/NotificationsViewModel.kt
+++ b/app/src/main/kotlin/com/darkwisp/app/viewmodel/NotificationsViewModel.kt
@@ -2,6 +2,7 @@ package com.darkwisp.app.viewmodel
 
 import android.app.Application
 import android.content.Context
+import android.content.SharedPreferences
 import android.util.Log
 import androidx.lifecycle.AndroidViewModel
 import androidx.lifecycle.viewModelScope
@@ -24,6 +25,7 @@ import com.darkwisp.app.relay.RelayPool
 import com.darkwisp.app.repo.ContactRepository
 import com.darkwisp.app.repo.DmRepository
 import com.darkwisp.app.repo.EventRepository
+import com.darkwisp.app.repo.InterfacePreferences
 import com.darkwisp.app.repo.KeyRepository
 import com.darkwisp.app.repo.MentionCandidate
 import com.darkwisp.app.repo.MentionSearchRepository
@@ -130,6 +132,109 @@ class NotificationsViewModel(app: Application) : AndroidViewModel(app) {
 
     private val _mentionCandidates = MutableStateFlow<List<MentionCandidate>>(emptyList())
     val mentionCandidates: StateFlow<List<MentionCandidate>> = _mentionCandidates
+
+    // ── Row expansion / feed style ──────────────────────────────────────
+
+    private val interfacePrefs = InterfacePreferences(app)
+
+    private val _feedStyle = MutableStateFlow(interfacePrefs.getNotificationFeedStyle())
+    val feedStyle: StateFlow<InterfacePreferences.NotificationFeedStyle> = _feedStyle
+
+    /**
+     * Rows the user manually folded shut while the feed is
+     * [InterfacePreferences.NotificationFeedStyle.EXPANDED] — the inverse of
+     * [expandedItemId], and without the accordion constraint, so collapsing one
+     * row leaves the rest open. Session-only: what persists is the style
+     * itself, not per-row state.
+     */
+    private val _collapsedItemIds = MutableStateFlow<Set<String>>(emptySet())
+    val collapsedItemIds: StateFlow<Set<String>> = _collapsedItemIds
+
+    /**
+     * Id of the single open row while the feed is
+     * [InterfacePreferences.NotificationFeedStyle.COMPACT] (or of the open DM
+     * row in either style), or null when none is open — opening one closes any
+     * other.
+     */
+    private val _expandedItemId = MutableStateFlow<String?>(null)
+    val expandedItemId: StateFlow<String?> = _expandedItemId
+
+    /**
+     * Interface settings writes the style straight to prefs, so mirror it back
+     * into [feedStyle] rather than leaving this view model — which outlives the
+     * notifications screen — holding the value from when it was created.
+     */
+    private val prefsListener = SharedPreferences.OnSharedPreferenceChangeListener { _, key ->
+        if (key == InterfacePreferences.KEY_NOTIFICATION_FEED_STYLE) {
+            val style = interfacePrefs.getNotificationFeedStyle()
+            if (style != _feedStyle.value) applyFeedStyle(style)
+        }
+    }
+
+    init {
+        settingsPrefs.registerOnSharedPreferenceChangeListener(prefsListener)
+    }
+
+    override fun onCleared() {
+        settingsPrefs.unregisterOnSharedPreferenceChangeListener(prefsListener)
+        super.onCleared()
+    }
+
+    /**
+     * Whether [item]'s detail should render. Resolved against state the caller
+     * has already collected ([feedStyle], [collapsedItemIds], [expandedItemId])
+     * so rows recompose when any of it changes.
+     *
+     * In EXPANDED every row is open unless the user folded it shut; in COMPACT
+     * only the accordion's single open row is.
+     */
+    fun isRowExpanded(
+        item: FlatNotificationItem,
+        style: InterfacePreferences.NotificationFeedStyle,
+        collapsedIds: Set<String>,
+        expandedId: String?
+    ): Boolean =
+        if (style == InterfacePreferences.NotificationFeedStyle.EXPANDED && autoExpands(item)) {
+            item.id !in collapsedIds
+        } else {
+            expandedId == item.id
+        }
+
+    /** Flip [item]'s open/closed state within the current style. */
+    fun toggleRowExpansion(item: FlatNotificationItem) {
+        if (_feedStyle.value == InterfacePreferences.NotificationFeedStyle.EXPANDED && autoExpands(item)) {
+            val collapsed = _collapsedItemIds.value
+            _collapsedItemIds.value =
+                if (item.id in collapsed) collapsed - item.id else collapsed + item.id
+        } else {
+            _expandedItemId.value = if (_expandedItemId.value == item.id) null else item.id
+        }
+    }
+
+    /**
+     * Switch list density and persist it. Per-row overrides accumulated under
+     * the previous style are dropped so the new style starts from its own
+     * baseline (everything open / everything closed).
+     */
+    fun setFeedStyle(style: InterfacePreferences.NotificationFeedStyle) {
+        if (style == _feedStyle.value) return
+        applyFeedStyle(style)
+        interfacePrefs.setNotificationFeedStyle(style)
+    }
+
+    private fun applyFeedStyle(style: InterfacePreferences.NotificationFeedStyle) {
+        _feedStyle.value = style
+        _collapsedItemIds.value = emptySet()
+        _expandedItemId.value = null
+    }
+
+    /**
+     * DM rows stay shut until tapped even in the expanded feed: their expansion
+     * is a live conversation with its own composer, so opening every one at
+     * once would stack the screen with message threads and text fields.
+     */
+    private fun autoExpands(item: FlatNotificationItem): Boolean =
+        item.type != NotificationType.DM
 
     fun init(
         notificationRepository: NotificationRepository,

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -266,6 +266,8 @@
     <string name="cd_seen_on">Seen on</string>
     <string name="cd_sent_with">Sent with</string>
     <string name="cd_filter_notifications">Filter notifications</string>
+    <string name="cd_notif_style_compact">Switch to compact notifications</string>
+    <string name="cd_notif_style_expanded">Switch to expanded notifications</string>
     <string name="filter_all">All</string>
     <string name="filter_replies">Replies</string>
     <string name="filter_zaps">Zaps</string>
@@ -515,6 +517,13 @@
     <string name="settings_media_layout_stack">Stack</string>
     <string name="settings_hide_live_streams">Hide live streams</string>
     <string name="settings_hide_live_streams_description">Hide the live streams row from the top of your feed</string>
+    <!-- Notifications display -->
+    <string name="settings_notifications">Notifications</string>
+    <string name="settings_notif_list_style">List style</string>
+    <string name="settings_notif_list_style_description">Expanded: every notification shows its note, zap message, or poll inline. Compact: one-line rows you tap to open.</string>
+    <string name="settings_notif_list_style_expanded">Expanded</string>
+    <string name="settings_notif_list_style_compact">Compact</string>
+
     <string name="settings_client_tag">Client Tag</string>
     <string name="settings_tag_notes">Tag notes with Dark Wisp</string>
     <string name="settings_tag_notes_description">Include a tag identifying Dark Wisp as the client. This is visible to others.</string>


### PR DESCRIPTION
## Summary

Notification rows shipped collapsed, so reading the feed meant tapping every row open one at a time. This flips the default: each row now renders its detail (referenced note, zap message, poll, reply composer) inline, and the accordion becomes an opt-in "compact" style.

## Changes

- **`InterfacePreferences.NotificationFeedStyle`** (EXPANDED default) persists the choice to SharedPreferences, so it survives relaunch. Cleared on logout with the other interface prefs.
- **`NotificationsViewModel`** owns the per-row resolution: EXPANDED opens everything except rows the user folded shut (`collapsedItemIds`), COMPACT keeps the single-open-row `expandedItemId` accordion. Style switches reset the per-row overrides to the new style's baseline. The view model mirrors prefs changes back via an `OnSharedPreferenceChangeListener`, so a switch made in interface settings reaches an already-created notifications screen.
- **Two entry points**: a top-bar toggle on the notifications screen (`UnfoldLess`/`UnfoldMore`), or Interface settings → Notifications → List style.
- **DM rows stay shut until tapped in both styles** — their expansion is a live conversation with its own composer, so a feed full of them would stack the screen with message threads and text fields.

## Test plan

The feature was validated end-to-end on a physical device in the upstream wisp app, where the same change is under review — expanded default, top-bar toggle both directions, persistence across a force-stop, and a clean logcat. This port is line-for-line equivalent, adapted only where the settings screen layout differs.

- [x] `./gradlew assembleDebug` — green
- [ ] Notifications open **expanded** on first run; reaction/zap/poll/reply rows show their detail inline
- [ ] Top-bar toggle switches to **compact** (one-line rows, accordion opens one at a time) and back
- [ ] Style persists across app restart
- [ ] Interface settings → Notifications → List style changes the style and reaches an open notifications screen
- [ ] DM rows stay collapsed until tapped in both styles
