### PR TITLE
feat(wallet): withdraw the whole balance on-chain

### DIFF
--- a/app/src/main/kotlin/com/darkwisp/app/repo/SparkRepository.kt
+++ b/app/src/main/kotlin/com/darkwisp/app/repo/SparkRepository.kt
@@ -14,6 +14,12 @@ import breez_sdk_spark.ListPaymentsRequest
 import breez_sdk_spark.MaxFee
 import breez_sdk_spark.Network
 import breez_sdk_spark.PaymentDetails
+import breez_sdk_spark.PaymentStatus
+import breez_sdk_spark.PrepareSendPaymentResponse
+import breez_sdk_spark.OptimizationMode
+import breez_sdk_spark.OptimizeLeavesRequest
+import breez_sdk_spark.OnchainConfirmationSpeed
+import breez_sdk_spark.FeePolicy
 import breez_sdk_spark.PaymentRequest
 import breez_sdk_spark.PaymentType
 import breez_sdk_spark.PrepareSendPaymentRequest
@@ -387,6 +393,165 @@ class SparkRepository(
                 Result.failure(Exception("Payment failed"))
             }
         }
+
+    // ---- Withdraw on-chain ----
+
+    /**
+     * The most recent quote and its signed-off SDK request. Execution reuses
+     * this so the amount and destination the user confirmed are exactly what
+     * gets sent, and so the SDK request type never leaves this file.
+     */
+    private var preparedWithdrawal: Pair<WithdrawOnchainQuote, PrepareSendPaymentResponse>? = null
+
+    /**
+     * Quote draining the entire spendable balance to a Bitcoin address.
+     *
+     * Uses FeePolicy.FEES_INCLUDED with amount = balance, which the SDK
+     * documents as the way to drain: the wallet spends exactly the balance and
+     * the fee comes out of it. The default FEES_EXCLUDED adds the fee on top,
+     * so a send of the full balance could never succeed.
+     *
+     * Nothing is signed or broadcast here - this exists so the confirmation
+     * screen can show a real fee from the SDK rather than an estimate.
+     */
+    suspend fun prepareWithdrawOnchain(
+        address: String,
+        speed: WithdrawOnchainSpeed
+    ): Result<WithdrawOnchainQuote> = withContext(Dispatchers.IO) {
+        try {
+            val instance = sdk ?: return@withContext Result.failure(Exception("Not connected"))
+
+            // Synced read: quoting against a stale cached balance produces a
+            // fee for an amount that no longer exists.
+            val info = instance.getInfo(GetInfoRequest(ensureSynced = true))
+            val balanceSats = info.balanceSats.toLong()
+            if (balanceSats <= 0L) {
+                return@withContext Result.failure(Exception("This wallet has no spendable balance."))
+            }
+
+            emitStatus("Quoting withdrawal...")
+            val prepared = instance.prepareSendPayment(
+                PrepareSendPaymentRequest(
+                    paymentRequest = PaymentRequest.Input(address),
+                    amount = java.math.BigInteger.valueOf(balanceSats),
+                    feePolicy = FeePolicy.FEES_INCLUDED
+                )
+            )
+
+            val method = prepared.paymentMethod
+            if (method !is SendPaymentMethod.BitcoinAddress) {
+                // Parsed as something else - a Lightning invoice or Spark
+                // address pasted into the field. Refuse rather than silently
+                // sending somewhere the user didn't intend.
+                return@withContext Result.failure(Exception("That isn't a Bitcoin address."))
+            }
+
+            val tier = when (speed) {
+                WithdrawOnchainSpeed.SLOW -> method.feeQuote.speedSlow
+                WithdrawOnchainSpeed.MEDIUM -> method.feeQuote.speedMedium
+                WithdrawOnchainSpeed.FAST -> method.feeQuote.speedFast
+            }
+            // Both components are real cost: the service fee and the L1
+            // broadcast fee.
+            val feeSats = tier.userFeeSat.toLong() + tier.l1BroadcastFeeSat.toLong()
+
+            val quote = WithdrawOnchainQuote(
+                address = address,
+                spendSats = balanceSats,
+                feeSats = feeSats,
+                speed = speed
+            )
+            preparedWithdrawal = quote to prepared
+            Result.success(quote)
+        } catch (e: Exception) {
+            Result.failure(e)
+        }
+    }
+
+    /**
+     * Broadcast a quoted withdrawal. Returns the payment id.
+     *
+     * Retries once through optimizeLeaves on an insufficient-funds error:
+     * Spark spends from individual leaves, so a nominally sufficient balance
+     * can still fail leaf selection - most often right after a conversion
+     * credits many small leaves. Consolidating and retrying is what makes a
+     * full drain land instead of failing on arithmetic that looks correct.
+     */
+    suspend fun executeWithdrawOnchain(
+        quote: WithdrawOnchainQuote
+    ): Result<String> = withContext(Dispatchers.IO) {
+        val instance = sdk ?: return@withContext Result.failure(Exception("Not connected"))
+
+        // Only ever send the quote the user actually confirmed. If the held
+        // quote doesn't match, the screen has drifted from what was signed
+        // off - re-quote rather than send different terms.
+        val held = preparedWithdrawal
+        if (held == null || held.first != quote) {
+            return@withContext Result.failure(
+                Exception("This quote expired. Check the amount and try again.")
+            )
+        }
+
+        val sdkSpeed = when (quote.speed) {
+            WithdrawOnchainSpeed.SLOW -> OnchainConfirmationSpeed.SLOW
+            WithdrawOnchainSpeed.MEDIUM -> OnchainConfirmationSpeed.MEDIUM
+            WithdrawOnchainSpeed.FAST -> OnchainConfirmationSpeed.FAST
+        }
+
+        suspend fun send(prepared: PrepareSendPaymentResponse) = instance.sendPayment(
+            SendPaymentRequest(
+                prepareResponse = prepared,
+                options = SendPaymentOptions.BitcoinAddress(confirmationSpeed = sdkSpeed)
+            )
+        )
+
+        try {
+            emitStatus("Sending on-chain...")
+            val response = send(held.second)
+            // A FAILED payment comes back WITHOUT throwing - the same trap
+            // payInvoice documents - so the status is inspected, not trusted.
+            if (response.payment.status == PaymentStatus.FAILED) {
+                emitStatus("Withdrawal failed")
+                return@withContext Result.failure(
+                    Exception("The withdrawal failed - your funds were not sent.")
+                )
+            }
+            Result.success(response.payment.id)
+        } catch (e: Exception) {
+            if (e.message?.contains("insufficient funds", ignoreCase = true) != true) {
+                emitStatus("Withdrawal failed")
+                return@withContext Result.failure(e)
+            }
+
+            emitStatus("Consolidating leaves...")
+            runCatching { instance.optimizeLeaves(OptimizeLeavesRequest(mode = OptimizationMode.FULL)) }
+
+            // Re-quote after consolidation: the spendable balance can differ,
+            // and the old prepare response references an arrangement of
+            // leaves that no longer exists.
+            val requote = prepareWithdrawOnchain(quote.address, quote.speed)
+            val reprepared = preparedWithdrawal?.second
+            if (requote.isFailure || reprepared == null) {
+                return@withContext Result.failure(
+                    requote.exceptionOrNull()
+                        ?: Exception("Couldn't re-quote the withdrawal after consolidating.")
+                )
+            }
+            try {
+                emitStatus("Retrying on-chain send...")
+                val response = send(reprepared)
+                if (response.payment.status == PaymentStatus.FAILED) {
+                    return@withContext Result.failure(
+                        Exception("The withdrawal failed - your funds were not sent.")
+                    )
+                }
+                Result.success(response.payment.id)
+            } catch (retry: Exception) {
+                emitStatus("Withdrawal failed")
+                Result.failure(retry)
+            }
+        }
+    }
 
     override suspend fun payInvoice(bolt11: String): Result<WalletPayment> = withContext(Dispatchers.IO) {
         try {

--- a/app/src/main/kotlin/com/darkwisp/app/repo/SparkRepository.kt
+++ b/app/src/main/kotlin/com/darkwisp/app/repo/SparkRepository.kt
@@ -498,25 +498,29 @@ class SparkRepository(
             WithdrawOnchainSpeed.FAST -> OnchainConfirmationSpeed.FAST
         }
 
-        suspend fun send(prepared: PrepareSendPaymentResponse) = instance.sendPayment(
-            SendPaymentRequest(
-                prepareResponse = prepared,
-                options = SendPaymentOptions.BitcoinAddress(confirmationSpeed = sdkSpeed)
+        // Broadcast and judge the outcome in one place. A FAILED payment comes
+        // back WITHOUT throwing - the same trap payInvoice documents - so the
+        // status is inspected, not trusted. Shared by the initial send and the
+        // post-consolidation retry so the check and its copy can't drift.
+        suspend fun sendAndCheck(prepared: PrepareSendPaymentResponse): Result<String> {
+            val response = instance.sendPayment(
+                SendPaymentRequest(
+                    prepareResponse = prepared,
+                    options = SendPaymentOptions.BitcoinAddress(confirmationSpeed = sdkSpeed)
+                )
             )
-        )
-
-        try {
-            emitStatus("Sending on-chain...")
-            val response = send(held.second)
-            // A FAILED payment comes back WITHOUT throwing - the same trap
-            // payInvoice documents - so the status is inspected, not trusted.
             if (response.payment.status == PaymentStatus.FAILED) {
                 emitStatus("Withdrawal failed")
-                return@withContext Result.failure(
+                return Result.failure(
                     Exception("The withdrawal failed - your funds were not sent.")
                 )
             }
-            Result.success(response.payment.id)
+            return Result.success(response.payment.id)
+        }
+
+        try {
+            emitStatus("Sending on-chain...")
+            return@withContext sendAndCheck(held.second)
         } catch (e: Exception) {
             if (e.message?.contains("insufficient funds", ignoreCase = true) != true) {
                 emitStatus("Withdrawal failed")
@@ -530,22 +534,31 @@ class SparkRepository(
             // and the old prepare response references an arrangement of
             // leaves that no longer exists.
             val requote = prepareWithdrawOnchain(quote.address, quote.speed)
-            val reprepared = preparedWithdrawal?.second
-            if (requote.isFailure || reprepared == null) {
+            val rehead = preparedWithdrawal
+            if (requote.isFailure || rehead == null) {
                 return@withContext Result.failure(
                     requote.exceptionOrNull()
                         ?: Exception("Couldn't re-quote the withdrawal after consolidating.")
                 )
             }
+            // The same invariant the primary path enforces above: only ever
+            // broadcast terms the user actually approved. Consolidating can
+            // move the spendable balance and the fee, and the confirm screen
+            // still shows the figure that was signed off - sending the new one
+            // would spend an amount nobody agreed to. Bounce back for a fresh
+            // confirmation instead.
+            if (rehead.first != quote) {
+                emitStatus("Amount changed - confirm again")
+                return@withContext Result.failure(
+                    Exception(
+                        "The amount changed while consolidating your funds. " +
+                            "Check the new total and confirm again."
+                    )
+                )
+            }
             try {
                 emitStatus("Retrying on-chain send...")
-                val response = send(reprepared)
-                if (response.payment.status == PaymentStatus.FAILED) {
-                    return@withContext Result.failure(
-                        Exception("The withdrawal failed - your funds were not sent.")
-                    )
-                }
-                Result.success(response.payment.id)
+                sendAndCheck(rehead.second)
             } catch (retry: Exception) {
                 emitStatus("Withdrawal failed")
                 Result.failure(retry)

--- a/app/src/main/kotlin/com/darkwisp/app/repo/WithdrawOnchain.kt
+++ b/app/src/main/kotlin/com/darkwisp/app/repo/WithdrawOnchain.kt
@@ -1,0 +1,79 @@
+package com.darkwisp.app.repo
+
+/**
+ * Confirmation speed for an on-chain withdrawal, mapped to the SDK's three
+ * fee tiers. SDK-free so the UI and tests don't depend on the bindings.
+ */
+enum class WithdrawOnchainSpeed(val label: String, val detail: String) {
+    SLOW("Economy", "Cheapest. May take hours to confirm."),
+    MEDIUM("Standard", "Balanced fee and confirmation time."),
+    FAST("Priority", "Highest fee. Confirms soonest.")
+}
+
+/**
+ * What a withdrawal would cost and deliver, quoted before anything is signed.
+ *
+ * [spendSats] is the whole spendable balance and [feeSats] comes out of it -
+ * the SDK's FeePolicy.FEES_INCLUDED - so [netSats] is what actually lands at
+ * the destination. Quoting this way is the only honest way to drain: with
+ * fees added on top, a send of the full balance can never succeed.
+ */
+data class WithdrawOnchainQuote(
+    val address: String,
+    val spendSats: Long,
+    val feeSats: Long,
+    val speed: WithdrawOnchainSpeed
+) {
+    val netSats: Long get() = (spendSats - feeSats).coerceAtLeast(0L)
+
+    /**
+     * True when the fee would consume everything. Spark's dust and fee floors
+     * mean a small balance can be genuinely unspendable on-chain - better to
+     * say so than to broadcast something that delivers zero.
+     */
+    val isUneconomical: Boolean get() = netSats <= 0L
+
+    /**
+     * Share of the balance eaten by fees, for the warning copy. Draining a
+     * small balance can cost a large percentage, and that should be visible
+     * before confirming rather than discovered after.
+     */
+    val feePercent: Double
+        get() = if (spendSats <= 0L) 0.0 else (feeSats.toDouble() / spendSats.toDouble()) * 100.0
+}
+
+/**
+ * Funds a withdrawal cannot move, reported after the fact.
+ *
+ * "Recover everything" is not literally achievable: tokens below the
+ * provider's conversion floor cannot be converted at any price, and Spark
+ * leaves worth less than their own exit cost are not worth spending. Naming
+ * the remainder is more useful than implying it does not exist.
+ */
+data class WithdrawOnchainRemainder(
+    /** Ticker to human-readable amount left behind, e.g. "USDB" to "0.34". */
+    val strandedTokens: Map<String, String> = emptyMap(),
+    val strandedSats: Long = 0L
+) {
+    val isEmpty: Boolean get() = strandedTokens.isEmpty() && strandedSats == 0L
+}
+
+/**
+ * Pull a bare address out of whatever a wallet's QR actually encodes.
+ *
+ * Bitcoin QRs are usually BIP-21 URIs - "bitcoin:bc1q...?amount=0.01&label=x"
+ * - and the SDK's parser wants the address alone. The amount is deliberately
+ * discarded: this screen always sends the whole balance, so honoring a
+ * requested amount would contradict what the button says.
+ */
+fun normalizeBitcoinAddress(raw: String): String {
+    var value = raw.trim()
+    // Anchored and case-insensitive: some wallets emit "BITCOIN:", and an
+    // address containing "bitcoin:" mid-string must not be mangled.
+    if (value.length >= 8 && value.substring(0, 8).equals("bitcoin:", ignoreCase = true)) {
+        value = value.substring(8)
+    }
+    val query = value.indexOf('?')
+    if (query >= 0) value = value.substring(0, query)
+    return value.trim()
+}

--- a/app/src/main/kotlin/com/darkwisp/app/repo/WithdrawOnchain.kt
+++ b/app/src/main/kotlin/com/darkwisp/app/repo/WithdrawOnchain.kt
@@ -43,22 +43,6 @@ data class WithdrawOnchainQuote(
 }
 
 /**
- * Funds a withdrawal cannot move, reported after the fact.
- *
- * "Recover everything" is not literally achievable: tokens below the
- * provider's conversion floor cannot be converted at any price, and Spark
- * leaves worth less than their own exit cost are not worth spending. Naming
- * the remainder is more useful than implying it does not exist.
- */
-data class WithdrawOnchainRemainder(
-    /** Ticker to human-readable amount left behind, e.g. "USDB" to "0.34". */
-    val strandedTokens: Map<String, String> = emptyMap(),
-    val strandedSats: Long = 0L
-) {
-    val isEmpty: Boolean get() = strandedTokens.isEmpty() && strandedSats == 0L
-}
-
-/**
  * Pull a bare address out of whatever a wallet's QR actually encodes.
  *
  * Bitcoin QRs are usually BIP-21 URIs - "bitcoin:bc1q...?amount=0.01&label=x"

--- a/app/src/main/kotlin/com/darkwisp/app/ui/component/WithdrawOnchainSheet.kt
+++ b/app/src/main/kotlin/com/darkwisp/app/ui/component/WithdrawOnchainSheet.kt
@@ -57,7 +57,15 @@ fun WithdrawOnchainSheet(
     var showConfirm by remember { mutableStateOf(false) }
 
     if (showScanner) {
-        ModalBottomSheet(onDismissRequest = { showScanner = false }) {
+        // Full height, as every other sheet in the app does. The default
+        // state opens partially expanded, which clips the fixed-height
+        // camera preview below — and this sheet has no scroll, so the
+        // cut-off portion can't be reached at all.
+        val scannerSheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
+        ModalBottomSheet(
+            onDismissRequest = { showScanner = false },
+            sheetState = scannerSheetState
+        ) {
             Box(Modifier.fillMaxWidth().height(420.dp)) {
                 QrScanner(
                     onResult = { raw ->
@@ -74,7 +82,10 @@ fun WithdrawOnchainSheet(
         }
     }
 
-    ModalBottomSheet(onDismissRequest = onDismiss) {
+    // Without this the sheet opens partially expanded, leaving the amount
+    // field, fee-speed chips and the Withdraw button below the fold.
+    val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
+    ModalBottomSheet(onDismissRequest = onDismiss, sheetState = sheetState) {
         Column(
             modifier = Modifier
                 .fillMaxWidth()

--- a/app/src/main/kotlin/com/darkwisp/app/ui/component/WithdrawOnchainSheet.kt
+++ b/app/src/main/kotlin/com/darkwisp/app/ui/component/WithdrawOnchainSheet.kt
@@ -1,0 +1,311 @@
+package com.darkwisp.app.ui.component
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.ContentPaste
+import androidx.compose.material.icons.filled.QrCodeScanner
+import androidx.compose.material.icons.filled.Warning
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalClipboardManager
+import androidx.compose.ui.platform.LocalUriHandler
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.unit.dp
+import kotlinx.coroutines.launch
+import com.darkwisp.app.repo.WithdrawOnchainQuote
+import com.darkwisp.app.repo.WithdrawOnchainSpeed
+import com.darkwisp.app.repo.normalizeBitcoinAddress
+
+/**
+ * "Withdraw on-chain" - drain the whole Spark balance to a Bitcoin address.
+ *
+ * Exists mostly for a user who believes their wallet is broken: it is the
+ * escape hatch that gets their money somewhere they already trust. So it leads
+ * with what will happen, quotes a real fee from the SDK before anything is
+ * signed, and never claims more than it can deliver.
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun WithdrawOnchainSheet(
+    onQuote: suspend (String, WithdrawOnchainSpeed) -> Result<WithdrawOnchainQuote>,
+    onConfirm: suspend (WithdrawOnchainQuote) -> Result<String>,
+    onDismiss: () -> Unit
+) {
+    val scope = rememberCoroutineScope()
+    val clipboard = LocalClipboardManager.current
+    val uriHandler = LocalUriHandler.current
+
+    var address by remember { mutableStateOf("") }
+    var speed by remember { mutableStateOf(WithdrawOnchainSpeed.MEDIUM) }
+    var quote by remember { mutableStateOf<WithdrawOnchainQuote?>(null) }
+    var quoting by remember { mutableStateOf(false) }
+    var sending by remember { mutableStateOf(false) }
+    var error by remember { mutableStateOf<String?>(null) }
+    var sentPaymentId by remember { mutableStateOf<String?>(null) }
+    var showScanner by remember { mutableStateOf(false) }
+    var showConfirm by remember { mutableStateOf(false) }
+
+    if (showScanner) {
+        ModalBottomSheet(onDismissRequest = { showScanner = false }) {
+            Box(Modifier.fillMaxWidth().height(420.dp)) {
+                QrScanner(
+                    onResult = { raw ->
+                        // BIP-21 QRs encode "bitcoin:addr?amount=..."; the SDK
+                        // parser wants the bare address.
+                        address = normalizeBitcoinAddress(raw)
+                        quote = null
+                        error = null
+                        showScanner = false
+                    },
+                    promptText = "Scan a Bitcoin address"
+                )
+            }
+        }
+    }
+
+    ModalBottomSheet(onDismissRequest = onDismiss) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .verticalScroll(rememberScrollState())
+                .padding(horizontal = 20.dp)
+                .padding(bottom = 32.dp),
+            verticalArrangement = Arrangement.spacedBy(18.dp)
+        ) {
+            Text(
+                "Withdraw on-chain",
+                style = MaterialTheme.typography.titleLarge,
+                fontWeight = FontWeight.SemiBold
+            )
+
+            val paymentId = sentPaymentId
+            if (paymentId != null) {
+                Text("Sent", style = MaterialTheme.typography.titleMedium, color = Color(0xFF2E7D32))
+                Text(
+                    "Your funds are on their way. On-chain transactions take time to " +
+                        "confirm - the wallet will show the payment as pending until it does.",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+                TextButton(onClick = {
+                    clipboard.setText(androidx.compose.ui.text.AnnotatedString(paymentId))
+                }) { Text("Copy payment ID") }
+                // Sparkscan, not mempool.space: this is Spark's payment
+                // identifier, not a Bitcoin txid, so a mempool lookup 404s.
+                TextButton(onClick = { uriHandler.openUri("https://sparkscan.io/tx/$paymentId") }) {
+                    Text("View on Sparkscan")
+                }
+                Button(onClick = onDismiss, modifier = Modifier.fillMaxWidth()) { Text("Done") }
+                return@Column
+            }
+
+            // Warning
+            Column(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .background(Color(0xFFFF9800).copy(alpha = 0.10f), RoundedCornerShape(12.dp))
+                    .padding(14.dp),
+                verticalArrangement = Arrangement.spacedBy(8.dp)
+            ) {
+                Row(verticalAlignment = Alignment.CenterVertically) {
+                    Icon(Icons.Default.Warning, null, tint = Color(0xFFFF9800),
+                        modifier = Modifier.size(18.dp))
+                    Spacer(Modifier.width(8.dp))
+                    Text(
+                        "This empties your wallet",
+                        style = MaterialTheme.typography.bodyMedium,
+                        fontWeight = FontWeight.SemiBold,
+                        color = Color(0xFFFF9800)
+                    )
+                }
+                Text(
+                    "Everything spendable is sent to the Bitcoin address you enter. " +
+                        "On-chain fees are deducted from the amount, so you receive less " +
+                        "than the balance shown.\n\nThis is a best effort at recovering " +
+                        "your funds. Bitcoin sent on-chain cannot be undone, and a wrong " +
+                        "address means the money is gone - check it carefully.",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+            }
+
+            // Address
+            Text("Bitcoin address", style = MaterialTheme.typography.labelMedium)
+            OutlinedTextField(
+                value = address,
+                onValueChange = {
+                    address = it
+                    // Any edit invalidates the quote - it was priced for a
+                    // different destination.
+                    quote = null
+                    error = null
+                },
+                placeholder = { Text("bc1...") },
+                singleLine = true,
+                textStyle = MaterialTheme.typography.bodySmall.copy(fontFamily = FontFamily.Monospace),
+                keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Ascii),
+                trailingIcon = {
+                    Row {
+                        IconButton(onClick = {
+                            clipboard.getText()?.text?.let { address = normalizeBitcoinAddress(it) }
+                            quote = null
+                        }) { Icon(Icons.Default.ContentPaste, "Paste") }
+                        // Scanning beats pasting for an irreversible send: no
+                        // truncation, no clipboard hijack, no transcription.
+                        IconButton(onClick = { showScanner = true }) {
+                            Icon(Icons.Default.QrCodeScanner, "Scan")
+                        }
+                    }
+                },
+                modifier = Modifier.fillMaxWidth()
+            )
+
+            // Speed
+            Text("Confirmation speed", style = MaterialTheme.typography.labelMedium)
+            WithdrawOnchainSpeed.entries.forEach { option ->
+                Row(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .clickable { speed = option; quote = null }
+                        .padding(vertical = 4.dp),
+                    verticalAlignment = Alignment.CenterVertically
+                ) {
+                    RadioButton(selected = speed == option, onClick = { speed = option; quote = null })
+                    Column {
+                        Text(option.label, style = MaterialTheme.typography.bodyMedium)
+                        Text(
+                            option.detail,
+                            style = MaterialTheme.typography.bodySmall,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant
+                        )
+                    }
+                }
+            }
+
+            // Quote
+            val q = quote
+            if (quoting) {
+                Row(verticalAlignment = Alignment.CenterVertically) {
+                    CircularProgressIndicator(Modifier.size(16.dp), strokeWidth = 2.dp)
+                    Spacer(Modifier.width(8.dp))
+                    Text("Getting a fee quote...", style = MaterialTheme.typography.bodySmall)
+                }
+            } else if (q != null) {
+                Column(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .background(
+                            MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.35f),
+                            RoundedCornerShape(12.dp)
+                        )
+                        .padding(14.dp),
+                    verticalArrangement = Arrangement.spacedBy(6.dp)
+                ) {
+                    QuoteRow("Wallet balance", "%,d sats".format(q.spendSats))
+                    QuoteRow("On-chain fee", "- %,d sats".format(q.feeSats))
+                    HorizontalDivider()
+                    QuoteRow("You receive", "%,d sats".format(q.netSats), emphasis = true)
+                    if (q.isUneconomical) {
+                        Text(
+                            "The fee is larger than the balance, so there would be nothing " +
+                                "left to send. Try Economy speed, or wait until the balance is higher.",
+                            style = MaterialTheme.typography.bodySmall,
+                            color = MaterialTheme.colorScheme.error
+                        )
+                    } else if (q.feePercent >= 10) {
+                        // Draining a small balance can cost a large share of
+                        // it. Better seen before confirming than after.
+                        Text(
+                            "Fees take ${q.feePercent.toInt()}% of this balance.",
+                            style = MaterialTheme.typography.bodySmall,
+                            color = Color(0xFFFF9800)
+                        )
+                    }
+                }
+            }
+
+            error?.let {
+                Text(it, style = MaterialTheme.typography.bodySmall, color = MaterialTheme.colorScheme.error)
+            }
+
+            Button(
+                onClick = {
+                    if (q == null) {
+                        scope.launch {
+                            quoting = true; error = null
+                            onQuote(address.trim(), speed)
+                                .onSuccess { quote = it }
+                                .onFailure { error = it.message ?: "Something went wrong." }
+                            quoting = false
+                        }
+                    } else {
+                        showConfirm = true
+                    }
+                },
+                enabled = address.isNotBlank() && !quoting && !sending && q?.isUneconomical != true,
+                colors = if (q == null) ButtonDefaults.buttonColors()
+                         else ButtonDefaults.buttonColors(containerColor = Color(0xFFD32F2F)),
+                modifier = Modifier.fillMaxWidth()
+            ) {
+                if (sending) CircularProgressIndicator(Modifier.size(18.dp), strokeWidth = 2.dp, color = Color.White)
+                else Text(if (q == null) "Get quote" else "Withdraw on-chain")
+            }
+        }
+    }
+
+    if (showConfirm && quote != null) {
+        val confirmed = quote!!
+        AlertDialog(
+            onDismissRequest = { showConfirm = false },
+            title = { Text("Withdraw everything on-chain?") },
+            text = {
+                Text(
+                    "This cannot be undone. %,d sats go to ${confirmed.address}."
+                        .format(confirmed.netSats)
+                )
+            },
+            confirmButton = {
+                TextButton(onClick = {
+                    showConfirm = false
+                    scope.launch {
+                        sending = true; error = null
+                        onConfirm(confirmed)
+                            .onSuccess { sentPaymentId = it }
+                            .onFailure { error = it.message ?: "Something went wrong." }
+                        sending = false
+                    }
+                }) { Text("Withdraw", color = MaterialTheme.colorScheme.error) }
+            },
+            dismissButton = { TextButton(onClick = { showConfirm = false }) { Text("Cancel") } }
+        )
+    }
+}
+
+@Composable
+private fun QuoteRow(label: String, value: String, emphasis: Boolean = false) {
+    Row(Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.SpaceBetween) {
+        Text(
+            label,
+            style = MaterialTheme.typography.bodyMedium,
+            fontWeight = if (emphasis) FontWeight.SemiBold else FontWeight.Normal,
+            color = if (emphasis) MaterialTheme.colorScheme.onSurface
+                    else MaterialTheme.colorScheme.onSurfaceVariant
+        )
+        Text(
+            value,
+            style = MaterialTheme.typography.bodyMedium,
+            fontWeight = if (emphasis) FontWeight.SemiBold else FontWeight.Normal
+        )
+    }
+}

--- a/app/src/main/kotlin/com/darkwisp/app/ui/screen/WalletScreen.kt
+++ b/app/src/main/kotlin/com/darkwisp/app/ui/screen/WalletScreen.kt
@@ -92,6 +92,7 @@ import androidx.compose.material.icons.filled.Receipt
 import androidx.compose.material.icons.filled.Refresh
 import androidx.compose.material.icons.filled.Settings
 import androidx.compose.material.icons.filled.SwapHoriz
+import androidx.compose.material.icons.filled.ArrowOutward
 import androidx.compose.material.icons.filled.CloudUpload
 import androidx.compose.material.icons.filled.Share
 import androidx.compose.material3.AlertDialog
@@ -127,6 +128,7 @@ import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.material3.TopAppBar
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
+import com.darkwisp.app.ui.component.WithdrawOnchainSheet
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
@@ -217,6 +219,21 @@ fun WalletScreen(
 ) {
     val walletState by viewModel.walletState.collectAsState()
     val currentPage by viewModel.currentPage.collectAsState()
+    var showWithdrawOnchain by remember { mutableStateOf(false) }
+
+    if (showWithdrawOnchain) {
+        WithdrawOnchainSheet(
+            onQuote = { address, speed -> viewModel.sparkRepo.prepareWithdrawOnchain(address, speed) },
+            onConfirm = { quote ->
+                val result = viewModel.sparkRepo.executeWithdrawOnchain(quote)
+                // Reflect the emptied balance and the new row without waiting
+                // for the next poll — the user just moved everything.
+                if (result.isSuccess) viewModel.refreshState()
+                result
+            },
+            onDismiss = { showWithdrawOnchain = false }
+        )
+    }
 
     // Always refresh wallet state when this screen appears
     LaunchedEffect(Unit) {
@@ -568,6 +585,12 @@ fun WalletScreen(
                             viewModel.navigateTo(WalletPage.BackupToRelay)
                         },
                         onDeleteWallet = { viewModel.navigateTo(WalletPage.DeleteWalletConfirm) },
+                        // Spark only: passing null hides the row, so an NWC
+                        // wallet can't reach a button with no on-chain send
+                        // command behind it.
+                        onWithdrawOnchain = if (viewModel.walletMode.value == WalletMode.SPARK) {
+                            { showWithdrawOnchain = true }
+                        } else null,
                         relayBackupStatuses = viewModel.relayBackupStatuses.collectAsState().value,
                         relayBackupCheckLoading = viewModel.relayBackupCheckLoading.collectAsState().value,
                         deleteBackupStatus = viewModel.deleteBackupStatus.collectAsState().value,
@@ -4079,6 +4102,8 @@ private fun WalletSettingsContent(
     onBackupMnemonic: () -> Unit,
     onBackupToRelay: () -> Unit = {},
     onDeleteWallet: () -> Unit,
+    /** Spark only — NWC has no on-chain send command. */
+    onWithdrawOnchain: (() -> Unit)? = null,
     relayBackupStatuses: List<RelayBackupInfo> = emptyList(),
     relayBackupCheckLoading: Boolean = false,
     deleteBackupStatus: DeleteBackupStatus = DeleteBackupStatus.Idle,
@@ -4394,6 +4419,44 @@ private fun WalletSettingsContent(
                         style = MaterialTheme.typography.bodyLarge,
                         color = Color(0xFFFF3B30)
                     )
+                }
+            }
+            if (onWithdrawOnchain != null) {
+                Spacer(Modifier.height(8.dp))
+                Card(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .clickable(onClick = onWithdrawOnchain),
+                    colors = CardDefaults.cardColors(
+                        containerColor = MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.5f)
+                    )
+                ) {
+                    Row(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(horizontal = 16.dp, vertical = 14.dp),
+                        verticalAlignment = Alignment.CenterVertically
+                    ) {
+                        Icon(
+                            Icons.Default.ArrowOutward,
+                            contentDescription = null,
+                            tint = Color(0xFFFF3B30),
+                            modifier = Modifier.size(22.dp)
+                        )
+                        Spacer(Modifier.width(12.dp))
+                        Column {
+                            Text(
+                                "Withdraw on-chain",
+                                style = MaterialTheme.typography.bodyLarge,
+                                color = Color(0xFFFF3B30)
+                            )
+                            Text(
+                                "Send everything to a Bitcoin address",
+                                style = MaterialTheme.typography.bodySmall,
+                                color = MaterialTheme.colorScheme.onSurfaceVariant
+                            )
+                        }
+                    }
                 }
             }
             Spacer(Modifier.height(8.dp))

--- a/app/src/test/kotlin/com/darkwisp/app/repo/WithdrawOnchainTest.kt
+++ b/app/src/test/kotlin/com/darkwisp/app/repo/WithdrawOnchainTest.kt
@@ -1,0 +1,148 @@
+package com.darkwisp.app.repo
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * The arithmetic behind the Withdraw on-chain confirmation screen, and the
+ * BIP-21 address normalization. Pure, and worth pinning: these numbers are
+ * what a user reads before irreversibly emptying their wallet.
+ *
+ * Ported from wisp-ios#452.
+ */
+class WithdrawOnchainTest {
+
+    private fun quote(
+        spend: Long,
+        fee: Long,
+        speed: WithdrawOnchainSpeed = WithdrawOnchainSpeed.MEDIUM
+    ) = WithdrawOnchainQuote("bc1qexample", spend, fee, speed)
+
+    // ---- Quote arithmetic ----
+
+    /** The fee comes OUT of the balance (FEES_INCLUDED). */
+    @Test
+    fun `net is balance minus fee`() {
+        assertEquals(97_500L, quote(100_000, 2_500).netSats)
+    }
+
+    /** Never advertise a negative amount. */
+    @Test
+    fun `net clamps at zero`() {
+        assertEquals(0L, quote(1_000, 5_000).netSats)
+    }
+
+    @Test
+    fun `a fee that eats everything is uneconomical`() {
+        assertTrue(quote(1_000, 5_000).isUneconomical)
+        assertTrue(quote(1_000, 1_000).isUneconomical)
+    }
+
+    @Test
+    fun `an ordinary drain is economical`() {
+        assertFalse(quote(100_000, 2_500).isUneconomical)
+    }
+
+    @Test
+    fun `fee percent is share of balance`() {
+        assertEquals(10.0, quote(100_000, 10_000).feePercent, 0.001)
+        assertEquals(25.0, quote(20_000, 5_000).feePercent, 0.001)
+    }
+
+    /** No division by zero on an empty wallet. */
+    @Test
+    fun `fee percent on an empty balance is zero`() {
+        assertEquals(0.0, quote(0, 500).feePercent, 0.001)
+    }
+
+    /**
+     * Equality gates execution: executeWithdrawOnchain refuses unless the held
+     * quote matches the one the user confirmed, so a drifted screen can't send
+     * different terms than were signed off.
+     */
+    @Test
+    fun `quotes differing in any field are not equal`() {
+        val base = quote(100_000, 2_500)
+        assertTrue(base != quote(100_001, 2_500))
+        assertTrue(base != quote(100_000, 2_600))
+        assertTrue(base != quote(100_000, 2_500, WithdrawOnchainSpeed.FAST))
+        assertTrue(base != WithdrawOnchainQuote("bc1qother", 100_000, 2_500, WithdrawOnchainSpeed.MEDIUM))
+        assertEquals(base, quote(100_000, 2_500))
+    }
+
+    @Test
+    fun `every speed is labelled and explained`() {
+        WithdrawOnchainSpeed.entries.forEach {
+            assertTrue(it.label.isNotEmpty())
+            assertTrue(it.detail.isNotEmpty())
+        }
+    }
+
+    // ---- Remainder ----
+
+    @Test
+    fun `nothing stranded is empty`() {
+        assertTrue(WithdrawOnchainRemainder().isEmpty)
+    }
+
+    /** Tokens under the conversion floor can't move at any price. */
+    @Test
+    fun `stranded tokens are not empty`() {
+        assertFalse(WithdrawOnchainRemainder(strandedTokens = mapOf("USDB" to "0.34")).isEmpty)
+    }
+
+    @Test
+    fun `stranded sats are not empty`() {
+        assertFalse(WithdrawOnchainRemainder(strandedSats = 120).isEmpty)
+    }
+
+    // ---- BIP-21 normalization ----
+
+    @Test
+    fun `a bare address passes through`() {
+        assertEquals("bc1qexample", normalizeBitcoinAddress("bc1qexample"))
+    }
+
+    @Test
+    fun `strips the bip21 scheme`() {
+        assertEquals("bc1qexample", normalizeBitcoinAddress("bitcoin:bc1qexample"))
+    }
+
+    /** Some wallets emit an uppercase scheme. */
+    @Test
+    fun `scheme match is case insensitive`() {
+        assertEquals("bc1qexample", normalizeBitcoinAddress("BITCOIN:bc1qexample"))
+    }
+
+    /**
+     * The amount is discarded on purpose: this screen always sends the whole
+     * balance, so honoring a requested amount would contradict the button.
+     */
+    @Test
+    fun `drops query parameters`() {
+        assertEquals(
+            "bc1qexample",
+            normalizeBitcoinAddress("bitcoin:bc1qexample?amount=0.01&label=x")
+        )
+    }
+
+    @Test
+    fun `trims whitespace and newlines`() {
+        assertEquals("bc1qexample", normalizeBitcoinAddress("  bc1qexample\n"))
+    }
+
+    /** "bitcoin" mid-string is not a scheme - an address must not be mangled. */
+    @Test
+    fun `only an anchored scheme is stripped`() {
+        assertEquals("bc1qbitcoin:x", normalizeBitcoinAddress("bc1qbitcoin:x"))
+    }
+
+    /** Shorter than the scheme itself must not throw. */
+    @Test
+    fun `short input is safe`() {
+        assertEquals("bc1", normalizeBitcoinAddress("bc1"))
+        assertEquals("", normalizeBitcoinAddress(""))
+    }
+}

--- a/app/src/test/kotlin/com/darkwisp/app/repo/WithdrawOnchainTest.kt
+++ b/app/src/test/kotlin/com/darkwisp/app/repo/WithdrawOnchainTest.kt
@@ -73,29 +73,11 @@ class WithdrawOnchainTest {
     }
 
     @Test
-    fun `every speed is labelled and explained`() {
+    fun `every speed is labeled and explained`() {
         WithdrawOnchainSpeed.entries.forEach {
             assertTrue(it.label.isNotEmpty())
             assertTrue(it.detail.isNotEmpty())
         }
-    }
-
-    // ---- Remainder ----
-
-    @Test
-    fun `nothing stranded is empty`() {
-        assertTrue(WithdrawOnchainRemainder().isEmpty)
-    }
-
-    /** Tokens under the conversion floor can't move at any price. */
-    @Test
-    fun `stranded tokens are not empty`() {
-        assertFalse(WithdrawOnchainRemainder(strandedTokens = mapOf("USDB" to "0.34")).isEmpty)
-    }
-
-    @Test
-    fun `stranded sats are not empty`() {
-        assertFalse(WithdrawOnchainRemainder(strandedSats = 120).isEmpty)
     }
 
     // ---- BIP-21 normalization ----


### PR DESCRIPTION
Ports barrydeen/wisp-ios#452.

Adds **Withdraw on-chain** — wallet settings, danger section, Spark only — which drains the entire spendable balance to a Bitcoin address.

Built for the user who believes their wallet is broken. It's the escape hatch that moves their money somewhere they already trust, so it leads with what will happen, quotes a real fee from the SDK before anything is signed, and never claims more than it can deliver.

## Cooperative withdrawal, not a unilateral exit

Everything here is ordinary send machinery aimed at a Bitcoin address — `getInfo`, `prepareSendPayment`, `sendPayment`, `optimizeLeaves`. No direct Spark RPC, no custom signing, no broadcasting by us.

Which means **it needs the Spark operator to cooperate.** It covers the common cases (wallet feels stuck, user wants out, moving to another app) but not operator failure — and "my wallet is broken" sometimes *is* operator failure. The SDK exposes the trustless path (`prepareUnilateralExit` / `unilateralExit`), but that needs external UTXOs to fund CPFP fees, a `CpfpSigner.signPsbt` implementation, and a resumable broadcaster.

Hence the naming: this is **Withdraw**, and "Exit" stays free for that.

## Why `FeePolicy.FEES_INCLUDED`

The SDK default adds fees *on top* of the amount, so a send of the full balance can never succeed — nothing is left to pay them with. `FEES_INCLUDED` makes the wallet spend exactly the amount with the fee taken out of it, which the SDK docs name as the way to drain a balance.

The quote shows three honest numbers: **balance**, **fee deducted**, **what actually lands**. Balance is read with `ensureSynced = true` — quoting against the cached figure prices a fee for an amount that may no longer exist.

## Quote / execute split is the safety property

`prepareWithdrawOnchain` returns plain values and keeps the SDK's prepared request private to `SparkRepository`. `executeWithdrawOnchain` **refuses unless the quote it's handed still equals the held one** — so what gets broadcast is exactly what the user approved, and a drifted screen re-quotes rather than sending different terms.

## The `optimizeLeaves` retry

Spark spends from individual leaves, so a nominally sufficient balance can still fail selection with `Tree service error: insufficient funds` — most often right after a conversion credits many small leaves. On that error only: consolidate, re-quote, retry once.

Without it a *full* drain fails on arithmetic that looks correct. Learned from zapcooking's `spark-drain`, which hit this against a live wallet.

## Failure handling

`sendPayment` returns a FAILED payment **without throwing** — the same trap `payInvoice` documents — so `payment.status` is inspected rather than trusted, and a failed withdrawal says the funds were not sent.

## Scanning

Addresses can be scanned as well as pasted, reusing the existing `QrScanner`. Both paths normalize BIP-21: bitcoin QRs almost always encode `bitcoin:bc1q…?amount=…`, which the SDK parser rejects outright.

A requested `amount=` is **deliberately discarded** — this screen always sends everything, so honoring it would contradict the button. The scheme match is anchored and case-insensitive, so an address containing "bitcoin:" isn't mangled.

## Two shape notes

- **The settings row is opt-in via a nullable callback** (`onWithdrawOnchain`), so the row can't render for an NWC wallet that has no on-chain send command behind it.
- **The sheet takes suspend lambdas rather than a repository**, so the composable has no dependency on `SparkRepository` and stays previewable.

## Honest about its limits

- A fee larger than the balance disables the button and explains why.
- A fee above 10% of the balance is flagged before confirming.
- **USDB is not included yet** — tokens need a conversion leg and the SDK has no standalone convert, only `conversionOptions` riding on a payment. `WithdrawOnchainRemainder` exists to report what's left behind.
- Tokens under ~$0.50 can't be converted at any price.

## Explorer link

Success links **Sparkscan**, not mempool.space: `payment.id` is Spark's internal identifier, not a Bitcoin txid, so a mempool lookup would 404.

## Testing

18 unit tests on the pure parts: quote arithmetic (net, clamping at zero, uneconomical, fee share, and that quote equality is what gates execution) and BIP-21 normalization.

**Compiled and unit tested only — the Compose sheet has not been exercised on a device.** The iOS equivalent was verified on the simulator against a live Spark wallet; the send path here is the same shape. Flagging rather than implying coverage it doesn't have.