### PR TITLE
fix(wallet): don't render token amounts as sats

### DIFF
--- a/app/src/main/kotlin/com/darkwisp/app/repo/SparkRepository.kt
+++ b/app/src/main/kotlin/com/darkwisp/app/repo/SparkRepository.kt
@@ -603,6 +603,13 @@ class SparkRepository(
                         assetAmount = payment.amount.toString()
                         assetFee = payment.fees.toString().takeIf { it != "0" }
                     }
+                    // One leg of a conversion. The step list is ordered
+                    // [cross-chain, AMM] for receives and [AMM, cross-chain]
+                    // for sends, so the FIRST step's source is the true origin
+                    // asset in both directions rather than an intermediate hop.
+                    val conversionFromAsset = payment.conversionDetails
+                        ?.conversions?.firstOrNull()?.from?.asset?.ticker
+
                     val isToken = assetTicker != null
                     // Zero for token rows: there is no honest sats value for a
                     // token transfer. `.toLong()` on a u128 BigInteger also
@@ -638,7 +645,8 @@ class SparkRepository(
                         isOnchain = onchain,
                         assetTicker = assetTicker,
                         assetAmount = assetAmount,
-                        assetFee = assetFee
+                        assetFee = assetFee,
+                        conversionFromAsset = conversionFromAsset
                     )
                 }
                 Result.success(transactions)

--- a/app/src/main/kotlin/com/darkwisp/app/repo/SparkRepository.kt
+++ b/app/src/main/kotlin/com/darkwisp/app/repo/SparkRepository.kt
@@ -14,6 +14,7 @@ import breez_sdk_spark.ListPaymentsRequest
 import breez_sdk_spark.MaxFee
 import breez_sdk_spark.Network
 import breez_sdk_spark.PaymentDetails
+import breez_sdk_spark.PaymentMethod
 import breez_sdk_spark.PaymentRequest
 import breez_sdk_spark.PaymentType
 import breez_sdk_spark.PrepareSendPaymentRequest
