### PR TITLE
fix(polls): show the author their own results, read NIP-22 comments, cap fan-out

### DIFF
--- a/app/src/main/kotlin/com/darkwisp/app/nostr/Nip22.kt
+++ b/app/src/main/kotlin/com/darkwisp/app/nostr/Nip22.kt
@@ -1,0 +1,17 @@
+package com.darkwisp.app.nostr
+
+/**
+ * NIP-22 comments (kind 1111).
+ *
+ * Partial: enough to *read* comment threads. A comment is scoped to a root by
+ * uppercase `E`/`A`/`I` tags, with lowercase tags naming the immediate parent.
+ *
+ * Composing replies is not handled here. NIP-22 forbids answering a comment with
+ * a kind 1, so a reply to a comment must itself be kind 1111 — until that's
+ * wired up, replies to comments are still built as NIP-10 kind-1 events.
+ */
+object Nip22 {
+    const val KIND_COMMENT = 1111
+
+    fun isComment(event: NostrEvent): Boolean = event.kind == KIND_COMMENT
+}

--- a/app/src/main/kotlin/com/darkwisp/app/repo/EventRepository.kt
+++ b/app/src/main/kotlin/com/darkwisp/app/repo/EventRepository.kt
@@ -608,6 +608,25 @@ class EventRepository(val profileRepo: ProfileRepository? = null, val muteRepo: 
         return userPollVotes.get(pollId) ?: emptyList()
     }
 
+    /**
+     * Per-choice voter lists for the details drawer, newest vote first so the
+     * freshest voters surface at the top of each choice. Built from the
+     * latest-wins voter state, so each voter appears under their current choice
+     * only — a revote moves them rather than counting twice.
+     */
+    fun getPollVoters(pollId: String): Map<String, List<String>> {
+        val voters = pollVoters.get(pollId) ?: return emptyMap()
+        val out = mutableMapOf<String, MutableList<String>>()
+        voters.entries
+            .sortedByDescending { it.value.first }
+            .forEach { entry ->
+                for (optionId in entry.value.second) {
+                    out.getOrPut(optionId) { mutableListOf() }.add(entry.key)
+                }
+            }
+        return out
+    }
+
     private fun addZapPollVote(zapReceipt: NostrEvent, pollId: String, sats: Long, zapperPubkey: String?) {
         val optionIndex = Nip69.getZapPollOptionFromZapReceipt(zapReceipt) ?: return
         val pubkey = zapperPubkey ?: return

--- a/app/src/main/kotlin/com/darkwisp/app/ui/component/PostCard.kt
+++ b/app/src/main/kotlin/com/darkwisp/app/ui/component/PostCard.kt
@@ -759,6 +759,7 @@ fun PostCard(
                     voteCounts = pollVoteCounts,
                     totalVotes = pollTotalVotes,
                     userVotes = userPollVotes,
+                    isAuthor = isOwnEvent,
                     onVote = onPollVote
                 )
             } else if (event.kind == Nip69.KIND_ZAP_POLL) {
@@ -767,6 +768,7 @@ fun PostCard(
                     satsCounts = zapPollSatsCounts,
                     totalSats = zapPollTotalSats,
                     userVote = userZapPollVote,
+                    isAuthor = isOwnEvent,
                     onVote = onZapPollVote
                 )
             }
@@ -858,6 +860,21 @@ fun PostCard(
                         eventRepo = eventRepo
                     )
                 }
+                if (event.kind == Nip88.KIND_POLL) {
+                    // Keyed on the tally so a vote arriving while the drawer is
+                    // open re-reads the voter lists.
+                    val votersByOption = remember(event.id, pollTotalVotes, pollVoteCounts) {
+                        eventRepo?.getPollVoters(event.id) ?: emptyMap()
+                    }
+                    PollVotesSection(
+                        event = event,
+                        voteCounts = pollVoteCounts,
+                        totalVotes = pollTotalVotes,
+                        votersByOption = votersByOption,
+                        resolveProfile = profileResolver,
+                        onProfileClick = navToProfile
+                    )
+                }
                 if (displayIcons.isNotEmpty()) {
                     SeenOnSection(relayIcons = displayIcons, onRelayClick = onRelayClick)
                 }
