### PR TITLE
feat(onboarding): match iOS on the quick-follow step

### DIFF
--- a/app/src/main/kotlin/com/darkwisp/app/ui/screen/ExistingUserOnboardingScreen.kt
+++ b/app/src/main/kotlin/com/darkwisp/app/ui/screen/ExistingUserOnboardingScreen.kt
@@ -43,11 +43,31 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import coil3.compose.AsyncImage
 import com.darkwisp.app.R
-import com.darkwisp.app.ui.component.ProfilePicture
 import com.darkwisp.app.viewmodel.FeedViewModel
 import kotlinx.coroutines.delay
+import androidx.compose.animation.core.animateFloat
+import androidx.compose.animation.core.FastOutSlowInEasing
+import androidx.compose.animation.core.RepeatMode
+import androidx.compose.animation.core.infiniteRepeatable
+import androidx.compose.animation.core.rememberInfiniteTransition
+import androidx.compose.animation.core.animateFloatAsState
+import androidx.compose.animation.core.spring
+import androidx.compose.foundation.ExperimentalFoundationApi
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.AccountCircle
+import androidx.compose.material3.Icon
+import androidx.compose.material3.TextButton
+import androidx.compose.ui.draw.clip
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.gestures.detectTapGestures
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.draw.alpha
+import androidx.compose.ui.draw.drawBehind
+import androidx.compose.ui.draw.scale
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
 
 private enum class OnboardingStep {
     WELCOME, DECENTRALIZATION, LONG_PRESS_DEMO, NWC_SETUP, WAITING
@@ -142,13 +162,14 @@ private fun WelcomeStep(onContinue: () -> Unit) {
             verticalArrangement = Arrangement.Center,
             modifier = Modifier.fillMaxWidth()
         ) {
-            AsyncImage(
-                model = null,
+            // The app's own mark, matching iOS's WelcomeStep. This used to be
+            // an AsyncImage with a null model, so it only ever rendered the
+            // generic profile placeholder.
+            Icon(
+                painter = painterResource(R.drawable.ic_wisp_logo),
                 contentDescription = stringResource(R.string.onboarding_wisp_logo),
-                placeholder = painterResource(R.drawable.ic_profile_placeholder),
-                fallback = painterResource(R.drawable.ic_profile_placeholder),
-                error = painterResource(R.drawable.ic_profile_placeholder),
-                modifier = Modifier.size(120.dp)
+                tint = Color.Unspecified,
+                modifier = Modifier.size(96.dp)
             )
 
             Spacer(Modifier.height(24.dp))
@@ -214,9 +235,38 @@ private fun DecentralizationStep(onContinue: () -> Unit) {
 }
 
 @Composable
+@OptIn(ExperimentalFoundationApi::class)
 private fun LongPressDemoStep(onContinue: () -> Unit) {
-    var showFollowBadge by remember { mutableStateOf(false) }
-    var hasLongPressed by remember { mutableStateOf(false) }
+    var didLongPress by remember { mutableStateOf(false) }
+    var showFollowed by remember { mutableStateOf(false) }
+
+    // Breathing glow, 0.4 -> 0.8 over 1.5s, autoreversing — matches iOS's
+    // FollowStep, which animates the symbol's shadow opacity the same way.
+    val glow by rememberInfiniteTransition(label = "glow").animateFloat(
+        initialValue = 0.4f,
+        targetValue = 0.8f,
+        animationSpec = infiniteRepeatable(
+            animation = tween(1500, easing = FastOutSlowInEasing),
+            repeatMode = RepeatMode.Reverse
+        ),
+        label = "glowAmount"
+    )
+    val scale by animateFloatAsState(
+        targetValue = if (showFollowed) 1.1f else 1f,
+        animationSpec = spring(dampingRatio = 0.7f),
+        label = "followScale"
+    )
+
+    // "Followed!" is transient on iOS — it reverts after a second while
+    // didLongPress stays set, so Continue remains enabled.
+    LaunchedEffect(showFollowed) {
+        if (showFollowed) {
+            delay(1000)
+            showFollowed = false
+        }
+    }
+
+    val primary = MaterialTheme.colorScheme.primary
 
     Box(
         modifier = Modifier
@@ -229,15 +279,77 @@ private fun LongPressDemoStep(onContinue: () -> Unit) {
             verticalArrangement = Arrangement.Center,
             modifier = Modifier.fillMaxWidth()
         ) {
+            // Generic figure rather than a real account: the press is a
+            // simulation and must not read as following someone specific.
+            Box(contentAlignment = Alignment.Center) {
+                // Halo is a sibling behind the avatar, not a modifier on it:
+                // drawn on the avatar it lands inside clip(CircleShape) and
+                // gets sheared off at the rim into a hard edge. On its own
+                // larger box it can fade out past the avatar, which is what
+                // iOS's shadow(radius: 20) does.
+                Box(
+                    modifier = Modifier
+                        .size(168.dp)
+                        .drawBehind {
+                            val r = size.minDimension / 2f
+                            drawCircle(
+                                brush = Brush.radialGradient(
+                                    colors = listOf(primary.copy(alpha = glow), Color.Transparent),
+                                    center = center,
+                                    radius = r
+                                ),
+                                radius = r
+                            )
+                        }
+                )
+
+                // No clip and no background: the vector draws its own circle
+                // with a soft antialiased edge, and nothing renders a tap
+                // target. The press area is bounded in code instead —
+                // AccountCircle fills 20 of its 24-unit viewport, so the
+                // drawn circle's radius is 20/24 of the box's half-width, and
+                // long-presses outside that are ignored.
+                Icon(
+                    imageVector = Icons.Filled.AccountCircle,
+                    contentDescription = null,
+                    tint = primary,
+                    modifier = Modifier
+                        .size(88.dp)
+                        .scale(scale)
+                        .pointerInput(Unit) {
+                            detectTapGestures(
+                                onLongPress = { offset ->
+                                    val centre = Offset(size.width / 2f, size.height / 2f)
+                                    val drawnRadius = size.width / 2f * (20f / 24f)
+                                    if ((offset - centre).getDistance() <= drawnRadius) {
+                                        showFollowed = true
+                                        didLongPress = true
+                                    }
+                                }
+                            )
+                        }
+                )
+            }
+
+            Spacer(Modifier.height(24.dp))
+
+            AnimatedVisibility(visible = showFollowed) {
+                Text(
+                    text = stringResource(R.string.onboarding_followed),
+                    style = MaterialTheme.typography.titleMedium,
+                    color = primary
+                )
+            }
+
             Text(
                 text = stringResource(R.string.onboarding_quick_follow),
-                fontSize = 24.sp,
+                fontSize = 28.sp,
                 fontWeight = FontWeight.Bold,
                 color = MaterialTheme.colorScheme.onBackground,
                 textAlign = TextAlign.Center
             )
 
-            Spacer(Modifier.height(8.dp))
+            Spacer(Modifier.height(24.dp))
 
             Text(
                 text = stringResource(R.string.onboarding_long_press_hint),
@@ -246,47 +358,38 @@ private fun LongPressDemoStep(onContinue: () -> Unit) {
                 textAlign = TextAlign.Center
             )
 
-            Spacer(Modifier.height(32.dp))
-
-            // Demo profile picture with breathing glow
-            ProfilePicture(
-                url = UTXO_PICTURE,
-                size = 80,
-                highlighted = true,
-                showFollowBadge = showFollowBadge,
-                onLongPress = {
-                    showFollowBadge = !showFollowBadge
-                    hasLongPressed = true
+            AnimatedVisibility(visible = !didLongPress) {
+                Column(horizontalAlignment = Alignment.CenterHorizontally) {
+                    Spacer(Modifier.height(24.dp))
+                    Text(
+                        text = stringResource(R.string.onboarding_try_it),
+                        style = MaterialTheme.typography.bodyMedium,
+                        color = primary
+                    )
                 }
-            )
-
-            Spacer(Modifier.height(12.dp))
-
-            Text(
-                text = stringResource(R.string.onboarding_utxo),
-                style = MaterialTheme.typography.bodyMedium,
-                color = MaterialTheme.colorScheme.onSurfaceVariant
-            )
-
-            Spacer(Modifier.height(8.dp))
-
-            AnimatedVisibility(visible = !hasLongPressed) {
-                Text(
-                    text = stringResource(R.string.onboarding_try_it),
-                    style = MaterialTheme.typography.bodySmall,
-                    color = MaterialTheme.colorScheme.primary
-                )
             }
 
-            Spacer(Modifier.height(32.dp))
+            Spacer(Modifier.height(40.dp))
 
-            if (hasLongPressed) {
-                Button(onClick = onContinue) {
-                    Text(stringResource(R.string.btn_continue))
-                }
-            } else {
-                OutlinedButton(onClick = onContinue) {
-                    Text(stringResource(R.string.btn_continue))
+            // Matches iOS: always on screen, dimmed and inert until the
+            // gesture has been tried.
+            Button(
+                onClick = onContinue,
+                enabled = didLongPress,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .alpha(if (didLongPress) 1f else 0.4f)
+            ) {
+                Text(stringResource(R.string.btn_continue))
+            }
+
+            // Not in iOS. Without it, a disabled Continue plus the screen's
+            // BackHandler leaves anyone who can't perform a long-press with
+            // no way off this step. Once the gesture has landed Continue is
+            // live, so the escape hatch has nothing left to do.
+            AnimatedVisibility(visible = !didLongPress) {
+                TextButton(onClick = onContinue) {
+                    Text(stringResource(R.string.btn_skip))
                 }
             }
         }

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -396,7 +396,6 @@
     <string name="onboarding_network_description">Dark Wisp findet heraus, welche Relays deine Freunde tatsächlich nutzen, und verbindet sich direkt mit diesen Relays. Das bedeutet schnellere Lieferung und weniger verpasste Posts — kein zentraler Server nötig.</string>
     <string name="onboarding_quick_follow">Schnell folgen</string>
     <string name="onboarding_long_press_hint">Halte ein beliebiges Profilbild lange gedrückt, um zu folgen oder nicht mehr zu folgen</string>
-    <string name="onboarding_utxo">utxo</string>
     <string name="onboarding_try_it">Probier es aus — halte das Bild oben lange gedrückt</string>
     <string name="onboarding_lightning_wallet_info">Dark Wisp unterstützt Zaps mit einer integrierten Lightning-Wallet oder Nostr Wallet Connect. Du kannst dies jederzeit auf dem Wallet-Bildschirm einrichten.</string>
     <string name="onboarding_setting_things_up">Einrichtung läuft</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -396,7 +396,6 @@
     <string name="onboarding_network_description">Dark Wisp descubre qué relays usan realmente tus amigos, y luego se conecta directamente a esos relays. Esto significa entregas más rápidas y menos publicaciones perdidas — sin servidor central.</string>
     <string name="onboarding_quick_follow">Seguir rápido</string>
     <string name="onboarding_long_press_hint">Mantén presionada cualquier foto de perfil para seguir o dejar de seguir</string>
-    <string name="onboarding_utxo">utxo</string>
     <string name="onboarding_try_it">Pruébalo — mantén presionada la imagen de arriba</string>
     <string name="onboarding_lightning_wallet_info">Dark Wisp soporta zaps con una billetera Lightning integrada o Nostr Wallet Connect. Puedes configurarlo en cualquier momento desde la pantalla de Billetera.</string>
     <string name="onboarding_setting_things_up">Configurando</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -396,7 +396,6 @@
     <string name="onboarding_network_description">Dark Wisp découvre quels relais vos amis utilisent réellement, puis se connecte directement à ces relais. Cela signifie une livraison plus rapide et moins de posts manqués — aucun serveur central nécessaire.</string>
     <string name="onboarding_quick_follow">Suivi rapide</string>
     <string name="onboarding_long_press_hint">Appuyez longuement sur n\'importe quelle photo de profil pour suivre ou ne plus suivre</string>
-    <string name="onboarding_utxo">utxo</string>
     <string name="onboarding_try_it">Essayez — appuyez longuement sur l\'image ci-dessus</string>
     <string name="onboarding_lightning_wallet_info">Dark Wisp prend en charge les zaps avec un portefeuille Lightning intégré ou Nostr Wallet Connect. Vous pouvez le configurer à tout moment depuis l\'écran Portefeuille.</string>
     <string name="onboarding_setting_things_up">Configuration en cours</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -396,7 +396,6 @@
     <string name="onboarding_network_description">Dark Wisp scopre quali relay usano i tuoi amici e si connette direttamente a questi relay. Questo significa consegne più veloci e meno post persi — nessun server centrale necessario.</string>
     <string name="onboarding_quick_follow">Segui rapidamente</string>
     <string name="onboarding_long_press_hint">Tieni premuta qualsiasi foto profilo per seguire o smettere di seguire</string>
-    <string name="onboarding_utxo">utxo</string>
     <string name="onboarding_try_it">Prova — tieni premuta l\'immagine sopra</string>
     <string name="onboarding_lightning_wallet_info">Dark Wisp supporta zap con portafoglio Lightning integrato o Nostr Wallet Connect. Puoi configurarlo in qualsiasi momento dalla schermata Portafoglio.</string>
     <string name="onboarding_setting_things_up">Configurazione in corso</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -396,7 +396,6 @@
     <string name="onboarding_network_description">Dark Wispは友達が実際に使っているリレーを発見し、直接それに接続します。これにより、より 빠른配信と投稿の見逃しが少なくなります— центрарサーバー的必要がありません。</string>
     <string name="onboarding_quick_follow">クイックフォロー</string>
     <string name="onboarding_long_press_hint">プロフィール写真をロングプレスするとフォロー/フォロー解除できます</string>
-    <string name="onboarding_utxo">utxo</string>
     <string name="onboarding_try_it">試してみよう— 上記の画像をロングプレス</string>
     <string name="onboarding_lightning_wallet_info">Dark Wispは組み込みLightningウォレットまたはNostr Wallet Connectでサップをサポートします。ウォレット画面からいつでも設定できます。</string>
     <string name="onboarding_setting_things_up">設定中</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -396,7 +396,6 @@
     <string name="onboarding_network_description">Dark Wisp는 친구들이 실제로 사용하는 릴레이를 발견하고 직접 연결합니다. 이를 통해 더 빠른 전달과 누락된 게시물 감소—중앙 서버 불필요.</string>
     <string name="onboarding_quick_follow">빠른 팔로우</string>
     <string name="onboarding_long_press_hint">프로필 사진을 길게 누르면 팔로우/언팔로우 가능</string>
-    <string name="onboarding_utxo">utxo</string>
     <string name="onboarding_try_it">사용해보세요— 위 사진을 길게 누르세요</string>
     <string name="onboarding_lightning_wallet_info">Dark Wisp는 내장 라이트닝 지갑 또는 Nostr Wallet Connect를 통한 잽을 지원합니다. 지갑 화면에서 언제든지 설정할 수 있습니다.</string>
     <string name="onboarding_setting_things_up">설정 중</string>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -396,7 +396,6 @@
     <string name="onboarding_network_description">Dark Wisp ontdekt welke relays je vrienden daadwerkelijk gebruiken en maakt rechtstreeks verbinding met die relays. Dit betekent snellere levering en minder gemiste posts — geen centrale server nodig.</string>
     <string name="onboarding_quick_follow">Snel Volgen</string>
     <string name="onboarding_long_press_hint">Houd een profielfoto lang ingedrukt om te volgen of te ontvolgen</string>
-    <string name="onboarding_utxo">utxo</string>
     <string name="onboarding_try_it">Probeer het — houd de afbeelding hierboven lang ingedrukt</string>
     <string name="onboarding_lightning_wallet_info">Dark Wisp ondersteunt zaps met een ingebedde Lightning portemonnee of Nostr Wallet Connect. Je kunt dit altijd instellen via het Portemonnee scherm.</string>
     <string name="onboarding_setting_things_up">Instellen bezig</string>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -396,7 +396,6 @@
     <string name="onboarding_network_description">Dark Wisp descobre quais relays seus amigos realmente usam e se conecta diretamente a esses relays. Isso significa entrega mais rápida e menos publicações perdidas — sem servidor central necessário.</string>
     <string name="onboarding_quick_follow">Seguir rápido</string>
     <string name="onboarding_long_press_hint">Pressione e segure qualquer foto de perfil para seguir ou deixar de seguir</string>
-    <string name="onboarding_utxo">utxo</string>
     <string name="onboarding_try_it">Experimente — pressione e segure a imagem acima</string>
     <string name="onboarding_lightning_wallet_info">Dark Wisp suporta zaps com carteira Lightning integrada ou Nostr Wallet Connect. Você pode configurar isso a qualquer momento na tela da Carteira.</string>
     <string name="onboarding_setting_things_up">Configurando</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -377,7 +377,6 @@
     <string name="onboarding_network_description">Dark Wisp обнаруживает, какие рилэи используют ваши друзья, и подключается напрямую к ним. Это означает более быструю доставку и меньше пропущенных постов — без центрального сервера.</string>
     <string name="onboarding_quick_follow">Быстрая подписка</string>
     <string name="onboarding_long_press_hint">Удерживайте аватар, чтобы подписаться или отписаться</string>
-    <string name="onboarding_utxo">utxo</string>
     <string name="onboarding_try_it">Попробуйте — удерживайте картинку выше</string>
     <string name="onboarding_lightning_wallet_info">Dark Wisp поддерживает запы со встроенным Lightning-кошельком или Nostr Wallet Connect. Настроить можно в любой момент через экран кошелька.</string>
     <string name="onboarding_setting_things_up">Настройка</string>

--- a/app/src/main/res/values-zh/strings.xml
+++ b/app/src/main/res/values-zh/strings.xml
@@ -396,7 +396,6 @@
     <string name="onboarding_network_description">Dark Wisp 发现你朋友实际使用的中继，然后直接连接到这些中继。这意味着更快的投递和更少的帖子遗漏——无需中央服务器。</string>
     <string name="onboarding_quick_follow">快速关注</string>
     <string name="onboarding_long_press_hint">长按任意头像可关注或取消关注</string>
-    <string name="onboarding_utxo">utxo</string>
     <string name="onboarding_try_it">试试看——长按上面的图片</string>
     <string name="onboarding_lightning_wallet_info">Dark Wisp 支持通过内置闪电钱包或 Nostr Wallet Connect 进行闪电支付。你可以随时在钱包页面设置。</string>
     <string name="onboarding_setting_things_up">正在设置</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -435,9 +435,9 @@
     <string name="onboarding_lets_get_set_up">Let\'s get you set up</string>
     <string name="onboarding_your_network_relays">Your network, your relays</string>
     <string name="onboarding_network_description">Dark Wisp discovers which relays your friends actually use, then connects directly to those relays. This means faster delivery and fewer missed posts — no central server needed.</string>
+    <string name="onboarding_followed">Followed!</string>
     <string name="onboarding_quick_follow">Quick follow</string>
     <string name="onboarding_long_press_hint">Long-press any profile picture to follow or unfollow</string>
-    <string name="onboarding_utxo">utxo</string>
     <string name="onboarding_try_it">Try it — long-press the picture above</string>
     <string name="onboarding_lightning_wallet_info">Dark Wisp supports zaps with an embedded Lightning wallet or Nostr Wallet Connect. You can set this up anytime from the Wallet screen.</string>
     <string name="onboarding_setting_things_up">Setting things up</string>


### PR DESCRIPTION
The step practised the gesture on a card captioned "utxo", so it read as being asked to follow a specific person. The avatar was already generic (`UTXO_PICTURE` has been `null`), so the caption was the whole problem — it's gone, along with the now-unused `onboarding_utxo` string in all eleven locales.

Brought in line with iOS's `FollowStep`: an 88dp generic figure in the primary tint with a breathing glow, springing to 1.1× with a transient "Followed!" that reverts after a second, ordered avatar → title → hint → "Try it", and a Continue that stays on screen dimmed and disabled until the gesture lands.

The press area is bounded in code rather than by a clip. `AccountCircle` fills 20 of its 24-unit viewport, so clipping to the layout box either overhung the drawn circle or replaced its antialiased edge with a hard one that read as a visible tap target. `detectTapGestures` ignores presses outside the drawn radius instead, leaving no visual trace.

Also adds a **Skip**, which iOS lacks: Continue is disabled until the gesture and this screen blocks back, so without it anyone unable to long-press was stuck. It hides once the press lands.

The welcome step's logo was an `AsyncImage` with a `null` model, so it only ever rendered the generic placeholder — it now shows `ic_wisp_logo` at 96dp, as iOS does.

Nothing is published: the press only flips local state, as before.

Tested on a Galaxy A54.