### PR TITLE
chore(spark): update Breez SDK to 0.23.1

### DIFF
--- a/app/src/main/kotlin/com/darkwisp/app/repo/SparkRepository.kt
+++ b/app/src/main/kotlin/com/darkwisp/app/repo/SparkRepository.kt
@@ -14,6 +14,7 @@ import breez_sdk_spark.ListPaymentsRequest
 import breez_sdk_spark.MaxFee
 import breez_sdk_spark.Network
 import breez_sdk_spark.PaymentDetails
+import breez_sdk_spark.PaymentRequest
 import breez_sdk_spark.PaymentType
 import breez_sdk_spark.PrepareSendPaymentRequest
 import breez_sdk_spark.ReceivePaymentMethod
@@ -392,7 +393,7 @@ class SparkRepository(
             val instance = sdk ?: return@withContext Result.failure(Exception("Not connected"))
             emitStatus("Preparing payment...")
 
-            val prepareReq = PrepareSendPaymentRequest(paymentRequest = bolt11)
+            val prepareReq = PrepareSendPaymentRequest(paymentRequest = PaymentRequest.Input(bolt11))
             val prepareResponse = instance.prepareSendPayment(prepareReq)
 
             emitStatus("Sending payment...")
@@ -415,7 +416,7 @@ class SparkRepository(
     suspend fun prepareSendPayment(bolt11: String): Result<Pair<Long?, Any>> = withContext(Dispatchers.IO) {
         try {
             val instance = sdk ?: return@withContext Result.failure(Exception("Not connected"))
-            val prepareReq = PrepareSendPaymentRequest(paymentRequest = bolt11)
+            val prepareReq = PrepareSendPaymentRequest(paymentRequest = PaymentRequest.Input(bolt11))
             val prepareResponse = instance.prepareSendPayment(prepareReq)
 
             val feeSats = when (val method = prepareResponse.paymentMethod) {
@@ -471,7 +472,8 @@ class SparkRepository(
                     description = description.ifEmpty { "Wisp wallet" },
                     amountSats = amountSats,
                     expirySecs = expirySecs.toUInt(),
-                    paymentHash = null
+                    paymentHash = null,
+                    receiverIdentityPublicKey = null
                 )
                 val response = instance.receivePayment(ReceivePaymentRequest(method))
                 emitStatus("Invoice created")

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -22,7 +22,7 @@ mlkit-language-id = "17.0.6"
 mlkit-barcode = "17.3.0"
 camerax = "1.4.1"
 objectbox = "5.2.0"
-breez-sdk-spark = "0.14.0"
+breez-sdk-spark = "0.23.1"
 # 2.4.x is the newest kmp-tor line compiled with Kotlin 2.1 — 2.5.0+ requires
 # Kotlin 2.2 metadata, unreadable by this project's Kotlin 2.0.21.
 kmp-tor-runtime = "2.4.0"


### PR DESCRIPTION
Some users are still hitting problems with the Spark wallet. We were pinned to Breez SDK **0.14.0** while wisp-ios is on **0.23.1** — nine minor versions behind, on a wallet that talks to a live service. This brings the two platforms back in step. 0.23.1 is also the newest release on Breez's Maven repo.

## API changes since 0.14.0

Three breakages, each resolved the same way wisp-ios handles it:

- `PrepareSendPaymentRequest.paymentRequest` now takes a `PaymentRequest` instead of a bare `String`, so the bolt11 goes in as `PaymentRequest.Input`. Two call sites: `payInvoice` and `prepareSendPayment`.
- `ReceivePaymentMethod.Bolt11Invoice` gained `receiverIdentityPublicKey`, passed as `null` to preserve today's behavior.
- `Config.supportLnurlVerify` was already dropped from our config during the 0.14.0 bump. 0.13.1 removed the field and made LNURL verify unconditional, so there's nothing to restore.

Nothing else in the 0.14.0 → 0.23.1 range touches how we use the SDK — the breaking changes in between are server-side (MySQL/multi-tenant storage) or in config we don't set (`OptimizationConfig` splitting into leaf and token configs). Several fixes in that window look directly relevant to the reports, notably "balance doesn't update immediately on receive".

## Two things worth flagging

**0.22.0 makes a Breez API key mandatory for LNURL on mainnet.** We already set `config.apiKey`, but a release built without `breez.api.key` in `local.properties` will now break lightning addresses outright rather than merely degrading.

**The APK grows about 7.5MB.** The arm64 binding goes from 26MB to 61MB uncompressed (10.1MB → 17.8MB compressed), putting the release APK at 50.5MB against the ~43MB noted in the `packaging` comment in `app/build.gradle.kts`. Only arm64-v8a ships, per `abiFilters`.

## Testing

`assembleRelease` passes, including R8 and lintVital — the existing wildcard keep rules in `proguard-rules.pro` still cover the new binding surface.

Installed a debug build on a Galaxy A54 **over the existing install**, so the SDK migrated a real `spark_data` store rather than starting clean — that's the upgrade path users will actually take. Exercised connect, balance, send (both the fee quote and a real payment, since they're separate call sites), receive, and lightning address. No errors, no `UnsatisfiedLinkError` from the new native binding.

## Follow-up, not included here

0.23.1 adds five `SdkEvent` variants that currently fall through our `else -> {}`: `ClaimedDeposits`, `NewDeposits`, `LightningAddressChanged`, `AutoOptimization` and `UnilateralExitStateChanged`. wisp-ios ignores them too via `default: break`, so I've left the platforms at parity rather than widening this PR. Wiring `ClaimedDeposits` to a balance refresh looks worthwhile on its own.