### PR TITLE
fix(feed): match wisp's compose FAB

### DIFF
--- a/app/src/main/kotlin/com/darkwisp/app/ui/screen/FeedScreen.kt
+++ b/app/src/main/kotlin/com/darkwisp/app/ui/screen/FeedScreen.kt
@@ -31,6 +31,7 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
@@ -1125,10 +1126,11 @@ fun FeedScreen(
                 )
                 FloatingActionButton(
                     onClick = onCompose,
+                    shape = CircleShape,
                     containerColor = MaterialTheme.colorScheme.primary,
                     modifier = Modifier.graphicsLayer { alpha = fabAlpha }
                 ) {
-                    Icon(Icons.Default.Add, contentDescription = "New post")
+                    Icon(Icons.Default.Edit, contentDescription = "New post")
                 }
             }
         ) { padding ->


### PR DESCRIPTION
The feed's compose FAB used `Icons.Default.Add` and the M3 default rounded-square shape, where wisp uses `Icons.Default.Edit` and `CircleShape`.

The other three FABs — DM list, lists hub, custom emoji — already matched.

Tested on a Galaxy A54.