@@ -579,6 +580,36 @@ class SparkRepository(
                     val description = lightningDetails?.description
                         ?: lightningDetails?.invoice?.let { com.darkwisp.app.nostr.Bolt11.decode(it)?.description }
 
+                    // Non-bitcoin assets. Payment.amount is documented as
+                    // "satoshis OR token base units", so a token payment's
+                    // amount must never reach the sats fields below. Property
+                    // access rather than destructuring keeps this working
+                    // across SDK versions that changed the case's arity.
+                    val tokenDetails = payment.details as? PaymentDetails.Token
+                    var assetTicker: String? = tokenDetails?.metadata?.ticker
+                    var assetAmount: String? = tokenDetails?.let {
+                        TokenAmounts.scale(payment.amount.toString(), it.metadata.decimals.toInt())
+                    }
+                    var assetFee: String? = tokenDetails?.let {
+                        val raw = payment.fees.toString()
+                        if (raw == "0") null else TokenAmounts.scale(raw, it.metadata.decimals.toInt())
+                    }
+                    // `method` is the fallback discriminator - the SDK notes
+                    // the details can be empty. Without metadata there are no
+                    // decimals to scale by, so show base units under a neutral
+                    // label rather than passing them off as sats.
+                    if (assetTicker == null && payment.method == PaymentMethod.TOKEN) {
+                        assetTicker = "tokens"
+                        assetAmount = payment.amount.toString()
+                        assetFee = payment.fees.toString().takeIf { it != "0" }
+                    }
+                    val isToken = assetTicker != null
+                    // Zero for token rows: there is no honest sats value for a
+                    // token transfer. `.toLong()` on a u128 BigInteger also
+                    // wraps silently past Long.MAX_VALUE.
+                    val satsAmount = if (isToken) 0L else payment.amount.toLong()
+                    val satsFees = if (isToken) 0L else payment.fees.toLong()
+
                     WalletTransaction(
                         type = when (payment.paymentType) {
                             PaymentType.SEND -> "outgoing"
@@ -586,8 +617,8 @@ class SparkRepository(
                         },
                         description = description,
                         paymentHash = paymentHash,
-                        amountMsats = payment.amount.toLong() * 1000,
-                        feeMsats = payment.fees.toLong() * 1000,
+                        amountMsats = satsAmount * 1000,
+                        feeMsats = satsFees * 1000,
                         createdAt = payment.timestamp.toLong(),
                         // Unsettled payments have no settle time yet — stamping
                         // one made a failed payment look like it had landed.
@@ -604,7 +635,10 @@ class SparkRepository(
                             breez_sdk_spark.PaymentStatus.PENDING -> TransactionStatus.PENDING
                             else -> TransactionStatus.FAILED
                         },
-                        isOnchain = onchain
+                        isOnchain = onchain,
+                        assetTicker = assetTicker,
+                        assetAmount = assetAmount,
+                        assetFee = assetFee
                     )
                 }
                 Result.success(transactions)

--- a/app/src/main/kotlin/com/darkwisp/app/repo/WalletProvider.kt
+++ b/app/src/main/kotlin/com/darkwisp/app/repo/WalletProvider.kt
@@ -87,10 +87,34 @@ data class WalletTransaction(
      */
     val assetAmount: String? = null,
     /** Fee in the same asset, scaled the same way. Null when the fee is zero. */
-    val assetFee: String? = null
+    val assetFee: String? = null,
+    /**
+     * Ticker of the asset this payment was converted FROM, when it was one leg
+     * of a conversion - "BTC" for sats into a stablecoin, "USDB" for the way
+     * back. Null for an ordinary payment.
+     *
+     * A conversion is not income or a spend: nothing entered or left the
+     * wallet, it changed shape inside it. Labelling one "Received" - which is
+     * what the bare row did - reads as money arriving from someone.
+     */
+    val conversionFromAsset: String? = null
 ) {
     /** True when this row moved something other than bitcoin. */
     val isTokenTransfer: Boolean get() = assetTicker != null
+
+    val isConversion: Boolean get() = conversionFromAsset != null
+
+    /**
+     * Row label for a conversion. Bitcoin reads lowercase - in this sentence
+     * it's the asset, not a ticker symbol.
+     */
+    val conversionLabel: String? get() = conversionFromAsset?.let { from ->
+        val name = when (from.uppercase()) {
+            "BTC", "SATS", "SAT" -> "bitcoin"
+            else -> from
+        }
+        "Converted from $name"
+    }
 
     /** Row-sized amount: two decimal places, full precision kept in [assetAmount]. */
     val assetAmountCompact: String? get() = assetAmount?.let { TokenAmounts.compact(it) }

--- a/app/src/main/kotlin/com/darkwisp/app/repo/WalletProvider.kt
+++ b/app/src/main/kotlin/com/darkwisp/app/repo/WalletProvider.kt
@@ -65,11 +65,81 @@ data class WalletTransaction(
     /** Pubkey of the counterparty (recipient for outgoing, sender for incoming zaps). */
     val counterpartyPubkey: String? = null,
     val status: TransactionStatus = TransactionStatus.COMPLETED,
-    val isOnchain: Boolean = false
+    val isOnchain: Boolean = false,
+    /**
+     * Ticker of the asset this row moved, when it wasn't bitcoin - e.g. "USDB".
+     * Null for every sats payment, which is the overwhelming majority.
+     *
+     * Spark wallets can hold tokens alongside sats, and Payment.amount is
+     * documented as "satoshis OR token base units". This app offers no token
+     * conversion, but a wallet restored from the same seed in an app that does
+     * hands us those payments anyway, and reading their base units as sats
+     * turns a 15.77 USDB transfer into "15,766,673 sats".
+     *
+     * When this is set, amountMsats / feeMsats are zero: there is no honest
+     * sats value for a token transfer, so nothing sats-denominated - including
+     * fiat conversion - may be derived from this row.
+     */
+    val assetTicker: String? = null,
+    /**
+     * Amount already scaled by the token's decimals, at full precision. Kept as
+     * a String because token base units are u128 and overflow Long.
+     */
+    val assetAmount: String? = null,
+    /** Fee in the same asset, scaled the same way. Null when the fee is zero. */
+    val assetFee: String? = null
 ) {
+    /** True when this row moved something other than bitcoin. */
+    val isTokenTransfer: Boolean get() = assetTicker != null
+
+    /** Row-sized amount: two decimal places, full precision kept in [assetAmount]. */
+    val assetAmountCompact: String? get() = assetAmount?.let { TokenAmounts.compact(it) }
     /** In-flight — unconfirmed and unsettled. */
     val pending: Boolean get() = status == TransactionStatus.PENDING
 
     /** Never settled: the sats were not sent and are back in the wallet. */
     val failed: Boolean get() = status == TransactionStatus.FAILED
+}
+
+/**
+ * Formatting for non-bitcoin assets that reach the wallet from another app
+ * sharing the same seed. Pure string / BigDecimal math so it is unit testable
+ * without the SDK.
+ */
+object TokenAmounts {
+    /**
+     * Shift a token's base-unit amount by its decimal places.
+     *
+     * Operates on the decimal string rather than a numeric type on purpose:
+     * base units are u128 and overflow Long, and Double loses cents well
+     * before that. Trailing zeros are dropped so a whole amount reads "150"
+     * rather than "150.000000".
+     */
+    fun scale(baseUnits: String, decimals: Int): String {
+        val digits = baseUnits.trim()
+        if (digits.isEmpty() || !digits.all { it.isDigit() }) return baseUnits
+        if (decimals <= 0) return digits
+
+        val padded = if (digits.length > decimals) digits
+                     else "0".repeat(decimals - digits.length + 1) + digits
+        val whole = padded.substring(0, padded.length - decimals)
+        val fraction = padded.substring(padded.length - decimals).trimEnd('0')
+        return if (fraction.isEmpty()) whole else "$whole.$fraction"
+    }
+
+    /**
+     * Round a scaled amount to two places for the transaction row. USDB is
+     * dollars, and six places is both unreadable at a glance and wrong for
+     * what the number means; the expanded detail keeps full precision.
+     *
+     * Dust that would round away to "0.00" keeps its full precision instead -
+     * that would otherwise read as nothing having arrived.
+     */
+    fun compact(scaled: String, places: Int = 2): String {
+        if (!scaled.contains('.')) return scaled
+        val value = scaled.toBigDecimalOrNull() ?: return scaled
+        val rounded = value.setScale(places, java.math.RoundingMode.HALF_UP)
+        if (rounded.signum() == 0 && value.signum() != 0) return scaled
+        return java.text.DecimalFormat("#,##0.00").format(rounded)
+    }
 }

--- a/app/src/main/kotlin/com/darkwisp/app/ui/screen/WalletScreen.kt
+++ b/app/src/main/kotlin/com/darkwisp/app/ui/screen/WalletScreen.kt
@@ -3127,6 +3127,25 @@ private fun TransactionRow(
                     .size(40.dp)
                     .clip(CircleShape)
             )
+        } else if (tx.isConversion) {
+            // Swap glyph in the accent, not a green down-arrow: nothing
+            // entered the wallet, it changed shape inside it.
+            Box(
+                modifier = Modifier
+                    .size(40.dp)
+                    .background(
+                        MaterialTheme.colorScheme.primary.copy(alpha = 0.12f),
+                        CircleShape
+                    ),
+                contentAlignment = Alignment.Center
+            ) {
+                Icon(
+                    Icons.Default.SwapHoriz,
+                    contentDescription = tx.conversionLabel,
+                    tint = MaterialTheme.colorScheme.primary,
+                    modifier = Modifier.size(20.dp)
+                )
+            }
         } else {
             Box(
                 modifier = Modifier
@@ -3158,7 +3177,11 @@ private fun TransactionRow(
                 val desc = tx.description?.takeIf {
                     it.isNotBlank() && it != "null" && !it.trimStart().startsWith("{")
                 }
-                desc ?: if (isIncoming) stringResource(R.string.wallet_received) else stringResource(R.string.wallet_sent)
+                // A conversion has no counterparty and rarely a description,
+                // so its label sits where "Received" / "Sent" would - which is
+                // what read as money arriving from someone.
+                desc ?: tx.conversionLabel
+                    ?: if (isIncoming) stringResource(R.string.wallet_received) else stringResource(R.string.wallet_sent)
             }
             Text(
                 displayLabel,
@@ -3204,7 +3227,14 @@ private fun TransactionRow(
         Column(horizontalAlignment = Alignment.End) {
             Row(verticalAlignment = Alignment.CenterVertically) {
                 val sign = if (isIncoming) "+" else "-"
-                val signColor = if (isIncoming) Color(0xFF2E7D32) else MaterialTheme.colorScheme.error
+                // Green means money arrived and red means it left. A
+                // conversion is neither, so it gets the neutral label color;
+                // the +/- still shows which leg of the swap it is.
+                val signColor = when {
+                    tx.isConversion -> MaterialTheme.colorScheme.onSurface
+                    isIncoming -> Color(0xFF2E7D32)
+                    else -> MaterialTheme.colorScheme.error
+                }
                 when {
                     isHidden -> Text(
                         "$sign* * *",
@@ -3348,14 +3378,17 @@ private fun TransactionDetailPanel(
                 TransactionStatus.FAILED -> "Failed — not sent"
             }
         )
+        val conversionType = tx.conversionFromAsset?.let { from ->
+            "Conversion · $from → ${tx.assetTicker ?: "sats"}"
+        }
         if (tx.isTokenTransfer) {
             val ticker = tx.assetTicker ?: ""
-            TxDetailRow("Type", "$ticker transfer")
+            TxDetailRow("Type", conversionType ?: "$ticker transfer")
             // Full precision here; the row above shows two places.
             TxDetailRow("Amount", "${tx.assetAmount ?: "?"} $ticker")
             tx.assetFee?.let { TxDetailRow("Fee", "$it $ticker") }
         } else {
-            TxDetailRow("Type", if (tx.isOnchain) "On-chain" else "Lightning")
+            TxDetailRow("Type", conversionType ?: if (tx.isOnchain) "On-chain" else "Lightning")
             TxDetailRow("Amount", "%,d sats".format(sats))
             if (tx.feeMsats > 0) TxDetailRow("Network fee", "%,d sats".format(feeSats))
         }

--- a/app/src/main/kotlin/com/darkwisp/app/ui/screen/WalletScreen.kt
+++ b/app/src/main/kotlin/com/darkwisp/app/ui/screen/WalletScreen.kt
@@ -3211,6 +3211,22 @@ private fun TransactionRow(
                         style = MaterialTheme.typography.titleMedium,
                         color = signColor
                     )
+                    // Before the fiat branches: a token row has no sats value,
+                    // and the fiat rate converts sats, so running it here
+                    // would only produce a second wrong number.
+                    tx.isTokenTransfer -> {
+                        Text(
+                            "$sign${tx.assetAmountCompact ?: "?"}",
+                            style = MaterialTheme.typography.titleMedium,
+                            color = signColor
+                        )
+                        Spacer(Modifier.width(4.dp))
+                        Text(
+                            tx.assetTicker ?: "",
+                            style = MaterialTheme.typography.bodySmall,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant
+                        )
+                    }
                     isWalletFiat -> {
                         val fiat = AmountFormatter.formatFiat(amountSats, fiatCurrency)
                         if (fiat != null) {
@@ -3332,9 +3348,17 @@ private fun TransactionDetailPanel(
                 TransactionStatus.FAILED -> "Failed — not sent"
             }
         )
-        TxDetailRow("Type", if (tx.isOnchain) "On-chain" else "Lightning")
-        TxDetailRow("Amount", "%,d sats".format(sats))
-        if (tx.feeMsats > 0) TxDetailRow("Network fee", "%,d sats".format(feeSats))
+        if (tx.isTokenTransfer) {
+            val ticker = tx.assetTicker ?: ""
+            TxDetailRow("Type", "$ticker transfer")
+            // Full precision here; the row above shows two places.
+            TxDetailRow("Amount", "${tx.assetAmount ?: "?"} $ticker")
+            tx.assetFee?.let { TxDetailRow("Fee", "$it $ticker") }
+        } else {
+            TxDetailRow("Type", if (tx.isOnchain) "On-chain" else "Lightning")
+            TxDetailRow("Amount", "%,d sats".format(sats))
+            if (tx.feeMsats > 0) TxDetailRow("Network fee", "%,d sats".format(feeSats))
+        }
         TxDetailRow("Date", fullDate)
         if (note != null) TxDetailRow("Note", note)
         TxDetailRow(idLabel, tx.paymentHash, mono = true, onCopy = { onCopy(tx.paymentHash) })

--- a/app/src/test/kotlin/com/darkwisp/app/repo/TokenAmountsTest.kt
+++ b/app/src/test/kotlin/com/darkwisp/app/repo/TokenAmountsTest.kt
@@ -117,4 +117,58 @@ class TokenAmountsTest {
         assertEquals("15.77", tx.assetAmountCompact)
         assertEquals("15.766673", tx.assetAmount)
     }
+
+    // --- Conversion labelling ---
+
+    /**
+     * A sats-to-USDB conversion is one payment on each side of the swap, and
+     * both rendered as a bare "Received" - money arriving from someone.
+     * Nothing arrived: the funds changed shape inside the wallet.
+     */
+    @Test
+    fun `bitcoin source reads lowercase as an asset not a ticker`() {
+        val tx = WalletTransaction(
+            type = "incoming", description = null, paymentHash = "h",
+            amountMsats = 0L, createdAt = 0L, settledAt = null,
+            assetTicker = "USDB", assetAmount = "15.766673",
+            conversionFromAsset = "BTC"
+        )
+        assertEquals("Converted from bitcoin", tx.conversionLabel)
+        assertEquals(true, tx.isConversion)
+    }
+
+    @Test
+    fun `sats spelled either way still reads as bitcoin`() {
+        listOf("SATS", "sats", "sat", "btc").forEach { ticker ->
+            val tx = WalletTransaction(
+                type = "incoming", description = null, paymentHash = "h",
+                amountMsats = 0L, createdAt = 0L, settledAt = null,
+                conversionFromAsset = ticker
+            )
+            assertEquals("Converted from bitcoin", tx.conversionLabel)
+        }
+    }
+
+    /** The other direction: USDB converted back into sats. */
+    @Test
+    fun `token source keeps its uppercase ticker`() {
+        val tx = WalletTransaction(
+            type = "incoming", description = null, paymentHash = "h",
+            amountMsats = 20_265_000L, createdAt = 0L, settledAt = null,
+            conversionFromAsset = "USDB"
+        )
+        assertEquals("Converted from USDB", tx.conversionLabel)
+        // A sats row can be a conversion leg without being a token transfer.
+        assertEquals(false, tx.isTokenTransfer)
+    }
+
+    @Test
+    fun `an ordinary payment is not a conversion`() {
+        val tx = WalletTransaction(
+            type = "incoming", description = null, paymentHash = "h",
+            amountMsats = 21_000_000L, createdAt = 0L, settledAt = null
+        )
+        assertEquals(false, tx.isConversion)
+        assertEquals(null, tx.conversionLabel)
+    }
 }

--- a/app/src/test/kotlin/com/darkwisp/app/repo/TokenAmountsTest.kt
+++ b/app/src/test/kotlin/com/darkwisp/app/repo/TokenAmountsTest.kt
@@ -1,0 +1,120 @@
+package com.darkwisp.app.repo
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+/**
+ * Spark wallets hold tokens alongside sats, and Payment.amount is documented
+ * as "satoshis OR token base units". This app offers no token conversion, but
+ * a wallet restored from the same seed in an app that does hands us those
+ * payments anyway - and reading their base units as sats turned a 15.77 USDB
+ * transfer into "15,766,673 sats".
+ *
+ * Ported from wisp-ios#451.
+ */
+class TokenAmountsTest {
+
+    // --- Decimal shifting ---
+
+    @Test
+    fun `scales by the tokens decimals`() {
+        // USDB-shaped: 6 decimals.
+        assertEquals("15.766673", TokenAmounts.scale("15766673", 6))
+    }
+
+    @Test
+    fun `trailing zeros are dropped`() {
+        assertEquals("150", TokenAmounts.scale("150000000", 6))
+        assertEquals("1.5", TokenAmounts.scale("1500000", 6))
+    }
+
+    /** Amounts under one whole unit need a leading zero, not ".5". */
+    @Test
+    fun `amounts under one unit keep their leading zero`() {
+        assertEquals("0.5", TokenAmounts.scale("500000", 6))
+        assertEquals("0.000001", TokenAmounts.scale("1", 6))
+    }
+
+    @Test
+    fun `zero decimals passes through`() {
+        assertEquals("42", TokenAmounts.scale("42", 0))
+    }
+
+    @Test
+    fun `zero is zero`() {
+        assertEquals("0", TokenAmounts.scale("0", 6))
+    }
+
+    /**
+     * Base units are u128. Anything routed through Long would wrap silently,
+     * so the scaler works on the decimal string.
+     */
+    @Test
+    fun `amounts beyond Long survive`() {
+        val huge = "340282366920938463463374607431768211455"  // u128 max
+        assertEquals("3402823669209384634633746074317682114.55", TokenAmounts.scale(huge, 2))
+    }
+
+    /** Never crash or fabricate a number on unexpected input. */
+    @Test
+    fun `non numeric input is returned unchanged`() {
+        assertEquals("abc", TokenAmounts.scale("abc", 6))
+        assertEquals("", TokenAmounts.scale("", 6))
+    }
+
+    // --- Row-sized display ---
+
+    /** USDB is dollars; six places is unreadable and wrong for what it means. */
+    @Test
+    fun `compact form rounds to two places`() {
+        assertEquals("15.77", TokenAmounts.compact("15.766673"))
+        assertEquals("15.80", TokenAmounts.compact("15.802229"))
+    }
+
+    @Test
+    fun `whole amounts pass through without a decimal point`() {
+        assertEquals("150", TokenAmounts.compact("150"))
+        assertEquals("150.00", TokenAmounts.compact("150.0"))
+    }
+
+    /** Dust must never render as "0.00" - that reads as nothing arriving. */
+    @Test
+    fun `dust keeps full precision`() {
+        assertEquals("0.000001", TokenAmounts.compact("0.000001"))
+    }
+
+    @Test
+    fun `real zero is allowed to be zero`() {
+        assertEquals("0.00", TokenAmounts.compact("0.0"))
+    }
+
+    @Test
+    fun `compact form groups thousands`() {
+        assertEquals("1,234.50", TokenAmounts.compact("1234.5"))
+    }
+
+    // --- Model ---
+
+    @Test
+    fun `a sats row is not a token transfer`() {
+        val tx = WalletTransaction(
+            type = "incoming", description = null, paymentHash = "h",
+            amountMsats = 21_000_000L, createdAt = 0L, settledAt = null
+        )
+        assertEquals(false, tx.isTokenTransfer)
+        assertEquals(null, tx.assetAmountCompact)
+    }
+
+    /** The row shows the compact form; the expanded detail keeps every digit. */
+    @Test
+    fun `a token row exposes both precisions`() {
+        val tx = WalletTransaction(
+            type = "incoming", description = null, paymentHash = "h",
+            amountMsats = 0L, createdAt = 0L, settledAt = null,
+            assetTicker = "USDB", assetAmount = "15.766673"
+        )
+        assertEquals(true, tx.isTokenTransfer)
+        assertEquals("15.77", tx.assetAmountCompact)
+        assertEquals("15.766673", tx.assetAmount)
+    }
+}


### PR DESCRIPTION
Ports barrydeen/wisp-ios#451 — **see that PR for screenshots** of the before / after.

A wallet restored from the same seed in an app that offers token conversion sends token payments back through `listPayments`, and we read every `Payment.amount` as satoshis. A **15.77 USDB transfer displayed as "+15,766,673 sats"** — off by eight orders of magnitude, in the direction that looks like a windfall.

## This is not stablecoin support

To be unambiguous about scope, because "handle USDB" reads like the opposite of what this does:

**No stablecoin balances are being added, and this doesn't move toward them.** There is no way to hold, convert, send or receive USDB — or any token — in this app before this change or after it. No conversion UI, no token balance on the dashboard, nothing in the send or receive paths. `GetInfoResponse.tokenBalances` stays unread.

What it accommodates is a shared seed. The other app's token payments come back down the same `listPayments` feed on the next sync whether we want them or not — the SDK returns the wallet's history, and the wallet is shared. The only choice available is how to render rows we did not create. Today we render them as a false statement about the user's money.

## Cause

The SDK is explicit — `Payment.amount` is *"Amount in satoshis **or token base units**"* — and `PaymentDetails.Token` carries the metadata to tell them apart. `PaymentMethod.TOKEN` is the fallback discriminator, since the SDK notes the details can be empty.

Read via property access rather than positional destructuring: the case's arity differs between SDK versions, and property access compiles against both.

## Fix — display only

- Token rows carry `assetTicker` / `assetAmount` / `assetFee`, scaled by the token's own `decimals`.
- Their **sats fields are forced to zero**. There is no honest sats value for a token transfer, so nothing sats-denominated can derive a number from one.
- The token branch sits **before** the fiat branch in the row: the fiat rate converts sats, so running it there would only produce a second wrong number.
- Rows show two decimal places (`15.77 USDB`) — USDB is dollars, and six places is unreadable at a glance and wrong for what the number means. The expanded detail keeps full precision, and dust that would round to `0.00` keeps its precision rather than reading as nothing having arrived.

## Latent overflow, also fixed

`payment.amount` is a `BigInteger` and `.toLong()` wraps silently past `Long.MAX_VALUE`. Token base units are u128, so a large amount would have rendered as a **0-sat** payment. Scaling works on the decimal string instead; a test pins u128 max.

## Conversion rows

A sats-to-USDB conversion is one payment on each side of the swap, and both rendered as a bare **"Received" with a green down-arrow** — money arriving from someone. Nothing arrived: the funds changed shape inside the wallet.

Rows now read **"Converted from bitcoin"** / **"Converted from USDB"**, matching how Glow presents the same history. The green and the arrow were making the same false claim as the label, so both go too:

| | Ordinary receive | Conversion |
|---|---|---|
| Label | "Received" | "Converted from bitcoin" / "Converted from USDB" |
| Icon | green down-arrow | swap glyph in the accent color |
| Amount | green | neutral label color |

The `+`/`-` sign stays — it still says which leg of the swap the row is — but nothing about it implies income.

Source asset comes from `conversionDetails.conversions.first?.from.asset.ticker`. The step list is ordered `[cross-chain, AMM]` for receives and `[AMM, cross-chain]` for sends, so the **first** step is the true origin in both directions rather than an intermediate hop. "BTC" renders lowercase as "bitcoin" — in that sentence it's the asset, not a ticker symbol. The expanded detail carries the full direction: `Conversion · BTC → USDB`.

Worth noting the two states are independent: **a sats row can be a conversion leg without being a token transfer** (USDB converted back into sats), and there's a test pinning that.

## Testing

18 tests on the pure formatting: decimal scaling (u128 max, sub-unit amounts keeping their leading zero, trailing-zero trimming), the two-place compact form, dust preservation, and the model's token/sats discrimination.

---

Verified on a Galaxy A54 against a live wallet holding USDB.

Confirmed on a Galaxy A54 against a live wallet holding USDB.