@@ -882,13 +899,16 @@ private fun PollSection(
     voteCounts: Map<String, Int>,
     totalVotes: Int,
     userVotes: List<String>,
+    isAuthor: Boolean,
     onVote: (List<String>) -> Unit
 ) {
     val options = remember(event.id) { Nip88.parsePollOptions(event) }
     val pollType = remember(event.id) { Nip88.parsePollType(event) }
     val isEnded = remember(event.id) { Nip88.isPollEnded(event) }
     val hasVoted = userVotes.isNotEmpty()
-    val showResults = hasVoted || isEnded
+    // The author sees the tally on their own poll without having to vote on it.
+    // Everyone else votes first, so the running count can't sway their choice.
+    val showResults = hasVoted || isEnded || isAuthor
 
     Column(
         modifier = Modifier
@@ -1057,12 +1077,13 @@ private fun ZapPollSection(
     satsCounts: Map<Int, Long>,
     totalSats: Long,
     userVote: Int?,
+    isAuthor: Boolean,
     onVote: (Int) -> Unit
 ) {
     val options = remember(event.id) { Nip69.parseZapPollOptions(event) }
     val isClosed = remember(event.id) { Nip69.isZapPollClosed(event) }
     val hasVoted = userVote != null
-    val showResults = hasVoted || isClosed || totalSats > 0
+    val showResults = hasVoted || isClosed || isAuthor
 
     Column(
         modifier = Modifier

--- a/app/src/main/kotlin/com/darkwisp/app/ui/component/ReactionDetailsSection.kt
+++ b/app/src/main/kotlin/com/darkwisp/app/ui/component/ReactionDetailsSection.kt
@@ -20,6 +20,8 @@ import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.KeyboardArrowDown
+import androidx.compose.material.icons.filled.KeyboardArrowUp
 import androidx.compose.material.icons.outlined.Repeat
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.HorizontalDivider
@@ -40,6 +42,7 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontWeight
+import kotlin.math.roundToInt
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
@@ -48,6 +51,7 @@ import coil3.compose.AsyncImage
 import androidx.compose.ui.platform.LocalContext
 import com.darkwisp.app.R
 import com.darkwisp.app.ui.util.AmountFormatter
+import com.darkwisp.app.nostr.Nip88
 import com.darkwisp.app.nostr.NostrEvent
 import com.darkwisp.app.nostr.ProfileData
 import com.darkwisp.app.nostr.toNpub
@@ -565,6 +569,107 @@ private fun RelayUrlChip(url: String) {
             maxLines = 1,
             overflow = TextOverflow.Ellipsis
         )
+    }
+}
+
+/**
+ * Per-choice voter lists for a NIP-88 poll, shown in the post details drawer.
+ * Choices are ordered by tally descending; tapping one expands it into the full
+ * list of voters who picked it. Mirrors the iOS details panel.
+ */
+@Composable
+fun PollVotesSection(
+    event: NostrEvent,
+    voteCounts: Map<String, Int>,
+    totalVotes: Int,
+    votersByOption: Map<String, List<String>>,
+    resolveProfile: (String) -> ProfileData?,
+    onProfileClick: (String) -> Unit,
+    modifier: Modifier = Modifier
+) {
+    val options = remember(event.id) { Nip88.parsePollOptions(event) }
+    if (options.isEmpty() || votersByOption.isEmpty()) return
+    var expandedOptionId by remember(event.id) { mutableStateOf<String?>(null) }
+
+    Column(
+        modifier = modifier
+            .fillMaxWidth()
+            .padding(horizontal = 20.dp, vertical = 8.dp)
+    ) {
+        Text(
+            text = stringResource(R.string.poll_votes),
+            style = MaterialTheme.typography.labelSmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant
+        )
+        Spacer(Modifier.height(6.dp))
+        options.sortedByDescending { voteCounts[it.id] ?: 0 }.forEach { option ->
+            val voters = votersByOption[option.id].orEmpty()
+            val count = voteCounts[option.id] ?: 0
+            val percent = if (totalVotes > 0) (count * 100f / totalVotes).roundToInt() else 0
+            val isExpanded = expandedOptionId == option.id
+
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .clickable {
+                        expandedOptionId = if (isExpanded) null else option.id
+                    }
+                    .padding(vertical = 8.dp),
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                Text(
+                    text = option.label,
+                    style = MaterialTheme.typography.labelMedium,
+                    fontWeight = FontWeight.SemiBold,
+                    color = MaterialTheme.colorScheme.onSurface,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                    modifier = Modifier.weight(1f)
+                )
+                Spacer(Modifier.width(8.dp))
+                Text(
+                    text = "$count \u00b7 $percent%",
+                    style = MaterialTheme.typography.labelSmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+                Icon(
+                    imageVector = if (isExpanded) Icons.Filled.KeyboardArrowUp
+                    else Icons.Filled.KeyboardArrowDown,
+                    contentDescription = null,
+                    tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                    modifier = Modifier.size(20.dp)
+                )
+            }
+
+            if (isExpanded) {
+                Column(modifier = Modifier.padding(start = 4.dp, bottom = 4.dp)) {
+                    voters.forEach { pubkey ->
+                        val profile = resolveProfile(pubkey)
+                        val displayName = remember(profile, pubkey) {
+                            profile?.displayString
+                                ?: pubkey.toNpub().let { "${it.take(12)}...${it.takeLast(4)}" }
+                        }
+                        Row(
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .clickable { onProfileClick(pubkey) }
+                                .padding(vertical = 5.dp),
+                            verticalAlignment = Alignment.CenterVertically
+                        ) {
+                            ProfilePicture(url = profile?.picture, size = 26)
+                            Spacer(Modifier.width(8.dp))
+                            Text(
+                                text = displayName,
+                                style = MaterialTheme.typography.labelMedium,
+                                color = MaterialTheme.colorScheme.onSurface,
+                                maxLines = 1,
+                                overflow = TextOverflow.Ellipsis
+                            )
+                        }
+                    }
+                }
+            }
+        }
     }
 }
 

--- a/app/src/main/kotlin/com/darkwisp/app/viewmodel/FeedSubscriptionManager.kt
+++ b/app/src/main/kotlin/com/darkwisp/app/viewmodel/FeedSubscriptionManager.kt
@@ -65,6 +65,10 @@ class FeedSubscriptionManager(
 ) {
     companion object {
         val FEED_KINDS = listOf(1, 6, 1068, 6969, 30023, 20, 21, 22)
+        // How many of a poll's advertised relays to reach past the persistent
+        // pool. iOS uses 3 and gets complete tallies; the votes land on the
+        // first few relays a poll lists, not the long tail.
+        private const val MAX_POLL_RELAY_HINTS = 3
         private const val KEY_LAST_FEED_TYPE = "last_feed_type"
         private const val KEY_LAST_RELAY_URL = "last_relay_url"
         private const val KEY_LAST_RELAY_SET_NAME = "last_relay_set_name"
@@ -1055,7 +1059,10 @@ class FeedSubscriptionManager(
                 val sentAll = relayPool.sendToAllRelays(msg)
                 Log.d("POLL", "[FeedSub] sent poll vote REQ to $sentAll persistent relays")
                 for (poll in nip88Polls) {
-                    for (url in Nip88.parsePollRelays(poll)) {
+                    // Cap the fan-out. A poll advertises as many relays as its
+                    // author's client cared to list — one in the wild carries 480 —
+                    // and every uncapped entry here becomes an ephemeral connection.
+                    for (url in Nip88.parsePollRelays(poll).take(MAX_POLL_RELAY_HINTS)) {
                         if (url !in sentUrls) relayPool.sendToRelayOrEphemeral(url, msg)
                     }
                 }
@@ -1077,7 +1084,7 @@ class FeedSubscriptionManager(
                 else ClientMessage.req(zapPollSubId, zapPollFilters)
                 relayPool.sendToAllRelays(zapPollMsg)
                 for (poll in zapPolls) {
-                    for (url in Nip69.parseZapPollRelays(poll)) {
+                    for (url in Nip69.parseZapPollRelays(poll).take(MAX_POLL_RELAY_HINTS)) {
                         if (url !in sentUrls) relayPool.sendToRelayOrEphemeral(url, zapPollMsg)
                     }
                 }

--- a/app/src/main/kotlin/com/darkwisp/app/viewmodel/ThreadViewModel.kt
+++ b/app/src/main/kotlin/com/darkwisp/app/viewmodel/ThreadViewModel.kt
@@ -6,6 +6,7 @@ import com.darkwisp.app.nostr.ClientMessage
 import com.darkwisp.app.nostr.Filter
 import com.darkwisp.app.nostr.Nip09
 import com.darkwisp.app.nostr.Nip10
+import com.darkwisp.app.nostr.Nip22
 import com.darkwisp.app.nostr.NostrEvent
 import com.darkwisp.app.relay.OutboxRouter
 import com.darkwisp.app.relay.RelayPool
@@ -215,7 +216,10 @@ class ThreadViewModel : ViewModel() {
                     return@collect
                 }
 
-                if (event.kind != 1) return@collect
+                // Admit NIP-22 comments (kind 1111). Clients increasingly reply with
+                // comments rather than kind 1, so a kind-1-only gate shows those
+                // threads as empty — every reply on some notes is a 1111.
+                if (event.kind != 1 && event.kind != Nip22.KIND_COMMENT) return@collect
 
                 // Silently drop events the user has already deleted on some other client/session.
                 if (eventRepo.deletedEventsRepo?.isDeleted(event.id) == true) return@collect
@@ -279,7 +283,7 @@ class ThreadViewModel : ViewModel() {
             // Phase 2: Now we (hopefully) have the root — use outbox routing for replies
             val rootEvent = _rootEvent.value
             // Include kind 5 so deletions of the root (or any event tagging the root) come through.
-            val repliesFilter = Filter(kinds = listOf(1, 5), eTags = listOf(rootId))
+            val repliesFilter = Filter(kinds = listOf(1, 5, Nip22.KIND_COMMENT), eTags = listOf(rootId))
             if (rootEvent != null) {
                 outboxRouter.subscribeToUserReadRelays(
                     "thread-replies", rootEvent.pubkey, repliesFilter

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -266,6 +266,7 @@
     <string name="account_switcher_title">Accounts</string>
     <string name="account_switcher_add">Sign in with another account</string>
     <string name="cd_seen_on">Seen on</string>
+    <string name="poll_votes">Votes</string>
     <string name="cd_sent_with">Sent with</string>
     <string name="cd_filter_notifications">Filter notifications</string>
     <string name="cd_notif_style_compact">Switch to compact notifications</string>


### PR DESCRIPTION
Four things surfaced on one poll. Device tested on an A54. Mirrors barrydeen/wisp#658.

## The author couldn't see results on their own poll

`showResults` gated on `hasVoted || isEnded`, so the one person who can't vote on a poll — whoever posted it — had no way to see the tally.

What deliberately doesn't change: a reader who hasn't voted still sees options rather than numbers. Showing the tally to everyone was considered and rejected, because the running count sways the vote.

The zap-poll variant gated on `hasVoted || isClosed || totalSats > 0`, revealing results to everyone the moment any sats landed. It now follows the same rule.

## Comment threads rendered as empty

The reply filter and the thread's event gate both admitted kind 1 only. A note whose replies are all NIP-22 comments (kind 1111) showed no replies and a blank count. On the poll that prompted this, *every* reply was a 1111 — pulling them straight off the relays gives `{1111: 5}`, not a single kind 1.

Reading comments is all this changes. Composing a reply *to* a comment still builds a kind-1 event, which NIP-22 forbids — a reply to a comment must itself be kind 1111. That needs the rest of the helper and is left for a follow-up, so expect comments to render correctly but a reply posted to one to thread wrongly elsewhere.

## Poll relay fan-out was uncapped

```kotlin
for (url in Nip88.parsePollRelays(poll)) {
    if (url !in sentUrls) relayPool.sendToRelayOrEphemeral(url, msg)
}
```

Every relay a poll advertises got an ephemeral connection, with no cap — and a poll in the wild advertises **480** of them. Capped at 3 for both poll kinds, matching iOS, which gets complete tallies from that many.

## Per-choice voter breakdown

Added to the details drawer: choices ordered by tally descending, each expanding into the list of voters who picked it, tappable through to a profile. The voter data was already being collected — with latest-wins revote handling, so a revote moves someone rather than double-counting — and nothing was reading it.