### PR TITLE
fix(wallet): never report an unsettled payment as sent

### DIFF
--- a/app/src/main/kotlin/com/darkwisp/app/repo/NwcRepository.kt
+++ b/app/src/main/kotlin/com/darkwisp/app/repo/NwcRepository.kt
@@ -344,11 +344,16 @@ class NwcRepository(private val context: Context, private val relayPool: RelayPo
         )
     }
 
-    override suspend fun payInvoice(bolt11: String): Result<String> {
+    override suspend fun payInvoice(bolt11: String): Result<WalletPayment> {
         // Payments can take minutes to settle — don't use the default 10s timeout.
         // A timeout here does NOT mean the payment failed; the wallet may still complete it.
         val result = sendRequest(Nip47.NwcRequest.PayInvoice(bolt11), timeoutMs = 0)
-        return result.map { (it as Nip47.NwcResponse.PayInvoiceResult).preimage }
+        // NIP-47 pay_invoice only yields a preimage once the payment settled,
+        // so a response here is genuinely COMPLETED — unlike Spark, which can
+        // return an in-flight payment.
+        return result.map {
+            WalletPayment((it as Nip47.NwcResponse.PayInvoiceResult).preimage, PaymentSettlement.COMPLETED)
+        }
     }
 
     override suspend fun makeInvoice(amountMsats: Long, description: String, expirySecs: Int): Result<String> {
@@ -371,7 +376,12 @@ class NwcRepository(private val context: Context, private val relayPool: RelayPo
                     amountMsats = tx.amount,
                     feeMsats = tx.feesPaid,
                     createdAt = tx.createdAt,
-                    settledAt = tx.settledAt
+                    settledAt = tx.settledAt,
+                    // NIP-47 list_transactions returns settled and in-flight
+                    // payments and leaves settled_at null until one settles;
+                    // it has no failed state to report.
+                    status = if (tx.settledAt == null) TransactionStatus.PENDING
+                    else TransactionStatus.COMPLETED
                 )
             }
         }

