### PR TITLE
fix(content): let a quoted note be opened directly

### DIFF
--- a/app/src/main/kotlin/com/darkwisp/app/ui/component/RichContent.kt
+++ b/app/src/main/kotlin/com/darkwisp/app/ui/component/RichContent.kt
@@ -1215,7 +1215,11 @@ fun QuotedNote(
     // Cap nesting: depth >= 1 means we're already inside a quoted note,
     // so force compact preview to avoid squashed action bars
     val effectiveActions = if (quoteDepth >= 1) null else noteActions
-    val effectiveNoteClick = effectiveActions?.onNoteClick ?: noteActions?.onNoteClick ?: onNoteClick
+    // The explicit parameter wins. `NoteActions.onNoteClick` is non-nullable with
+    // a no-op default, so "nobody wired it" and "wired to do nothing" look
+    // identical to `?:` — putting it first let the default swallow the tap and
+    // made the working handler below it unreachable.
+    val effectiveNoteClick = onNoteClick ?: effectiveActions?.onNoteClick ?: noteActions?.onNoteClick
 
     // Fetch poll votes when quoted event is a poll
     LaunchedEffect(event?.id, event?.kind) {
@@ -1278,6 +1282,13 @@ fun QuotedNote(
             modifier = Modifier
                 .fillMaxWidth()
                 .padding(vertical = 6.dp)
+                .then(
+                    // Only the no-actions fallback path below carried this, so
+                    // taps landing on the card's padding rather than the inner
+                    // post went nowhere.
+                    if (effectiveNoteClick != null) Modifier.clickable { effectiveNoteClick(eventId) }
+                    else Modifier
+                )
         ) {
             if (isGalleryEvent(event)) {
                 GalleryCard(


### PR DESCRIPTION
Tapping a quoted note in the timeline highlighted the card and did nothing. The quoted note could only be reached by opening its parent first and following the quote from there. Device tested on an A54.

## Cause

`NoteActions.onNoteClick` is declared `(String) -> Unit = {}` — non-nullable, defaulting to a no-op. So in

```kotlin
val effectiveNoteClick = effectiveActions?.onNoteClick ?: noteActions?.onNoteClick ?: onNoteClick
```

the first term can never be null. `onNoteClick` — the parameter `PostCard` fills from `onQuotedNoteClick`, the handler that actually navigates — was unreachable on any screen whose `NoteActions` left the field defaulted.

The card really was clickable, which is why it rippled on touch. It just called a function that does nothing. Logging confirmed it: the inner card's handler fired on every tap with a non-null callback, while no screen's handler ever ran.

Putting the explicit parameter first resolves it, matching how the same expression is ordered in Wisp Android.

## Also included

The quoted-note surface now gets the same click handling the no-actions fallback path already had, so a tap landing on the card's padding rather than the inner post opens the note too. On its own this doesn't fix the bug — the inner `PostCard` is unconditionally clickable and consumes the tap first — but it closes the gap against the fallback path.

## Worth a follow-up

The underlying hazard is the non-nullable callback with a no-op default: "nobody wired it" and "wired to do nothing" are indistinguishable to `?:` and to every caller, with no null to catch. Two screens currently build a `NoteActions` without setting `onNoteClick`. Making the field nullable would turn this class of bug into something the compiler can see, rather than a card that silently goes nowhere.