--- a/app/src/main/kotlin/com/darkwisp/app/repo/SparkRepository.kt
+++ b/app/src/main/kotlin/com/darkwisp/app/repo/SparkRepository.kt
@@ -362,7 +362,33 @@ class SparkRepository(
 
     // --- Send ---
 
-    override suspend fun payInvoice(bolt11: String): Result<String> = withContext(Dispatchers.IO) {
+    /**
+     * Map an SDK payment to a settlement outcome.
+     *
+     * `sendPayment` waits up to `completionTimeoutSecs` and then returns
+     * whatever status it has: a payment that cannot settle — a second attempt
+     * on an already-settled invoice, for instance — comes back PENDING, and
+     * FAILED comes back without throwing. Reading only `payment.id` and
+     * calling every non-throwing response a success told the user sats had
+     * left their wallet when they had not.
+     */
+    private fun settlementOf(payment: breez_sdk_spark.Payment): Result<WalletPayment> =
+        when (payment.status) {
+            breez_sdk_spark.PaymentStatus.COMPLETED -> {
+                emitStatus("Payment completed")
+                Result.success(WalletPayment(payment.id, PaymentSettlement.COMPLETED))
+            }
+            breez_sdk_spark.PaymentStatus.PENDING -> {
+                emitStatus("Payment pending")
+                Result.success(WalletPayment(payment.id, PaymentSettlement.PENDING))
+            }
+            else -> {
+                emitStatus("Payment failed (${payment.status})")
+                Result.failure(Exception("Payment failed"))
+            }
+        }
+
+    override suspend fun payInvoice(bolt11: String): Result<WalletPayment> = withContext(Dispatchers.IO) {
         try {
             val instance = sdk ?: return@withContext Result.failure(Exception("Not connected"))
             emitStatus("Preparing payment...")
@@ -379,9 +405,7 @@ class SparkRepository(
                 SendPaymentRequest(prepareResponse, options)
             )
 
-            val paymentId = sendResponse.payment.id
-            emitStatus("Payment sent")
-            Result.success(paymentId)
+            settlementOf(sendResponse.payment)
         } catch (e: Exception) {
             emitStatus("Payment failed: ${e.message}")
             Result.failure(e)
@@ -414,7 +438,7 @@ class SparkRepository(
     }
 
     /** Send using a previously prepared response (avoids double-prepare). */
-    suspend fun sendPreparedPayment(prepareData: Any): Result<String> = withContext(Dispatchers.IO) {
+    suspend fun sendPreparedPayment(prepareData: Any): Result<WalletPayment> = withContext(Dispatchers.IO) {
         try {
             val instance = sdk ?: return@withContext Result.failure(Exception("Not connected"))
             val prepareResponse = prepareData as breez_sdk_spark.PrepareSendPaymentResponse
@@ -428,9 +452,7 @@ class SparkRepository(
                 SendPaymentRequest(prepareResponse, options)
             )
 
-            val paymentId = sendResponse.payment.id
-            emitStatus("Payment sent")
-            Result.success(paymentId)
+            settlementOf(sendResponse.payment)
         } catch (e: Exception) {
             emitStatus("Payment failed: ${e.message}")
             Result.failure(e)
@@ -566,14 +588,21 @@ class SparkRepository(
                         amountMsats = payment.amount.toLong() * 1000,
                         feeMsats = payment.fees.toLong() * 1000,
                         createdAt = payment.timestamp.toLong(),
-                        settledAt = payment.timestamp.toLong(),
+                        // Unsettled payments have no settle time yet — stamping
+                        // one made a failed payment look like it had landed.
+                        settledAt = if (onchain || payment.status == breez_sdk_spark.PaymentStatus.COMPLETED)
+                            payment.timestamp.toLong() else null,
                         // On-chain payments made outside this app instance (another
                         // wallet on the same seed) aren't tracked by this SDK session,
                         // so PaymentStatus can stay stuck at PENDING long after the
                         // underlying transaction is confirmed. Since dark-wisp doesn't
                         // initiate on-chain send/receive itself, don't trust that flag
                         // for on-chain rows — the mempool.space link lets users verify.
-                        pending = !onchain && payment.status == breez_sdk_spark.PaymentStatus.PENDING,
+                        status = if (onchain) TransactionStatus.COMPLETED else when (payment.status) {
+                            breez_sdk_spark.PaymentStatus.COMPLETED -> TransactionStatus.COMPLETED
+                            breez_sdk_spark.PaymentStatus.PENDING -> TransactionStatus.PENDING
+                            else -> TransactionStatus.FAILED
+                        },
                         isOnchain = onchain
                     )
                 }

--- a/app/src/main/kotlin/com/darkwisp/app/repo/WalletProvider.kt
+++ b/app/src/main/kotlin/com/darkwisp/app/repo/WalletProvider.kt
@@ -3,6 +3,32 @@ package com.darkwisp.app.repo
 import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.StateFlow
 
+/**
+ * Whether a payment actually settled, or is still in flight.
+ *
+ * Reporting an in-flight payment as settled tells the user sats left their
+ * wallet when they may still return.
+ */
+enum class PaymentSettlement { COMPLETED, PENDING }
+
+/**
+ * Outcome of a successful `pay_invoice` call. [reference] is the preimage for
+ * NWC (which only exists once settled) or the payment id for Spark.
+ */
+data class WalletPayment(
+    val reference: String,
+    val settlement: PaymentSettlement
+)
+
+/**
+ * Where a transaction actually ended up.
+ *
+ * [WalletTransaction] used to carry only `pending`, which cannot express
+ * failure: a FAILED payment arrived as `pending = false` and every binary
+ * `if (pending) ... else "Completed"` in the UI reported it as completed.
+ */
+enum class TransactionStatus { PENDING, COMPLETED, FAILED }
+
 interface WalletProvider {
     val balance: StateFlow<Long?>
     val isConnected: StateFlow<Boolean>
@@ -18,7 +44,12 @@ interface WalletProvider {
     fun connect()
     fun disconnect()
     suspend fun fetchBalance(): Result<Long>
-    suspend fun payInvoice(bolt11: String): Result<String>
+    /**
+     * Pay a BOLT11 invoice. A returned [Result.success] means the wallet
+     * accepted it — check [WalletPayment.settlement] before telling the user
+     * it landed.
+     */
+    suspend fun payInvoice(bolt11: String): Result<WalletPayment>
     suspend fun makeInvoice(amountMsats: Long, description: String, expirySecs: Int = 3600): Result<String>
     suspend fun listTransactions(limit: Int = 50, offset: Int = 0): Result<List<WalletTransaction>>
 }
@@ -33,6 +64,12 @@ data class WalletTransaction(
     val settledAt: Long?,
     /** Pubkey of the counterparty (recipient for outgoing, sender for incoming zaps). */
     val counterpartyPubkey: String? = null,
-    val pending: Boolean = false,
+    val status: TransactionStatus = TransactionStatus.COMPLETED,
     val isOnchain: Boolean = false
-)
+) {
+    /** In-flight — unconfirmed and unsettled. */
+    val pending: Boolean get() = status == TransactionStatus.PENDING
+
+    /** Never settled: the sats were not sent and are back in the wallet. */
+    val failed: Boolean get() = status == TransactionStatus.FAILED
+}

--- a/app/src/main/kotlin/com/darkwisp/app/ui/screen/WalletScreen.kt
+++ b/app/src/main/kotlin/com/darkwisp/app/ui/screen/WalletScreen.kt
@@ -191,6 +191,7 @@ import com.darkwisp.app.viewmodel.RestoreFromRelayStatus
 import com.darkwisp.app.viewmodel.WalletPage
 import com.darkwisp.app.viewmodel.WalletState
 import com.darkwisp.app.viewmodel.WalletViewModel
+import com.darkwisp.app.repo.TransactionStatus
 
 // Full-screen wallet bottom sheets (Transactions, Send, Receive) expand all
 // the way to the top of the window — push the grab handle below the status
@@ -3206,12 +3207,20 @@ private fun TransactionRow(
                 overflow = TextOverflow.Ellipsis
             )
             Row(verticalAlignment = Alignment.CenterVertically) {
-                if (tx.pending) {
+                // A failed payment needs its own label: without one it
+                // reads as an ordinary completed row, i.e. as sats spent.
+                val statusLabel = when (tx.status) {
+                    TransactionStatus.PENDING -> stringResource(R.string.wallet_tx_pending)
+                    TransactionStatus.FAILED -> stringResource(R.string.wallet_tx_failed)
+                    TransactionStatus.COMPLETED -> null
+                }
+                if (statusLabel != null) {
                     Text(
-                        stringResource(R.string.wallet_tx_pending),
+                        statusLabel,
                         style = MaterialTheme.typography.bodySmall,
                         fontWeight = FontWeight.Medium,
-                        color = WispThemeColors.zapColor
+                        color = if (tx.failed) MaterialTheme.colorScheme.error
+                        else WispThemeColors.zapColor
                     )
                     Text(
                         " · ",
@@ -3354,7 +3363,14 @@ private fun TransactionDetailPanel(
             .padding(14.dp),
         verticalArrangement = Arrangement.spacedBy(10.dp)
     ) {
-        TxDetailRow("Status", if (tx.pending) "Pending" else "Completed")
+        TxDetailRow(
+            "Status",
+            when (tx.status) {
+                TransactionStatus.PENDING -> "Pending"
+                TransactionStatus.COMPLETED -> "Completed"
+                TransactionStatus.FAILED -> "Failed — not sent"
+            }
+        )
         TxDetailRow("Type", if (tx.isOnchain) "On-chain" else "Lightning")
         TxDetailRow("Amount", "%,d sats".format(sats))
         if (tx.feeMsats > 0) TxDetailRow("Network fee", "%,d sats".format(feeSats))

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -899,6 +899,7 @@
     <string name="action_generate_invite">Generate invite code</string>
     <string name="label_latest_invite_code">Latest invite code</string>
     <string name="action_copy">Copy</string>
+    <string name="wallet_tx_failed">Failed</string>
     <string name="wallet_tx_pending">Pending</string>
     <string name="action_copy_code">Copy code</string>
     <string name="action_copy_invite_link">Copy invite link</string>


### PR DESCRIPTION
## The bug

Spark's `sendPayment` waits up to `completionTimeoutSecs` and then returns whatever status it has. A payment that cannot settle — a second attempt on an already-settled invoice, for instance — comes back `PENDING`, and a **`FAILED` payment comes back without throwing**, so it never reaches the `catch`.

Both payment paths read only `payment.id` and returned `Result.success`:

```kotlin
val paymentId = sendResponse.payment.id
emitStatus("Payment sent")
Result.success(paymentId)          // status never checked
```

`WalletTransaction` had the matching gap: it carried only `pending`, so a `FAILED` payment arrived as `pending = false` and the wallet UI's binary check

```kotlin
TxDetailRow("Status", if (tx.pending) "Pending" else "Completed")
```

rendered **a failed payment as Completed**. `listTransactions` also stamped `settledAt` unconditionally, giving an unsettled payment a settle time.

Net effect: a payment that never left the wallet could be reported as sent in three separate places.

## How it surfaced

On zap_cooking_android. A user paid an invoice; the card reset to a tappable "Pay" a few seconds later; they paid the same invoice again; the duplicate 10,000 sat attempt was reported as **Completed** while the payment was actually unsettled. Same SDK, same call shape here.

## The fix

- `payInvoice` / `sendPreparedPayment` check `payment.status` and return a `WalletPayment` carrying `COMPLETED` or `PENDING`; `FAILED` is now a failure.
- `WalletTransaction` carries a real `TransactionStatus`; `pending` and `failed` derive from it.
- `settledAt` is set only for a settled payment.
- History row and detail row show Pending, Completed, or **Failed — not sent**.
- NWC reports `COMPLETED`, since NIP-47 only yields a preimage once the payment has settled.

The deliberate on-chain caveat is preserved: on-chain rows still don't trust `PaymentStatus`, for the reason documented at that call site.

## Testing

`compileDebugKotlin` and `testDebugUnitTest` pass. Branched from current `main` (not from the stale fork base). The equivalent fix is verified on-device in zap_cooking_android.

## Related

- barrydeen/wisp#639 — same fix for wisp
- barrydeen/wisp-ios#440 — iOS equivalent

🤖 Generated with GLM-5.2